### PR TITLE
Feature/ehr 163 support canonical for datavalue

### DIFF
--- a/base/src/main/resources/db/migration/V11__raw_json_encoding_new_format.sql
+++ b/base/src/main/resources/db/migration/V11__raw_json_encoding_new_format.sql
@@ -1,0 +1,418 @@
+/*
+ * Modifications copyright (C) 2019 Vitasystems GmbH and Hannover Medical School.
+
+ * This file is part of Project EHRbase
+
+ * Copyright (c) 2015 Christian Chevalley
+ * This file is part of Project Ethercis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- archetyped.sql
+CREATE OR REPLACE FUNCTION ehr.js_archetyped(TEXT, TEXT)
+  RETURNS JSON AS
+  $$
+  DECLARE
+    archetype_id ALIAS FOR $1;
+    template_id ALIAS FOR $2;
+  BEGIN
+    RETURN
+      json_build_object(
+          '_type', 'ARCHETYPED',
+          'archetype_id',
+          json_build_object(
+              '_type', 'ARCHETYPE_ID',
+              'value', archetype_id
+          ),
+          template_id,
+          json_build_object(
+              '_type', 'TEMPLATE_ID',
+              'value', template_id
+          ),
+          'rm_version', '1.0.1'
+      );
+  END
+  $$
+LANGUAGE plpgsql;
+
+--code_phrase.sql
+CREATE OR REPLACE FUNCTION ehr.js_code_phrase(TEXT, TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  code_string ALIAS FOR $1;
+  terminology ALIAS FOR $2;
+BEGIN
+  RETURN
+  json_build_object(
+      '_type', 'CODE_PHRASE',
+      'terminology_id',
+      json_build_object(
+          '_type', 'TERMINOLOGY_ID',
+          'value', terminology
+      ),
+      'code_string', code_string
+  );
+END
+$$
+LANGUAGE plpgsql;
+
+--context.sql
+CREATE OR REPLACE FUNCTION ehr.js_context(UUID)
+  RETURNS JSON AS
+  $$
+  DECLARE
+    context_id ALIAS FOR $1;
+    json_context_query   TEXT;
+    json_context         JSON;
+    v_start_time         TIMESTAMP;
+    v_start_time_tzid    TEXT;
+    v_end_time           TIMESTAMP;
+    v_end_time_tzid      TEXT;
+    v_facility           UUID;
+    v_location           TEXT;
+    v_other_context      JSONB;
+    v_other_context_text TEXT;
+    v_setting            UUID;
+  BEGIN
+
+    IF (context_id IS NULL)
+    THEN
+      RETURN NULL;
+    END IF;
+
+    -- build the query
+    SELECT
+      start_time,
+      start_time_tzid,
+      end_time,
+      end_time_tzid,
+      facility,
+      location,
+      other_context,
+      setting
+    FROM ehr.event_context
+    WHERE id = context_id
+    INTO v_start_time, v_start_time_tzid, v_end_time, v_end_time_tzid, v_facility, v_location, v_other_context, v_setting;
+
+    json_context_query := ' SELECT json_build_object(
+                                  ''_type'', ''EVENT_CONTEXT'',
+                                  ''start_time'', ehr.js_dv_date_time(''' || v_start_time || ''',''' ||
+                          v_start_time_tzid || '''),';
+
+    IF (v_end_time IS NOT NULL)
+    THEN
+      json_context_query :=
+      json_context_query || '''end_date'', ehr.js_dv_date_time(''' || v_end_time || ''',''' || v_end_time_tzid ||
+      '''),';
+    END IF;
+
+    IF (v_location IS NOT NULL)
+    THEN
+      json_context_query := json_context_query || '''location'', ''' || v_location || ''',';
+    END IF;
+
+    IF (v_facility IS NOT NULL)
+    THEN
+      json_context_query := json_context_query || '''health_care_facility'', ehr.js_party('''||v_facility||'''),';
+    END IF;
+
+    json_context_query := json_context_query || '''setting'',ehr.js_context_setting(''' || v_setting || '''))';
+
+
+    --     IF (participation IS NOT NULL) THEN
+    --       json_context_query := json_context_query || '''participation'', participation,';
+    --     END IF;
+
+    IF (json_context_query IS NULL)
+    THEN
+      RETURN NULL;
+    END IF;
+
+    EXECUTE json_context_query
+    INTO STRICT json_context;
+
+    IF (v_other_context IS NOT NULL)
+    THEN
+      --       v_other_context_text := regexp_replace(v_other_context::TEXT, '''', '''''', 'g');
+      json_context := jsonb_insert(
+          json_context::JSONB,
+          '{other_context}', v_other_context::JSONB->'/context/other_context[at0001]'
+      );
+    END IF;
+
+    RETURN json_context;
+  END
+  $$
+LANGUAGE plpgsql;
+
+-- context_setting.sql
+CREATE OR REPLACE FUNCTION ehr.js_context_setting(UUID)
+  RETURNS JSON AS
+  $$
+  DECLARE
+    concept_id ALIAS FOR $1;
+  BEGIN
+
+    IF (concept_id IS NULL) THEN
+      RETURN NULL;
+    END IF;
+
+    RETURN (
+      SELECT ehr.js_dv_coded_text(description, ehr.js_code_phrase(conceptid :: TEXT, 'openehr'))
+      FROM ehr.concept
+      WHERE id = concept_id AND language = 'en'
+    );
+  END
+  $$
+LANGUAGE plpgsql;
+
+-- dv_coded_text.sql
+CREATE OR REPLACE FUNCTION ehr.js_dv_coded_text(TEXT, JSON)
+  RETURNS JSON AS
+$$
+DECLARE
+  value_string ALIAS FOR $1;
+  code_phrase ALIAS FOR $2;
+BEGIN
+  RETURN
+  json_build_object(
+      '_type', 'DV_CODED_TEXT',
+      'value', value_string,
+      'defining_code', code_phrase
+  );
+END
+$$
+LANGUAGE plpgsql;
+
+-- dv_date_time.sql
+CREATE OR REPLACE FUNCTION ehr.js_dv_date_time(TIMESTAMPTZ, TEXT)
+  RETURNS JSON AS
+  $$
+  DECLARE
+    date_time ALIAS FOR $1;
+    time_zone ALIAS FOR $2;
+  BEGIN
+
+    IF (date_time IS NULL)
+    THEN
+      RETURN NULL;
+    END IF;
+
+    IF (time_zone IS NULL)
+    THEN
+      time_zone := 'UTC';
+    END IF;
+
+    RETURN
+      json_build_object(
+          '_type', 'DV_DATE_TIME',
+          'value', ehr.iso_timestamp(date_time)||time_zone
+      );
+  END
+  $$
+LANGUAGE plpgsql;
+
+-- dv_text.sql
+CREATE OR REPLACE FUNCTION ehr.js_dv_text(TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  value_string ALIAS FOR $1;
+BEGIN
+  RETURN
+  json_build_object(
+      '_type', 'DV_TEXT',
+      'value', value_string
+  );
+END
+$$
+LANGUAGE plpgsql;
+
+-- iso_timestamp.sql
+create or replace function ehr.iso_timestamp(timestamp with time zone)
+  returns varchar as $$
+select substring(xmlelement(name x, $1)::varchar from 4 for 19)
+$$ language sql immutable;
+
+-- json_composition_pg10.sql
+-- CTE enforces 1-to-1 entry-composition relationship since multiple entries can be
+-- associated to one composition. This is not supported at this stage.
+CREATE OR REPLACE FUNCTION ehr.js_composition(UUID)
+  RETURNS JSON AS
+  $$
+  DECLARE
+    composition_uuid ALIAS FOR $1;
+  BEGIN
+    RETURN (
+      WITH composition_data AS (
+          SELECT
+            composition.language  as language,
+            composition.territory as territory,
+            composition.composer  as composer,
+            event_context.id      as context_id,
+            territory.twoletter   as territory_code,
+            entry.template_id     as template_id,
+            entry.archetype_id    as archetype_id,
+            concept.conceptid     as category_defining_code,
+            concept.description   as category_description,
+            entry.entry           as content
+          FROM ehr.composition
+            INNER JOIN ehr.entry ON entry.composition_id = composition.id
+            LEFT JOIN ehr.event_context ON event_context.composition_id = composition.id
+            LEFT JOIN ehr.territory ON territory.code = composition.territory
+            LEFT JOIN ehr.concept ON concept.id = entry.category
+          WHERE composition.id = composition_uuid
+        LIMIT 1
+      )
+      SELECT
+        jsonb_strip_nulls(
+            jsonb_build_object(
+                '_type', 'COMPOSITION',
+                'language', ehr.js_code_phrase(language, 'ISO_639-1'),
+                'territory', ehr.js_code_phrase(territory_code, 'ISO_3166-1'),
+                'composer', ehr.js_party(composer),
+                'category',
+                ehr.js_dv_coded_text(category_description, ehr.js_code_phrase(category_defining_code :: TEXT, 'openehr')),
+                'context', ehr.js_context(context_id),
+                'content', content
+            )
+        )
+      FROM composition_data
+    );
+  END
+  $$
+LANGUAGE plpgsql;
+-- object_version_id.sql
+CREATE OR REPLACE FUNCTION ehr.object_version_id(UUID, TEXT, INT)
+  RETURNS JSON AS
+$$
+DECLARE
+  object_uuid ALIAS FOR $1;
+  object_host ALIAS FOR $2;
+  object_version ALIAS FOR $3;
+BEGIN
+  RETURN
+  json_build_object(
+      '_type', 'OBJECT_VERSION_ID',
+      'value', object_uuid::TEXT || '::' || object_host || '::' || object_version::TEXT
+  );
+END
+$$
+LANGUAGE plpgsql;
+-- party.sql
+CREATE OR REPLACE FUNCTION ehr.js_party(UUID)
+  RETURNS JSON AS
+$$
+DECLARE
+  party_id ALIAS FOR $1;
+BEGIN
+  RETURN (
+    SELECT ehr.js_party_identified(name,
+                                   ehr.js_party_ref(party_ref_value, party_ref_scheme, party_ref_namespace, party_ref_type))
+    FROM ehr.party_identified
+    WHERE id = party_id
+  );
+END
+$$
+LANGUAGE plpgsql;
+-- party_identified.sql
+CREATE OR REPLACE FUNCTION ehr.js_party_identified(TEXT, JSON)
+  RETURNS JSON AS
+$$
+DECLARE
+  name_value ALIAS FOR $1;
+  external_ref ALIAS FOR $2;
+BEGIN
+  IF (external_ref IS NOT NULL) THEN
+    RETURN
+    json_build_object(
+        '_type', 'PARTY_IDENTIFIED',
+        'name', name_value,
+        'external_ref', external_ref
+    );
+  ELSE
+    RETURN
+    json_build_object(
+        '_type', 'PARTY_IDENTIFIED',
+        'name', name_value
+    );
+  END IF;
+END
+$$
+LANGUAGE plpgsql;
+-- party_ref.sql
+CREATE OR REPLACE FUNCTION ehr.js_party_ref(TEXT, TEXT, TEXT, TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  id_value ALIAS FOR $1;
+  id_scheme ALIAS FOR $2;
+  namespace ALIAS FOR $3;
+  party_type ALIAS FOR $4;
+BEGIN
+
+  IF (id_value IS NULL AND id_scheme IS NULL AND namespace IS NULL AND party_type IS NULL) THEN
+    RETURN NULL;
+  ELSE
+    RETURN
+    json_build_object(
+        '_type', 'PARTY_REF',
+        'id',
+        json_build_object(
+            '_type', 'GENERIC_ID',
+            'value', id_value,
+            'scheme', id_scheme
+        ),
+        'namespace', namespace
+    );
+  END IF;
+END
+$$
+LANGUAGE plpgsql;
+
+-- ehr_status
+CREATE OR REPLACE FUNCTION ehr.js_ehr_status(UUID)
+  RETURNS JSON AS
+$$
+DECLARE
+  ehr_uuid ALIAS FOR $1;
+BEGIN
+  RETURN (
+    WITH ehr_status_data AS (
+      SELECT
+        status.other_details as other_details,
+        status.party as subject,
+        status.is_queryable as is_queryable,
+        status.is_modifiable as is_modifiable,
+        status.sys_transaction as time_created
+      FROM ehr.status
+      WHERE status.ehr_id = ehr_uuid
+      LIMIT 1
+    )
+    SELECT
+      jsonb_strip_nulls(
+          jsonb_build_object(
+              '_type', 'EHR_STATUS',
+              'subject', ehr.js_party(subject),
+              'is_queryable', is_queryable,
+              'is_modifiable', is_modifiable,
+              'other_details', other_details
+            )
+        )
+    FROM ehr_status_data
+  );
+END
+$$
+LANGUAGE plpgsql;

--- a/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
+++ b/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
@@ -22,16 +22,14 @@ $$
 LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION ehr.js_canonical_hier_object_id(TEXT)
+CREATE OR REPLACE FUNCTION ehr.js_canonical_hier_object_id(ehr_id UUID)
   RETURNS JSON AS
 $$
-DECLARE
-  value ALIAS FOR $1;
 BEGIN
   RETURN
     json_build_object(
         '_type', 'HIER_OBJECT_ID',
-        'value', value
+        'value', ehr_id
       );
 END
 $$

--- a/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
+++ b/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
@@ -65,11 +65,251 @@ BEGIN
             '_type', 'PARTY_REF',
             'namespace', namespace,
             'type', type,
-            'id', ehr.js_generic_id(scheme, id)
+            'id', ehr.js_canonical_generic_id(scheme, id)
           )
       );
 END
 $$
 LANGUAGE plpgsql;
+
+
+-- some minor fixes to support the 'new' canonical json format
+CREATE OR REPLACE FUNCTION ehr.js_context(UUID)
+  RETURNS JSON AS
+$$
+DECLARE
+  context_id ALIAS FOR $1;
+  json_context_query   TEXT;
+  json_context         JSON;
+  v_start_time         TIMESTAMP;
+  v_start_time_tzid    TEXT;
+  v_end_time           TIMESTAMP;
+  v_end_time_tzid      TEXT;
+  v_facility           UUID;
+  v_location           TEXT;
+  v_other_context      JSON;
+  v_setting            UUID;
+BEGIN
+
+  IF (context_id IS NULL)
+  THEN
+    RETURN NULL;
+  END IF;
+
+  -- build the query
+  SELECT
+    start_time,
+    start_time_tzid,
+    end_time,
+    end_time_tzid,
+    facility,
+    location,
+    other_context,
+    setting
+  FROM ehr.event_context
+  WHERE id = context_id
+        INTO v_start_time, v_start_time_tzid, v_end_time, v_end_time_tzid, v_facility, v_location, v_other_context, v_setting;
+
+  json_context_query := ' SELECT json_build_object(
+                                  ''_time'', ''EVENT_CONTEXT'',
+                                  ''start_time'', ehr.js_dv_date_time(''' || v_start_time || ''',''' ||
+                        v_start_time_tzid || '''),';
+
+  IF (v_end_time IS NOT NULL)
+  THEN
+    json_context_query :=
+          json_context_query || '''end_date'', ehr.js_dv_date_time(''' || v_end_time || ''',''' || v_end_time_tzid ||
+          '''),';
+  END IF;
+
+  IF (v_location IS NOT NULL)
+  THEN
+    json_context_query := json_context_query || '''location'', ''' || v_location || ''',';
+  END IF;
+
+  IF (v_facility IS NOT NULL)
+  THEN
+    json_context_query := json_context_query || '''health_care_facility'', ehr.js_party('''||v_facility||'''),';
+  END IF;
+
+  json_context_query := json_context_query || '''setting'',ehr.js_context_setting(''' || v_setting || '''))';
+
+
+  --     IF (participation IS NOT NULL) THEN
+  --       json_context_query := json_context_query || '''participation'', participation,';
+  --     END IF;
+
+  IF (json_context_query IS NULL)
+  THEN
+    RETURN NULL;
+  END IF;
+
+  EXECUTE json_context_query
+    INTO STRICT json_context;
+
+  IF (v_other_context IS NOT NULL)
+  THEN
+    json_context := jsonb_insert(
+        json_context::JSONB,
+        '{other_context}', v_other_context::JSONB
+      )::JSON;
+  END IF;
+
+  RETURN json_context;
+END
+$$
+LANGUAGE plpgsql;;
+
+-- return the composition name as extracted from the jsonb entry
+CREATE OR REPLACE FUNCTION ehr.composition_name(content JSONB)
+  RETURNS TEXT AS
+$$
+BEGIN
+  RETURN
+    (with root_json as (
+      select jsonb_object_keys(content) root)
+     select trim(LEADING '''' FROM (trim(TRAILING ''']' FROM (regexp_split_to_array(root_json.root, 'and name/value='))[2])))
+     from root_json
+     where root like '/composition%');
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ehr.composition_uid(composition_uid UUID, server_id TEXT)
+  RETURNS TEXT AS
+$$
+BEGIN
+  select "composition_join"."id"||'::'||server_id||'::'||1
+        + COALESCE(
+          (select count(*)
+            from "ehr"."composition_history"
+              where "composition_join"."id" = "ehr"."composition_history"."id"
+              group by "ehr"."composition_history"."id")
+          , 0) as "uid/value"
+        from "ehr"."entry"
+            right outer join "ehr"."composition" as "composition_join"
+                        on "composition_join"."id" = composition_uid;
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ehr.js_archetype_details(archetype_node_id TEXT, template_id TEXT)
+  RETURNS jsonb AS
+$$
+BEGIN
+  RETURN
+    jsonb_strip_nulls(
+        jsonb_build_object(
+            '_type', 'ARCHETYPED',
+            'archetype_id', jsonb_build_object (
+                '_type', 'ARCHETYPE_ID',
+                'value', archetype_node_id
+            ),
+            'template_id', jsonb_build_object (
+                '_type', 'TEMPLATE_ID',
+                'value', template_id
+              ),
+            'rm_version', '1.0.2'
+          )
+      );
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ehr.js_object_version_id(version_id TEXT)
+  RETURNS jsonb AS
+$$
+BEGIN
+  RETURN
+    jsonb_strip_nulls(
+        jsonb_build_object(
+            '_type', 'OBJECT_VERSION_ID',
+            'value', version_id
+          )
+      );
+END
+$$
+  LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION ehr.composition_uid(composition_uid UUID, server_id TEXT)
+  RETURNS TEXT AS
+$$
+BEGIN
+  RETURN (select "composition"."id"||'::'||server_id||'::'||1
+    + COALESCE(
+                                                                (select count(*)
+                                                                 from "ehr"."composition_history"
+                                                                 where "composition"."id" = composition_uid
+                                                                 group by "ehr"."composition_history"."id")
+                                                              , 0)
+          from ehr.composition
+          where composition.id = composition_uid);
+END
+$$
+  LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ehr.js_composition(UUID, server_node_id TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  composition_uuid ALIAS FOR $1;
+BEGIN
+  RETURN (
+    WITH composition_data AS (
+      SELECT
+        composition.id as composition_id,
+        composition.language  as language,
+        composition.territory as territory,
+        composition.composer  as composer,
+        event_context.id      as context_id,
+        territory.twoletter   as territory_code,
+        entry.template_id     as template_id,
+        entry.archetype_id    as archetype_id,
+        concept.conceptid     as category_defining_code,
+        concept.description   as category_description,
+        entry.entry           as content
+      FROM ehr.composition
+             INNER JOIN ehr.entry ON entry.composition_id = composition.id
+             LEFT JOIN ehr.event_context ON event_context.composition_id = composition.id
+             LEFT JOIN ehr.territory ON territory.code = composition.territory
+             LEFT JOIN ehr.concept ON concept.id = entry.category
+      WHERE composition.id = composition_uuid
+      LIMIT 1
+    ),
+         entry_content AS (
+           WITH values as (
+             select composition_data.*,
+                    to_jsonb(jsonb_each(to_jsonb(jsonb_each((composition_data.content)::jsonb)))) #>> '{value}' as jsonvalue
+             from composition_data
+             where composition_data.composition_id = composition_uuid
+           )
+           select values.*
+           FROM values
+           where jsonvalue like '{"/content%'
+           LIMIT 1
+         )
+    SELECT
+      jsonb_strip_nulls(
+          jsonb_build_object(
+              '_type', 'COMPOSITION',
+              'name', ehr.js_dv_text(ehr.composition_name(entry_content.content)),
+              'archetype_details', ehr.js_archetype_details(entry_content.archetype_id, entry_content.template_id),
+              'archetype_node_id', entry_content.archetype_id,
+              'uid', ehr.js_object_version_id(ehr.composition_uid(entry_content.composition_id, server_node_id)),
+              'language', ehr.js_code_phrase(language, 'ISO_639-1'),
+              'territory', ehr.js_code_phrase(territory_code, 'ISO_3166-1'),
+              'composer', ehr.js_party(composer),
+              'category',
+              ehr.js_dv_coded_text(category_description, ehr.js_code_phrase(category_defining_code :: TEXT, 'openehr')),
+              'context', ehr.js_context(context_id),
+              'content', entry_content.jsonvalue::jsonb
+            )
+        )
+    FROM entry_content
+  );
+END
+$$
+  LANGUAGE plpgsql;
 
 

--- a/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
+++ b/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
@@ -1,0 +1,75 @@
+-- convert a db dv_quantity into its canonical representation
+-- DB representation:
+-- {"units": "mg", "accuracy": 0.0, "magnitude": 636.3397240638733, "precision": 0, "accuracyPercent": false, "measurementService": {}}
+-- Canonical comes out with type
+
+CREATE OR REPLACE FUNCTION ehr.js_canonical_dv_quantity(magnitude FLOAT, units TEXT, _precision INT, accuracy_percent BOOLEAN)
+  RETURNS JSON AS
+$$
+BEGIN
+  RETURN
+    jsonb_strip_nulls(
+        jsonb_build_object(
+            '_type', 'DV_QUANTITY',
+            'magnitude', magnitude,
+            'units', units,
+            'precision', _precision,
+            'accuracy_is_percent', accuracy_percent
+          )
+      );
+END
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION ehr.js_canonical_hier_object_id(TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  value ALIAS FOR $1;
+BEGIN
+  RETURN
+    json_build_object(
+        '_type', 'HIER_OBJECT_ID',
+        'value', value
+      );
+END
+$$
+  LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION ehr.js_canonical_generic_id(scheme TEXT, id TEXT)
+  RETURNS json AS
+$$
+BEGIN
+  RETURN
+    jsonb_strip_nulls(
+        jsonb_build_object(
+                '_type', 'GENERIC_ID',
+                'value', id,
+                'scheme', scheme
+              )
+          );
+END
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION ehr.js_canonical_party_ref(namespace TEXT, type TEXT, scheme TEXT, id TEXT)
+  RETURNS json AS
+$$
+BEGIN
+  RETURN
+    jsonb_strip_nulls(
+        jsonb_build_object(
+            '_type', 'PARTY_REF',
+            'namespace', namespace,
+            'type', type,
+            'id', ehr.js_generic_id(scheme, id)
+          )
+      );
+END
+$$
+LANGUAGE plpgsql;
+
+

--- a/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
+++ b/base/src/main/resources/db/migration/V12__datatypes_canonical_json.sql
@@ -21,6 +21,34 @@ END
 $$
 LANGUAGE plpgsql;
 
+--fixed bad encoding
+CREATE OR REPLACE FUNCTION ehr.js_dv_date_time(TIMESTAMP, TEXT)
+  RETURNS JSON AS
+$$
+DECLARE
+  date_time ALIAS FOR $1;
+  time_zone ALIAS FOR $2;
+BEGIN
+
+  IF (date_time IS NULL)
+  THEN
+    RETURN NULL;
+  END IF;
+
+  IF (time_zone IS NULL)
+  THEN
+    time_zone := 'UTC';
+  END IF;
+
+  RETURN
+    json_build_object(
+        '_type', 'DV_DATE_TIME',
+        'value', ehr.iso_timestamp(date_time)||time_zone
+      );
+END
+$$
+  LANGUAGE plpgsql;
+
 
 CREATE OR REPLACE FUNCTION ehr.js_canonical_hier_object_id(ehr_id UUID)
   RETURNS JSON AS

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/response/QueryResponseData.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/response/QueryResponseData.java
@@ -62,11 +62,11 @@ public class QueryResponseData {
 
                 if (queryResultDto.getVariables().containsKey(columnId)) {
                     fieldMap.put("name", columnId);
-                    fieldMap.put("path", "/"+queryResultDto.getVariables().get(columnId));
+                    fieldMap.put("path", queryResultDto.getVariables().get(columnId));
                 }
                 else {
                     fieldMap.put("name", "#"+count);
-                    fieldMap.put("path", "/"+columnId);
+                    fieldMap.put("path", columnId);
                 }
                 count++;
                 columns.add(fieldMap);

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
@@ -47,7 +47,7 @@ public class LightRawJsonEncoder {
 
     public String encodeContentAsString(String root) {
 
-        Map<String, Object> fromDB = db2map();
+        Map<String, Object> fromDB = db2map(root != null && root.equals("value"));
 
         GsonBuilder gsonRaw = EncodeUtilArchie.getGsonBuilderInstance(I_DvTypeAdapter.AdapterType.DBJSON2RAWJSON);
         String raw;
@@ -61,7 +61,7 @@ public class LightRawJsonEncoder {
 
     public JsonElement encodeContentAsJson(String root){
         GsonBuilder gsonRaw = EncodeUtilArchie.getGsonBuilderInstance(I_DvTypeAdapter.AdapterType.DBJSON2RAWJSON);
-        JsonElement jsonElement = gsonRaw.create().toJsonTree(db2map());
+        JsonElement jsonElement = gsonRaw.create().toJsonTree(db2map(root != null && root.equals("value")));
         if (root != null) {
             //in order to create the canonical form, build the ELEMENT json (hence the type is passed into the embedded value)
             jsonElement = jsonElement.getAsJsonObject().get(root);
@@ -79,10 +79,13 @@ public class LightRawJsonEncoder {
         return converted.replaceFirst(Pattern.quote("{"), new ArchieCompositionProlog(root).toString());
     }
 
-    private Map<String, Object> db2map(){
+    private Map<String, Object> db2map(boolean isValue){
         GsonBuilder gsondb = EncodeUtilArchie.getGsonBuilderInstance();
         if (jsonbOrigin.startsWith("[")) {
-            jsonbOrigin = "{\"items\":"+jsonbOrigin+"}"; //joy of json...
+            if (isValue)
+                jsonbOrigin = jsonbOrigin.trim().substring(1, jsonbOrigin.length() - 1);
+            else
+                jsonbOrigin = "{\"items\":"+jsonbOrigin+"}"; //joy of json... this deals with array with and name/value predicate
         }
 
         Map<String, Object> fromDB = gsondb.create().fromJson(jsonbOrigin, Map.class);

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
@@ -81,8 +81,8 @@ public class LightRawJsonEncoder {
 
     private Map<String, Object> db2map(){
         GsonBuilder gsondb = EncodeUtilArchie.getGsonBuilderInstance();
-        if (jsonbOrigin.startsWith("[")) { //strip the expression as an array
-            jsonbOrigin = jsonbOrigin.trim().substring(1, jsonbOrigin.length() - 1);
+        if (jsonbOrigin.startsWith("[")) {
+            jsonbOrigin = "{\"items\":"+jsonbOrigin+"}"; //joy of json...
         }
 
         Map<String, Object> fromDB = gsondb.create().fromJson(jsonbOrigin, Map.class);

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/rawjson/LightRawJsonEncoder.java
@@ -22,11 +22,15 @@
 package org.ehrbase.ehr.encode.rawjson;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 import org.ehrbase.ehr.encode.EncodeUtilArchie;
 import org.ehrbase.ehr.encode.wrappers.json.I_DvTypeAdapter;
 import org.ehrbase.ehr.encode.wrappers.json.writer.translator_db2raw.ArchieCompositionProlog;
 import org.ehrbase.ehr.encode.wrappers.json.writer.translator_db2raw.CompositionRoot;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -42,12 +46,8 @@ public class LightRawJsonEncoder {
     }
 
     public String encodeContentAsString(String root) {
-//        Type listType = new TypeToken<ArrayList<ArrayList<Object>>>(){}.getType();
-        GsonBuilder gsondb = EncodeUtilArchie.getGsonBuilderInstance();
-        if (jsonbOrigin.startsWith("[")) { //strip the expression as an array
-            jsonbOrigin = jsonbOrigin.trim().substring(1, jsonbOrigin.length() - 1);
-        }
-        Map<String, Object> fromDB = gsondb.create().fromJson(jsonbOrigin, Map.class);
+
+        Map<String, Object> fromDB = db2map();
 
         GsonBuilder gsonRaw = EncodeUtilArchie.getGsonBuilderInstance(I_DvTypeAdapter.AdapterType.DBJSON2RAWJSON);
         String raw;
@@ -59,6 +59,17 @@ public class LightRawJsonEncoder {
         return raw;
     }
 
+    public JsonElement encodeContentAsJson(String root){
+        GsonBuilder gsonRaw = EncodeUtilArchie.getGsonBuilderInstance(I_DvTypeAdapter.AdapterType.DBJSON2RAWJSON);
+        JsonElement jsonElement = gsonRaw.create().toJsonTree(db2map());
+        if (root != null) {
+            //in order to create the canonical form, build the ELEMENT json (hence the type is passed into the embedded value)
+            jsonElement = jsonElement.getAsJsonObject().get(root);
+        }
+
+        return jsonElement;
+    }
+
     public String encodeCompositionAsString() {
         //get the composition root key
         String root = new CompositionRoot(jsonbOrigin).toString();
@@ -68,5 +79,26 @@ public class LightRawJsonEncoder {
         return converted.replaceFirst(Pattern.quote("{"), new ArchieCompositionProlog(root).toString());
     }
 
+    private Map<String, Object> db2map(){
+        GsonBuilder gsondb = EncodeUtilArchie.getGsonBuilderInstance();
+        if (jsonbOrigin.startsWith("[")) { //strip the expression as an array
+            jsonbOrigin = jsonbOrigin.trim().substring(1, jsonbOrigin.length() - 1);
+        }
+
+        Map<String, Object> fromDB = gsondb.create().fromJson(jsonbOrigin, Map.class);
+
+        if (fromDB.containsKey("content")){
+            //push contents upward
+            for (Object contentItem: ((LinkedTreeMap)fromDB.get("content")).entrySet()){
+                if (contentItem instanceof Map.Entry) {
+                    fromDB.put(((Map.Entry) contentItem).getKey().toString(), ((Map.Entry) contentItem).getValue());
+                }
+            }
+
+        }
+
+        fromDB.remove("content");
+        return fromDB;
+    }
 
 }

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/Children.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/Children.java
@@ -85,7 +85,7 @@ public class Children {
                 contents++;
             }
         }
-        return contents > 0;
+        return contents > 1;
     }
 
     public int contentCount() {
@@ -176,5 +176,17 @@ public class Children {
         }
 
         return contents;
+    }
+
+    public LinkedTreeMap removeContents(){
+        String key = linkedTreeMap.keySet().iterator().next();
+        while (key != null){
+            if (key.startsWith(CompositionSerializer.TAG_CONTENT))
+                linkedTreeMap.remove(key);
+            if (linkedTreeMap.keySet().size() == 0)
+                break;
+            key = linkedTreeMap.keySet().iterator().next();
+        }
+        return linkedTreeMap;
     }
 }

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
@@ -96,10 +96,7 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
         }
 
         if (isItemsOnly) {
-            if (parentItemsArchetypeNodeId != null)
-                writer.name(ARCHETYPE_NODE_ID).value(parentItemsArchetypeNodeId);
-
-
+            //CHC 20191003: Removed archetype_node_id writer since it is serviced by closing the array.
             ArrayList items = new Children(map).items();
             writeItemInArray(ITEMS, items, writer, parentItemsArchetypeNodeId, parentItemsType);
         } else if (isMultiEvents) {
@@ -372,12 +369,10 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
                             writer.name(AT_TYPE).value(new SnakeCase(((String) value)).camelToUpperSnake());
                         break;
                     case CompositionSerializer.TAG_PATH:  //this is an element
-                        //identify the key of this node from the path
-//                        String itemKey = new LocatableHelper()
                         String archetypeNodeId2 = new PathAttribute((String) value).archetypeNodeId();
                         if (archetypeNodeId2 != null)
                             writer.name(AT_TYPE).value(ELEMENT);
-                        new ArchetypeNodeId(writer, archetypeNodeId).write();
+                        //CHC 20191003: removed writer for archetype_node_id as it was not applicable here
                         break;
                     case CompositionSerializer.TAG_NAME:
                         writeNameAsValue(writer, value.toString());

--- a/serialisation/src/test/java/org/ehrbase/serialisation/DBEncodeTest.java
+++ b/serialisation/src/test/java/org/ehrbase/serialisation/DBEncodeTest.java
@@ -18,11 +18,15 @@
 
 package org.ehrbase.serialisation;
 
+import com.google.gson.JsonElement;
 import org.ehrbase.test_data.composition.CompositionTestDataCanonicalXML;
 import com.nedap.archie.rm.composition.Composition;
 import org.ehrbase.ehr.encode.rawjson.LightRawJsonEncoder;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,5 +81,32 @@ public class DBEncodeTest {
 
             assertNotNull(interpreted);
         }
+    }
+
+    @Test
+    public void testDBDecodeFullComposition() throws Exception {
+
+        String db_encoded = IOUtils.resourceToString("/composition/canonical_json/full_composition.json", UTF_8);
+        assertNotNull(db_encoded);
+
+        JsonElement converted = new LightRawJsonEncoder(db_encoded).encodeContentAsJson(null);
+
+        //see if this can be interpreted by Archie
+        Object object = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
+
+        assertTrue(object instanceof Composition);
+
+        String interpreted = new CanonicalXML().marshal((Composition) object);
+
+        assertNotNull(interpreted);
+    }
+
+    @Test
+    public void unmarshal_from_js_composition() throws IOException {
+        String marshal = IOUtils.resourceToString("/composition/canonical_json/rawdb_composition.json", UTF_8);
+        JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
+        Object object = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
+
+        assertTrue(object instanceof Composition);
     }
 }

--- a/serialisation/src/test/java/org/ehrbase/serialisation/RawJsonTest.java
+++ b/serialisation/src/test/java/org/ehrbase/serialisation/RawJsonTest.java
@@ -27,6 +27,8 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,4 +104,24 @@ public class RawJsonTest {
         assertThat(actual).isNotNull();
         assertThat(composition.getName().getValue()).isEqualTo("DiADeM Assessment");
     }
+
+    @Test
+    public void unmarshal2() throws IOException {
+
+        String value = IOUtils.toString(CompositionTestDataCanonicalXML.ALL_TYPES_FIXED.getStream(), UTF_8);
+
+        CanonicalXML canonicalXML = new CanonicalXML();
+
+        Composition composition = canonicalXML.unmarshal(value, Composition.class);
+
+        RawJson cut = new RawJson();
+
+        String marshal = cut.marshal(composition);
+
+        Composition actual = cut.unmarshal(marshal, Composition.class);
+
+        assertThat(actual).isNotNull();
+        assertThat(composition.getName().getValue()).isEqualTo("Test all types");
+    }
+
 }

--- a/service/src/main/java/org/ehrbase/aql/definition/ExtensionDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/ExtensionDefinition.java
@@ -76,4 +76,14 @@ public class ExtensionDefinition implements I_VariableDefinition {
     public List<FuncParameter> getFuncParameters() {
         return null;
     }
+
+    @Override
+    public I_VariableDefinition clone() {
+        return new ExtensionDefinition(this.context, this.parsableExpression, this.alias);
+    }
+
+    @Override
+    public void setPath(String path) {
+
+    }
 }

--- a/service/src/main/java/org/ehrbase/aql/definition/FunctionDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/FunctionDefinition.java
@@ -80,4 +80,14 @@ public class FunctionDefinition implements I_VariableDefinition {
     public List<FuncParameter> getFuncParameters() {
         return parameters;
     }
+
+    @Override
+    public I_VariableDefinition clone() {
+        return new FunctionDefinition(this.identifier, this.alias, this.path, this.parameters);
+    }
+
+    @Override
+    public void setPath(String path) {
+        this.path = path;
+    }
 }

--- a/service/src/main/java/org/ehrbase/aql/definition/I_VariableDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/I_VariableDefinition.java
@@ -42,4 +42,8 @@ public interface I_VariableDefinition {
     boolean isExtension();
 
     List<FuncParameter> getFuncParameters();
+
+    I_VariableDefinition clone();
+
+    void setPath(String path); //used to modify the path in case of struct query (canonical json).
 }

--- a/service/src/main/java/org/ehrbase/aql/definition/VariableDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/VariableDefinition.java
@@ -80,4 +80,14 @@ public class VariableDefinition implements I_VariableDefinition {
     public List<FuncParameter> getFuncParameters() {
         return null;
     }
+
+    @Override
+    public I_VariableDefinition clone(){
+        return new VariableDefinition(this.path, this.alias, this.identifier, this.isDistinct);
+    }
+
+    @Override
+    public void setPath(String path){
+        this.path = path;
+    }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -27,7 +27,6 @@ import org.ehrbase.aql.compiler.Statements;
 import org.ehrbase.aql.compiler.TopAttributes;
 import org.ehrbase.aql.definition.Variables;
 import org.ehrbase.aql.sql.binding.*;
-import org.ehrbase.aql.sql.postprocessing.I_RawJsonTransform;
 import org.ehrbase.aql.sql.postprocessing.RawJsonTransform;
 import org.ehrbase.aql.sql.queryImpl.ContainsSet;
 import org.ehrbase.aql.sql.queryImpl.TemplateMetaData;
@@ -111,7 +110,7 @@ public class QueryProcessor extends TemplateMetaData {
         //if any jsonb data field transform them into raw json
         if (aqlSelectQuery.isOutputWithJson() && knowledgeCache != null) {
             RawJsonTransform.toRawJson(result, aqlSelectQuery.getQuerySteps(), knowledgeCache);
-            result = RawJsonTransform.deleteNamedColumn(result, I_RawJsonTransform.TEMPLATE_ID);
+//            result = RawJsonTransform.deleteNamedColumn(result, I_RawJsonTransform.TEMPLATE_ID);
         }
 
         List<List<String>> explainList = buildExplain(aqlSelectQuery.getSelectQuery());
@@ -184,7 +183,7 @@ public class QueryProcessor extends TemplateMetaData {
             unionSetQuery = new SuperQuery(context, statements.getVariables(), unionSetQuery).select();
         }
 
-        return new AqlSelectQuery(unionSetQuery, cacheQuery.values(), cacheQuery.values().stream().anyMatch(QuerySteps::isContainsJQueryPath));
+        return new AqlSelectQuery(unionSetQuery, cacheQuery.values(), cacheQuery.values().stream().anyMatch(QuerySteps::isContainsJson));
     }
 
     private QuerySteps buildQuerySteps(UUID compId, String templateId, String entryRoot) {

--- a/service/src/main/java/org/ehrbase/aql/sql/QuerySteps.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QuerySteps.java
@@ -77,4 +77,8 @@ public class QuerySteps {
     public boolean isContainsJQueryPath() {
         return containsJQueryPath;
     }
+
+    public boolean isContainsJson(){
+        return jsonColumnsSize() > 0 || isContainsJQueryPath();
+    }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/I_JoinBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/I_JoinBinder.java
@@ -21,10 +21,7 @@
 
 package org.ehrbase.aql.sql.binding;
 
-import org.ehrbase.jooq.pg.tables.records.CompositionRecord;
-import org.ehrbase.jooq.pg.tables.records.EhrRecord;
-import org.ehrbase.jooq.pg.tables.records.PartyIdentifiedRecord;
-import org.ehrbase.jooq.pg.tables.records.StatusRecord;
+import org.ehrbase.jooq.pg.tables.records.*;
 import org.jooq.Table;
 
 import static org.ehrbase.jooq.pg.Tables.*;
@@ -34,10 +31,12 @@ import static org.ehrbase.jooq.pg.Tables.*;
  */
 public interface I_JoinBinder {
     String COMPOSITION_JOIN = "composition_join";
+    String SYSTEM_JOIN = "system_join";
     String STATUS_JOIN = "status_join";
     String EHR_JOIN = "ehr_join";
 
     Table<CompositionRecord> compositionRecordTable = COMPOSITION.as(COMPOSITION_JOIN);
+    Table<SystemRecord> systemRecordTable = SYSTEM.as(SYSTEM_JOIN);
     Table<StatusRecord> statusRecordTable = STATUS.as(STATUS_JOIN);
     Table<EhrRecord> ehrRecordTable = EHR_.as(EHR_JOIN);
     Table<PartyIdentifiedRecord> composerRef = PARTY_IDENTIFIED.as("composer_ref");

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/JsonbBlockDef.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/JsonbBlockDef.java
@@ -29,10 +29,12 @@ import org.jooq.Field;
 public class JsonbBlockDef {
     private String path;
     private Field field;
+    private String jsonPathRoot; //if set, use this root to extract the actual json struct from the result (f.e. /value in an Element)
 
-    public JsonbBlockDef(String path, Field field) {
+    public JsonbBlockDef(String path, Field field, String jsonPathRoot) {
         this.path = path;
         this.field = field;
+        this.jsonPathRoot = jsonPathRoot;
     }
 
     public String getPath() {
@@ -41,5 +43,9 @@ public class JsonbBlockDef {
 
     public Field getField() {
         return field;
+    }
+
+    public String getJsonPathRoot() {
+        return jsonPathRoot;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
@@ -147,25 +147,25 @@ public class SelectBinder extends TemplateMetaData implements I_SelectBinder {
     }
 
 
-    public PathResolver getPathResolver() {
-        return pathResolver;
-    }
-
-    public boolean hasEhrIdExpression() {
-        return compositionAttributeQuery.containsEhrId();
-    }
-
-    public String getEhrIdAlias() {
-        return compositionAttributeQuery.getEhrIdAlias();
-    }
-
-    public boolean isCompositionIdFiltered() {
-        return compositionAttributeQuery.isCompositionIdFiltered();
-    }
-
-    public boolean isEhrIdFiltered() {
-        return compositionAttributeQuery.isEhrIdFiltered();
-    }
+//    public PathResolver getPathResolver() {
+//        return pathResolver;
+//    }
+//
+//    public boolean hasEhrIdExpression() {
+//        return compositionAttributeQuery.containsEhrId();
+//    }
+//
+//    public String getEhrIdAlias() {
+//        return compositionAttributeQuery.getEhrIdAlias();
+//    }
+//
+//    public boolean isCompositionIdFiltered() {
+//        return compositionAttributeQuery.isCompositionIdFiltered();
+//    }
+//
+//    public boolean isEhrIdFiltered() {
+//        return compositionAttributeQuery.isEhrIdFiltered();
+//    }
 
     public boolean containsJQueryPath() {
         return jsonbEntryQuery.isContainsJqueryPath();

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
@@ -106,7 +106,7 @@ public class SelectBinder extends TemplateMetaData implements I_SelectBinder {
                 case "COMPOSITION":
                     if (variableDefinition.getPath() != null && variableDefinition.getPath().startsWith("content")) {
                         field = jsonbEntryQuery.makeField(template_id, comp_id, identifier, variableDefinition, I_QueryImpl.Clause.SELECT);
-                        handleJsonDataBlock(jsonbEntryQuery, field, null, null);
+                        handleJsonDataBlock(jsonbEntryQuery, field, null, variableDefinition.getPath());
                     } else {
                         field = compositionAttributeQuery.makeField(template_id, comp_id, identifier, variableDefinition, I_QueryImpl.Clause.SELECT);
                         handleJsonDataBlock(compositionAttributeQuery, field, null, variableDefinition.getPath());

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -316,7 +316,7 @@ public class WhereBinder {
             ) {
                 Object nextToken = whereClause.get(lcursor + 1); //check operator
                 if (nextToken instanceof String && !nextToken.equals("="))
-                    throw new IllegalArgumentException("name/value for Composition must be an equality");
+                    throw new IllegalArgumentException("name/value for CompositionAttribute must be an equality");
                 nextToken = whereClause.get(lcursor + 2);
                 if (nextToken instanceof String) {
                     token = (String) nextToken;

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -81,7 +81,7 @@ public class WhereBinder {
                 field = compositionAttributeQuery.whereField(templateId, comp_id, identifier, variableDefinition);
             } else { //should be removed (?)
                 //TODO: identify a method to avoid using Set Returning Function (jsonb_array_element) in WHERE (unsupported in PG10+) while still filtering values in a set
-                field = jsonbEntryQuery.makeField(templateId, comp_id, identifier, variableDefinition, false, I_QueryImpl.Clause.WHERE);
+                field = jsonbEntryQuery.makeField(templateId, comp_id, identifier, variableDefinition, I_QueryImpl.Clause.WHERE);
             }
             if (field == null)
                 return null;

--- a/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
@@ -69,7 +69,7 @@ public class RawJsonTransform implements I_RawJsonTransform {
 
                             //
                             //   String rawJson = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsString(jsonbBlockDef.getField().getName());
-                            String rawJson = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsString(null);
+                            String rawJson = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsString(jsonbBlockDef.getJsonPathRoot());
                             //debugging
                             if (jsonbOrigin.contains("@class"))
                                 System.out.print("Hum...");

--- a/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
@@ -21,6 +21,7 @@
 
 package org.ehrbase.aql.sql.postprocessing;
 
+import com.google.gson.JsonElement;
 import org.ehrbase.aql.sql.QuerySteps;
 import org.ehrbase.aql.sql.binding.JsonbBlockDef;
 import org.ehrbase.ehr.knowledge.I_KnowledgeCache;
@@ -48,35 +49,30 @@ public class RawJsonTransform implements I_RawJsonTransform {
 
     public static void toRawJson(Result<Record> result, Collection<QuerySteps> querySteps, I_KnowledgeCache knowledgeCache) {
 
-
-
         for (QuerySteps queryStep : querySteps) {
             if (queryStep.jsonColumnsSize() > 0) {
                 for (int cursor = 0; cursor < result.size(); cursor++) {
                     Record record = result.get(cursor);
-                    String templateIdNow = record.getValue(TEMPLATE_ID, String.class);
-                    if (!templateIdNow.equals(queryStep.getTemplateId()))
-                        continue;
+                    List<JsonbBlockDef> deleteList = new ArrayList<>();
                     for (JsonbBlockDef jsonbBlockDef : queryStep.getJsonColumns()) {
                         String jsonbOrigin = (String) record.getValue(jsonbBlockDef.getField());
                         if (jsonbOrigin == null)
                             continue;
-                        String templateId = (String) record.getValue(TEMPLATE_ID);
-                        String itemPath = jsonbBlockDef.getPath();
                         //apply the transformation
                         try {
-//                            jsonbOrigin = "{\""+jsonbBlockDef.getField().getName()+"\":"+jsonbOrigin+"}";
-
-                            //
-                            //   String rawJson = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsString(jsonbBlockDef.getField().getName());
-                            String rawJson = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsString(jsonbBlockDef.getJsonPathRoot());
+                            JsonElement jsonElement = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsJson(jsonbBlockDef.getJsonPathRoot());
                             //debugging
                             if (jsonbOrigin.contains("@class"))
                                 System.out.print("Hum...");
-                            record.setValue(jsonbBlockDef.getField(), rawJson);
+                            record.setValue(jsonbBlockDef.getField(), jsonElement);
                         } catch (Exception e) {
-                            throw new IllegalArgumentException("Could not encode raw json for template Id:" + templateId);
+                            //assumes this is not a json element
+                            record.setValue(jsonbBlockDef.getField(), jsonbOrigin);
+                            deleteList.add(jsonbBlockDef);
                         }
+                    }
+                    for (JsonbBlockDef deleteBlock: deleteList){
+                        queryStep.getJsonColumns().remove(deleteBlock);
                     }
                 }
             }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
@@ -82,8 +82,12 @@ public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImp
         Field retField;
 
         if (columnAlias == null) {
-            if (clause.equals(Clause.SELECT))
-                retField =  new FullCompositionJson(fieldResolutionContext, joinSetup).sqlField();
+            if (clause.equals(Clause.SELECT)) {
+                if (pathResolver.classNameOf(variableDefinition.getIdentifier()).equals("COMPOSITION"))
+                    retField = new FullCompositionJson(fieldResolutionContext, joinSetup).sqlField();
+                else
+                    throw new IllegalArgumentException("Only full composition canonical json is supported at this stage, found class:" + pathResolver.classNameOf(variableDefinition.getIdentifier()));
+            }
             else
                 retField = null;
         } else {

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
@@ -21,19 +21,21 @@
 
 package org.ehrbase.aql.sql.queryImpl;
 
+import org.ehrbase.aql.definition.FromEhrDefinition;
 import org.ehrbase.aql.definition.I_VariableDefinition;
 import org.ehrbase.aql.sql.PathResolver;
 import org.ehrbase.aql.sql.binding.I_JoinBinder;
-import org.ehrbase.jooq.pg.tables.records.PartyIdentifiedRecord;
+import org.ehrbase.aql.sql.queryImpl.attribute.*;
+import org.ehrbase.aql.sql.queryImpl.attribute.composer.ComposerResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.composition.CompositionResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.EventContextResolver;
 import org.ehrbase.service.IntrospectService;
 import org.jooq.DSLContext;
 import org.jooq.Field;
-import org.jooq.SelectQuery;
-import org.jooq.Table;
+import org.jooq.TableField;
 import org.jooq.impl.DSL;
-import org.jooq.impl.SQLDataType;
 
-import java.sql.Timestamp;
 import java.util.UUID;
 
 import static org.ehrbase.jooq.pg.Tables.*;
@@ -46,28 +48,13 @@ import static org.ehrbase.jooq.pg.Tables.*;
 public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImpl, I_JoinBinder {
 
     private String serverNodeId;
-    private String columnAlias;
-    private boolean containsEhrStatus = false;
-    private boolean containsOtherContext = false;
-    private boolean containsEhrId = false;
-    private String ehrIdAlias;
 
-    private boolean ehrIdFiltered = false; //true if the query specifies the ehr id (in the AQL FROM clause)
-    private boolean compositionIdFiltered = false; //true if the query contains a where clause with composition id specified
-    private boolean compositionIdField = false;
-
-    //boolean indicating the resulting joins to generate
-    private boolean joinComposition = false;
-    private boolean joinEventContext = false;
-    private boolean joinSubject = false;
-    private boolean joinEhr = false;
-    private boolean joinEhrStatus = false;
-    private boolean joinComposer = false;
-    private boolean joinContextFacility = false;
-
+    protected JoinSetup joinSetup = new JoinSetup(); //used to pass join metadata to perform binding
     private final String entry_root;
     //    private MetaData metaData;
     private final IntrospectService introspectCache;
+
+    protected final TableField NULL_FIELD = null;
 
     public CompositionAttributeQuery(DSLContext context, PathResolver pathResolver, String serverNodeId, String entry_root, IntrospectService introspectCache) {
         super(context, pathResolver);
@@ -79,115 +66,36 @@ public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImp
     @Override
     public Field<?> makeField(String templateId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, boolean withAlias, Clause clause) {
         //resolve composition attributes and/or context
-        columnAlias = variableDefinition.getPath();
-        compositionIdField = false;
+        String columnAlias = variableDefinition.getPath();
+        FieldResolutionContext fieldResolutionContext =
+                new FieldResolutionContext(context,
+                        serverNodeId,
+                        compositionId,
+                        identifier,
+                        variableDefinition,
+                        withAlias,
+                        clause,
+                        pathResolver,
+                        introspectCache,
+                        entry_root);
         if (columnAlias == null) {
-//            if (identifier.contains("/")) //a composite, unsupported attribute
-//                return null;
-//            else {
-//                //assume it is the whole composition object
-//                return rawUid(compositionId, withAlias, variableDefinition.getAlias());
-//            }
             return null;
         }
-        switch (columnAlias) {
-            case "uid/value":
-                if (clause == Clause.WHERE)
-                    compositionIdFiltered = true;
-                else
-                    compositionIdField = true;
-
-                joinComposition = true;
-
-                if (withAlias)
-                    return uid(compositionId, withAlias, variableDefinition.getAlias());
                 else {
-                    return rawUid(compositionId, withAlias, variableDefinition.getAlias());
+            if (pathResolver.classNameOf(variableDefinition.getIdentifier()).equals("EHR")) {
+                return new EhrResolver(fieldResolutionContext, joinSetup).sqlField(columnAlias);
                 }
-//                return rawUid(compositionId, withAlias, variableDefinition.getAlias());
-            case "name/value":
-                return name(compositionId, withAlias, variableDefinition.getAlias(), clause);
-            case "archetype_node_id":
-                return archetypeNodeId(compositionId, withAlias, variableDefinition.getAlias());
-            case "template_id":
-                return templateId(compositionId, withAlias, variableDefinition.getAlias());
-            case "language/value":
-                joinComposition = true;
-                return language(compositionId, withAlias, variableDefinition.getAlias());
-            case "territory/value":
-                joinComposition = true;
-                return territory(compositionId, withAlias, variableDefinition.getAlias());
-            case "composer/name":
-                joinComposer = true;
-                return composerNameValue(compositionId, withAlias, variableDefinition.getAlias());
-            case "composer/id/namespace":
-            case "composer/external_ref/namespace":
-                joinComposer = true;
-                return composerIdNamespace(compositionId, withAlias, variableDefinition.getAlias());
-            case "composer/id/scheme":
-            case "composer/external_ref/scheme":
-                joinComposer = true;
-                return composerIdScheme(compositionId, withAlias, variableDefinition.getAlias());
-            case "composer/id/ref":
-            case "composer/external_ref/id/value":
-                joinComposer = true;
-                return composerIdRef(compositionId, withAlias, variableDefinition.getAlias());
-            case "composer/type":
-                joinComposer = true;
-                return composerType(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/start_time/value":
-                joinEventContext = true;
-                return contextStartTime(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/end_time/value":
-                joinEventContext = true;
-                return contextEndTime(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/location":
-                joinEventContext = true;
-                return contextLocation(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/facility/name/value":
-            case "context/health_care_facility/name/value":
-                joinContextFacility = true;
-                return contextFacilityName(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/facility/id/namespace":
-            case "context/health_care_facility/id/namespace":
-                joinContextFacility = true;
-                return contextFacilityNamespace(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/facility/id/ref":
-            case "context/health_care_facility/id/ref":
-                joinContextFacility = true;
-                return contextFacilityRef(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/facility/id/scheme":
-            case "context/health_care_facility/id/scheme":
-                joinContextFacility = true;
-                return contextFacilityScheme(compositionId, withAlias, variableDefinition.getAlias());
-            case "context/facility/id/type":
-            case "context/health_care_facility/id/type":
-                joinContextFacility = true;
-                return contextFacilityType(compositionId, withAlias, variableDefinition.getAlias());
-            case "ehr_status/subject/external_ref/namespace":
-                joinSubject = true;
-                return ehrStatusSubjectNamespace(compositionId, withAlias, variableDefinition.getAlias());
-            case "ehr_status/subject/external_ref/id/value":
-                joinSubject = true;
-                return ehrStatusSubjectIdValue(compositionId, withAlias, variableDefinition.getAlias());
-            case "ehr_id/value":
-                if (clause == Clause.FROM)
-                    ehrIdFiltered = true;
-                return ehrIdValue(compositionId, withAlias, variableDefinition.getAlias());
-            case "archetype_details/template_id/value":
-                return templateIdValue(compositionId, withAlias, variableDefinition.getAlias());
-
-
+            else if (pathResolver.classNameOf(variableDefinition.getIdentifier()).equals("COMPOSITION")) {
+                if (columnAlias.startsWith("composer"))
+                    return new ComposerResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("composer").redux(columnAlias));
+                else if (columnAlias.startsWith("context"))
+                    return new EventContextResolver(fieldResolutionContext, joinSetup).sqlField(columnAlias);
+                else //assume composition attribute
+                    return new CompositionResolver(fieldResolutionContext, joinSetup).sqlField(columnAlias);
         }
-        if (columnAlias.startsWith("ehr_status/other_details")) {
-            joinEhrStatus = true;
-            return ehrStatusOtherDetails(variableDefinition, withAlias);
+            else
+                throw new IllegalArgumentException("INTERNAL: the following class cannot be resolved for AQL querying:"+(pathResolver.classNameOf(variableDefinition.getIdentifier())));
         }
-        if (columnAlias.startsWith("context/other_context")) {
-            joinEventContext = true;
-            return ehrContextOtherContext(variableDefinition, withAlias);
-        }
-        throw new IllegalArgumentException("Could not interpret field:" + columnAlias);
     }
 
     @Override
@@ -195,291 +103,40 @@ public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImp
         return makeField(templateId, compositionId, identifier, variableDefinition, false, Clause.WHERE);
     }
 
-    private Field<?> uid(UUID compositionId, boolean alias, String aliasStr) {
-
-        //use inline SQL as it seems coalesce is not going through with POSTGRES dialect
-        SelectQuery<?> subSelect = context.selectQuery();
-        subSelect.addSelect(DSL.count());
-        subSelect.addFrom(COMPOSITION_HISTORY);
-        subSelect.addConditions(I_JoinBinder.compositionRecordTable.field("id", UUID.class).eq(COMPOSITION_HISTORY.ID));
-        subSelect.addGroupBy(COMPOSITION_HISTORY.ID);
-
-        String coalesceVersion = "1 + COALESCE(\n(" + subSelect + "), 0)";
-
-        Field<?> select = DSL.field(I_JoinBinder.compositionRecordTable.field("id")
-                        + "||"
-                        + DSL.val("::")
-                        + "||"
-                        + DSL.val(serverNodeId)
-                        + "||"
-                        + DSL.val("::")
-                        + "||"
-                        + DSL.field(coalesceVersion)
-                , SQLDataType.VARCHAR)
-                .as(alias && aliasStr != null && !aliasStr.isEmpty() ? aliasStr : "uid");
-
-        return select;
+    public boolean isJoinComposition() {
+        return joinSetup.isJoinComposition();
     }
 
-    private Field<?> rawUid(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class).as(aliasStr == null ? columnAlias : aliasStr));
-            return select;
-        } else
-            return DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class));
+    public boolean isJoinEventContext() {
+        return joinSetup.isJoinEventContext();
     }
 
-    private Field<?> name(UUID compositionId, boolean alias, String aliasStr, Clause clause) {
-        //extract the composition name from the jsonb root key
-        String trimName = "trim(LEADING '''' FROM (trim(TRAILING ''']' FROM\n" +
-                " (regexp_split_to_array((select root_json_key from jsonb_object_keys(" + ENTRY.ENTRY_ + ") root_json_key where root_json_key like '/composition%')," +
-                " 'and name/value=')) [2])))";
-        //postgresql equivalent expression
-        if (alias) {
-            Field<?> select = DSL.field(trimName).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else {
-            if (clause.equals(Clause.WHERE)) {
-                trimName = "(SELECT " + trimName + ")";
-            }
-            return DSL.field(trimName);
-        }
+    public boolean isJoinSubject() {
+        return joinSetup.isJoinSubject();
     }
 
-    private Field<?> archetypeNodeId(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(ENTRY.ARCHETYPE_ID).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(ENTRY.ARCHETYPE_ID);
+    public boolean isJoinEhr() {
+        return joinSetup.isJoinEhr();
     }
 
-    private Field<?> templateId(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(ENTRY.TEMPLATE_ID).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(ENTRY.TEMPLATE_ID);
+    public boolean isJoinSystem() {
+        return joinSetup.isJoinSystem();
     }
 
-    private Field<?> language(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(COMPOSITION.LANGUAGE).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(COMPOSITION.LANGUAGE);
+    public boolean isJoinEhrStatus() {
+        return joinSetup.isJoinEhrStatus();
     }
 
-    private Field<?> territory(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(COMPOSITION.TERRITORY).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(COMPOSITION.TERRITORY);
+    public boolean isJoinComposer() {
+        return joinSetup.isJoinComposer();
     }
 
-    private Field<?> composerNameValue(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(composerRef.field(PARTY_IDENTIFIED.NAME)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(composerRef.field(PARTY_IDENTIFIED.NAME));
-    }
-
-    private Field<?> composerIdNamespace(UUID compositionId, boolean alias, String aliasStr) {
-        SelectQuery selectQuery = context.selectQuery();
-        if (alias) {
-            Field<?> select = DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE));
-    }
-
-    private Field<?> composerIdScheme(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_SCHEME)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_SCHEME));
-    }
-
-    private Field<?> composerIdRef(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE));
-    }
-
-    private Field<?> composerType(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_TYPE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(composerRef.field(PARTY_IDENTIFIED.PARTY_REF_TYPE));
-    }
-
-    private Field<?> tzNoZulu(Field<String> field) {
-        return DSL.field(DSL.decode().when(field.equal("UTC"), "Z").otherwise(field));
-    }
-
-    private Field<?> prettyDateTime(Field<Timestamp> dateTime, Field<String> timeZone) {
-        return DSL.field("to_char(" + dateTimeOffsetTimezone(dateTime, timeZone) + ",'YYYY-MM-DD\"T\"HH24:MI:SS')");
-    }
-
-    //sql expression adjusting the date with the timezone. Ignore literals and null timezone
-    private Field<?> dateTimeOffsetTimezone(Field<Timestamp> dateTime, Field<String> timeZone) {
-        return DSL.field("(" + dateTime + "::timestamptz AT TIME ZONE 'UTC'" +
-                " + (case when left(" + timeZone + ",1)='+'" +
-                " then \"interval\"(" + timeZone + ")" +
-                " else \"interval\"('+00:00')" +
-                " end))");
-    }
-
-    private Field<?> contextStartTime(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(prettyDateTime(EVENT_CONTEXT.START_TIME, EVENT_CONTEXT.START_TIME_TZID) + "||" + tzNoZulu(EVENT_CONTEXT.START_TIME_TZID))
-                    .as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(prettyDateTime(EVENT_CONTEXT.START_TIME, EVENT_CONTEXT.START_TIME_TZID) + "||" + tzNoZulu(EVENT_CONTEXT.START_TIME_TZID));
-    }
-
-    private Field<?> contextEndTime(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(prettyDateTime(EVENT_CONTEXT.END_TIME, EVENT_CONTEXT.END_TIME_TZID) + "||" + tzNoZulu(EVENT_CONTEXT.END_TIME_TZID))
-                    .as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(prettyDateTime(EVENT_CONTEXT.END_TIME, EVENT_CONTEXT.START_TIME_TZID) + "||" + tzNoZulu(EVENT_CONTEXT.END_TIME_TZID));
-    }
-
-    private Field<?> contextLocation(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(EVENT_CONTEXT.LOCATION).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(EVENT_CONTEXT.LOCATION);
-    }
-
-    private Field<?> contextFacilityName(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(facilityRef.field(PARTY_IDENTIFIED.NAME)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(facilityRef.field(PARTY_IDENTIFIED.NAME));
-    }
-
-    private Field<?> templateIdValue(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(ENTRY.TEMPLATE_ID).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(ENTRY.TEMPLATE_ID);
-    }
-
-    private Field<?> contextFacilityRef(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE));
-    }
-
-    private Field<?> contextFacilityScheme(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_SCHEME)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_SCHEME));
-    }
-
-    private Field<?> contextFacilityNamespace(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE));
-    }
-
-    private Field<?> contextFacilityType(UUID compositionId, boolean alias, String aliasStr) {
-        if (alias) {
-            Field<?> select = DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_TYPE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(facilityRef.field(PARTY_IDENTIFIED.PARTY_REF_TYPE));
-    }
-
-    private Field<?> ehrStatusSubjectIdValue(UUID compositionId, boolean alias, String aliasStr) {
-        containsEhrStatus = true;
-        if (alias) {
-            Field<?> select = DSL.field(subjectRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(subjectRef.field(PARTY_IDENTIFIED.PARTY_REF_VALUE));
-    }
-
-    private Field<?> ehrStatusSubjectNamespace(UUID compositionId, boolean alias, String aliasStr) {
-        containsEhrStatus = true;
-        if (alias) {
-            Field<?> select = DSL.field(subjectRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE)).as(aliasStr == null ? columnAlias : aliasStr);
-            return select;
-        } else
-            return DSL.field(subjectRef.field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE));
-    }
-
-    private Field<?> ehrIdValue(UUID compositionId, boolean alias, String aliasStr) {
-        containsEhrId = true;
-        ehrIdAlias = (aliasStr == null ? columnAlias : aliasStr);
-        if (useFromEntry()) {
-            joinEhr = true;
-            if (alias) {
-                Field<?> select = DSL.field("{0}", ehrRecordTable.field(EHR_.ID.getName())).as(aliasStr == null ? columnAlias : aliasStr);
-                return select;
-            } else
-                return DSL.field(ehrRecordTable.field(ehrRecordTable.field(EHR_.ID.getName())));
-        } else if (!containsEhrStatus()) {
-            joinEhr = true;
-            if (alias) {
-                Field<?> select = DSL.field("{0}", ehrRecordTable.field(EHR_.ID.getName())).as(aliasStr == null ? columnAlias : aliasStr);
-                return select;
-            } else
-                return DSL.field(ehrRecordTable.field(EHR_.ID.getName()));
-        } else {
-            if (alias) {
-                Field<?> select = DSL.field("{0}", ehrRecordTable.field(EHR_.ID.getName())).as(aliasStr == null ? columnAlias : aliasStr);
-                return select;
-            } else
-                return DSL.field(ehrRecordTable.field(EHR_.ID.getName()));
-        }
-    }
-
-    private Field<?> ehrStatusOtherDetails(I_VariableDefinition variableDefinition, boolean withAlias) {
-        containsEhrStatus = true;
-        String variablePath = variableDefinition.getPath().substring("ehr_status/other_details".length() + 1);
-        Field<?> field = new JsonbEntryQuery(context, introspectCache, pathResolver, entry_root).makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_DETAILS, null, variableDefinition.getAlias(), variablePath, withAlias);
-        return field;
-    }
-
-    private Field<?> ehrContextOtherContext(I_VariableDefinition variableDefinition, boolean withAlias) {
-        containsOtherContext = true;
-        String variablePath = variableDefinition.getPath().substring("context/other_context".length() + 1);
-        variablePath = variablePath.substring(variablePath.indexOf("]") + 1);
-        String otherContextPath = "/" + variableDefinition.getPath().substring(0, variableDefinition.getPath().indexOf("]") + 1);
-        Field<?> field = new JsonbEntryQuery(context, introspectCache, pathResolver, entry_root).makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_CONTEXT, null, variableDefinition.getAlias(), variablePath, withAlias);
-        return field;
+    public boolean isJoinContextFacility() {
+        return joinSetup.isJoinContextFacility();
     }
 
     public boolean containsEhrStatus() {
-        return containsEhrStatus;
-    }
-
-    public boolean containsEhrId() {
-        return containsEhrId;
-    }
-
-    public String getEhrIdAlias() {
-        return ehrIdAlias;
+        return joinSetup.isContainsEhrStatus();
     }
 
     @Override
@@ -488,73 +145,13 @@ public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImp
     }
 
     @Override
-    public boolean isEhrIdFiltered() {
-        return ehrIdFiltered;
-    }
-
-    @Override
-    public boolean isCompositionIdFiltered() {
-        return compositionIdFiltered;
-    }
-
-    @Override
     public boolean isContainsJqueryPath() {
-        return false;
-    }
-
-    @Override
-    public boolean isUseEntry() {
-
         return false;
     }
 
     @Override
     public String getJsonbItemPath() {
         return null;
-    }
-
-    public boolean isJoinComposition() {
-        return joinComposition;
-    }
-
-    public boolean isJoinEventContext() {
-        return joinEventContext;
-    }
-
-    public boolean isJoinSubject() {
-        return joinSubject;
-    }
-
-    public boolean isJoinEhr() {
-        return joinEhr;
-    }
-
-    public boolean isJoinEhrStatus() {
-        return joinEhrStatus;
-    }
-
-    public boolean isJoinComposer() {
-        return joinComposer;
-    }
-
-    public boolean isJoinContextFacility() {
-        return joinContextFacility;
-    }
-
-    public boolean isCompositionIdField() {
-        return compositionIdField;
-    }
-
-    public Table<PartyIdentifiedRecord> getComposerRef() {
-        return composerRef;
-    }
-
-    public Table<PartyIdentifiedRecord> getSubjectRef() {
-        return subjectRef;
-    }
-
-    public Table<PartyIdentifiedRecord> getFacilityRef() {
-        return facilityRef;
     }
 
     /**

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/DefaultColumnId.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/DefaultColumnId.java
@@ -1,0 +1,13 @@
+package org.ehrbase.aql.sql.queryImpl;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.definition.VariableDefinition;
+
+public class DefaultColumnId {
+
+    protected static int serial = 0;
+
+    public String value(I_VariableDefinition variableDefinition){
+        return (variableDefinition.getPath() == null ? (variableDefinition.getIdentifier() == null ? ("field_"+ (serial++)) : variableDefinition.getIdentifier()) : "/"+variableDefinition.getPath());
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/EntryAttributeMapper.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/EntryAttributeMapper.java
@@ -108,13 +108,9 @@ public class EntryAttributeMapper {
             floor = 3;
         } else if (fields.get(0).equals(NAME)) {
             fields.add(1, "0"); //name is now formatted as /name -> array of values! Required to deal with cluster items
-//            if (fields.get(1).equals(VALUE)){
-//                fields.remove(1);
-//            } else if (fields.get(1).equals(DEFINING_CODE)){
-//                fields.remove(0);
-//            }
         } else if (fields.get(0).equals(VALUE) && fields.size() == 1) {
-            fields.add(1, VALUE);
+            //CCH 191016: removed 'shortcut' for values to allow canonical json structure return
+            //fields.add(1, VALUE);
         } else { //this deals with the "/value,value"
             Integer match = firstOccurence(0, fields, VALUE);
 //            Integer match = fields.stream().filter(m -> m.equals("value"));

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/I_QueryImpl.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/I_QueryImpl.java
@@ -47,13 +47,7 @@ public interface I_QueryImpl {
 
     boolean isJsonDataBlock();
 
-    boolean isEhrIdFiltered();
-
-    boolean isCompositionIdFiltered();
-
     boolean isContainsJqueryPath();
-
-    boolean isUseEntry();
 
     String getJsonbItemPath();
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/I_QueryImpl.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/I_QueryImpl.java
@@ -53,7 +53,9 @@ public interface I_QueryImpl {
 
     enum Clause {SELECT, WHERE, ORDERBY, FROM}
 
-    Field<?> makeField(String templateId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, boolean withAlias, Clause clause);
+    Field<?> makeField(String templateId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, Clause clause);
 
     Field<?> whereField(String templateId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition);
+
+    public String getItemType();
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -64,7 +64,7 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
     private final static String JSONBSelector_EHR_OTHER_CONTEXT_OPEN = SELECT_EHR_OTHER_CONTEXT_MACRO + " #>> '{";
     public final static String Jsquery_EHR_OTHER_CONTEXT_OPEN = SELECT_EHR_OTHER_CONTEXT_MACRO + " @@ '";
 
-    public final static String matchNodePredicate = "/(content|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action|at)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\]";
+    public final static String matchNodePredicate = "/(content|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\]";
 
     //Generic stuff
     private final static String JSONBSelector_CLOSE = "}'";

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -364,7 +364,7 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
             if (alias != null && StringUtils.isNotEmpty(alias))
                 fieldPathItem = DSL.field(itemPath, String.class).as(alias);
             else {
-                String tempAlias = "FIELD_" + getSerial();
+                String tempAlias = new DefaultColumnId().value(variableDefinition);
                 fieldPathItem = DSL.field(itemPath, String.class).as(tempAlias);
             }
         } else

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -454,23 +454,8 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
     }
 
     @Override
-    public boolean isEhrIdFiltered() {
-        return false;
-    }
-
-    @Override
-    public boolean isCompositionIdFiltered() {
-        return false;
-    }
-
-    @Override
     public boolean isContainsJqueryPath() {
         return containsJqueryPath;
-    }
-
-    @Override
-    public boolean isUseEntry() {
-        return useEntry;
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -73,6 +73,7 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
     public final static String Jsquery_CLOSE = " '::jsquery";
     private static final String namedItemPrefix = " and name/value='";
     public static final String TAG_COMPOSITION = "/composition";
+    public static final String TAG_CONTENT = "/content";
 
     private static boolean useEntry = false;
 
@@ -259,10 +260,20 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
 
     @Override
     public Field<?> makeField(String templateId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, Clause clause) {
+
+        boolean isRootContent = false; //that is a query path on a full composition starting from the root content
+
         if (entry_root == null) //case of (invalid) composition with null entry!
             return null;
 
-        String path = pathResolver.pathOf(variableDefinition.getIdentifier());
+        String path;
+        if (variableDefinition.getPath() != null && variableDefinition.getPath().startsWith("content")) {
+            path = "/" + variableDefinition.getPath();
+            isRootContent = true;
+        }
+        else
+            path = pathResolver.pathOf(variableDefinition.getIdentifier());
+
         String alias = clause.equals(Clause.WHERE) ? null : variableDefinition.getAlias();
 
         if (path == null) {
@@ -282,7 +293,7 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
 
         List<String> itemPathArray = new ArrayList<>();
         itemPathArray.add(entry_root.replaceAll("'", "''"));
-        if (!path.startsWith(TAG_COMPOSITION))
+        if (!path.startsWith(TAG_COMPOSITION) && !isRootContent)
             itemPathArray.addAll(jqueryPath(PATH_PART.IDENTIFIER_PATH_PART, path, "0"));
         itemPathArray.addAll(jqueryPath(PATH_PART.VARIABLE_PATH_PART, variableDefinition.getPath(), "0"));
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/ObjectQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/ObjectQuery.java
@@ -31,6 +31,9 @@ public abstract class ObjectQuery {
 
     protected DSLContext context;
     protected PathResolver pathResolver;
+    protected boolean jsonDataBlock = false;
+    protected String itemType = null;
+
     protected static int serial = 0; //used to alias fields for now.
 
     protected ObjectQuery(DSLContext context, PathResolver pathResolver) {
@@ -50,5 +53,13 @@ public abstract class ObjectQuery {
 
     public static int getSerial() {
         return serial;
+    }
+
+    public String getItemType() {
+        return itemType;
+    }
+
+    public boolean isJsonDataBlock() {
+        return jsonDataBlock;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/VariableAqlPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/VariableAqlPath.java
@@ -1,0 +1,33 @@
+package org.ehrbase.aql.sql.queryImpl;
+
+import com.google.common.collect.Lists;
+import org.apache.logging.log4j.util.Strings;
+import org.ehrbase.ehr.util.LocatableHelper;
+
+import java.util.List;
+
+public class VariableAqlPath {
+
+    private final String jsonPathQualifierMatcher = "value|name|time";
+
+    String path;
+
+    public VariableAqlPath(String path) {
+        this.path = path;
+    }
+
+    public String getSuffix(){
+        List<String> segments = LocatableHelper.dividePathIntoSegments(path);
+        return segments.get(segments.size() - 1);
+    }
+
+    public String getInfix(){
+        List<String> segments = LocatableHelper.dividePathIntoSegments(path);
+        return String.join("/", segments.subList(0, segments.size() - 1));
+    }
+
+    public boolean isPartialAqlDataValuePath(){
+        return getSuffix().matches(jsonPathQualifierMatcher);
+    }
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/AttributePath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/AttributePath.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+public class AttributePath {
+
+    String rootPath;
+
+    public AttributePath(String rootPath) {
+        this.rootPath = rootPath;
+    }
+
+    /**
+     * return the path without the root part
+     * @return
+     */
+    public String redux(String path){
+
+        if (path.equals(rootPath)) return ""; //empty non null path to resolve (partial path for canonical result)
+
+        return path.substring(rootPath.length()+1); //skip trailing '/'
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/AttributeResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/AttributeResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+public abstract class AttributeResolver implements RMAttributeResolver {
+
+    protected final JoinSetup joinSetup;
+    protected final FieldResolutionContext fieldResolutionContext;
+
+    protected AttributeResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        this.fieldResolutionContext = fieldResolutionContext;
+        this.joinSetup = joinSetup;
+    }
+
+
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.PathResolver;
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.service.IntrospectService;
+import org.jooq.DSLContext;
+
+import java.util.UUID;
+
+public class FieldResolutionContext {
+
+    private final String columnAlias;
+    private final UUID compositionId;
+    private final String identifier;
+    private final I_VariableDefinition variableDefinition;
+    private final boolean withAlias;
+    private final I_QueryImpl.Clause clause;
+    private final DSLContext context;
+    private final String serverNodeId;
+    private final PathResolver pathResolver;
+    private final IntrospectService introspectCache;
+    private final String entry_root;
+
+    public FieldResolutionContext(DSLContext context, String serverNodeId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, boolean withAlias, I_QueryImpl.Clause clause, PathResolver pathResolver, IntrospectService introspectCache, String entry_root) {
+        this.compositionId = compositionId;
+        this.identifier = identifier;
+        this.variableDefinition = variableDefinition;
+        this.withAlias = withAlias;
+        this.clause = clause;
+        this.context = context;
+        this.serverNodeId = serverNodeId;
+        this.pathResolver = pathResolver;
+        this.entry_root = entry_root;
+        this.introspectCache = introspectCache;
+        columnAlias = variableDefinition.getPath();
+    }
+
+    public String getColumnAlias() {
+        return columnAlias;
+    }
+
+    public UUID getCompositionId() {
+        return compositionId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public I_VariableDefinition getVariableDefinition() {
+        return variableDefinition;
+    }
+
+    public boolean isWithAlias() {
+        return withAlias;
+    }
+
+    public I_QueryImpl.Clause getClause() {
+        return clause;
+    }
+
+    public DSLContext getContext() {
+        return context;
+    }
+
+    public String getServerNodeId() {
+        return serverNodeId;
+    }
+
+    public PathResolver getPathResolver() {
+        return pathResolver;
+    }
+
+    public IntrospectService getIntrospectCache() {
+        return introspectCache;
+    }
+
+    public String getEntry_root() {
+        return entry_root;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
@@ -38,12 +38,14 @@ public class FieldResolutionContext {
     private final PathResolver pathResolver;
     private final IntrospectService introspectCache;
     private final String entry_root;
+    private boolean jsonDatablock = false;
+    private String rmType;
 
-    public FieldResolutionContext(DSLContext context, String serverNodeId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, boolean withAlias, I_QueryImpl.Clause clause, PathResolver pathResolver, IntrospectService introspectCache, String entry_root) {
+    public FieldResolutionContext(DSLContext context, String serverNodeId, UUID compositionId, String identifier, I_VariableDefinition variableDefinition, I_QueryImpl.Clause clause, PathResolver pathResolver, IntrospectService introspectCache, String entry_root) {
         this.compositionId = compositionId;
         this.identifier = identifier;
         this.variableDefinition = variableDefinition;
-        this.withAlias = withAlias;
+        this.withAlias = clause.equals(I_QueryImpl.Clause.SELECT) && variableDefinition.getPath() != null;
         this.clause = clause;
         this.context = context;
         this.serverNodeId = serverNodeId;
@@ -67,6 +69,14 @@ public class FieldResolutionContext {
 
     public I_VariableDefinition getVariableDefinition() {
         return variableDefinition;
+    }
+
+    public String getRmType() {
+        return rmType;
+    }
+
+    public void setRmType(String rmType) {
+        this.rmType = rmType;
     }
 
     public boolean isWithAlias() {
@@ -95,5 +105,13 @@ public class FieldResolutionContext {
 
     public String getEntry_root() {
         return entry_root;
+    }
+
+    public boolean isJsonDatablock() {
+        return jsonDatablock;
+    }
+
+    public void setJsonDatablock(boolean jsonDatablock) {
+        this.jsonDatablock = jsonDatablock;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FilterSetup.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FilterSetup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+/**
+ * maintain the state of specific filter to apply in WHERE clause
+ */
+public class FilterSetup {
+    private boolean ehrIdFiltered = false; //true if the query specifies the ehr id (in the AQL FROM clause)
+    private boolean compositionIdFiltered = false; //true if the query contains a where clause with composition id specified
+
+    public boolean isEhrIdFiltered() {
+        return ehrIdFiltered;
+    }
+
+    public void setEhrIdFiltered(boolean ehrIdFiltered) {
+        this.ehrIdFiltered = ehrIdFiltered;
+    }
+
+    public boolean isCompositionIdFiltered() {
+        return compositionIdFiltered;
+    }
+
+    public void setCompositionIdFiltered(boolean compositionIdFiltered) {
+        this.compositionIdFiltered = compositionIdFiltered;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
@@ -29,6 +29,10 @@ public class GenericJsonPath {
                 //takes care of array expression (unless the occurrence is specified (TODO)
                 actualPaths.add("0");
             }
+            else if (segment.startsWith("content")){
+                actualPaths.add("content,/"+ segment);
+                actualPaths.add("0"); //as above
+            }
             else if (segment.equals("value") && (i < jqueryPaths.size() - 1) && jqueryPaths.get(i + 1).equals("value")){
                 actualPaths.add("/"+ segment);
             }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
@@ -1,0 +1,41 @@
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class GenericJsonPath {
+
+    final String path;
+
+    public GenericJsonPath(String path) {
+        this.path = path;
+    }
+
+    public String jqueryPath(){
+        if (path == null || path.isEmpty())
+            return path;
+
+        List<String> jqueryPaths = Arrays.asList(path.split("/|,"));
+        List<String> actualPaths = new ArrayList<>();
+
+        for (int i = 0; i < jqueryPaths.size(); i++){
+            String segment = jqueryPaths.get(i);
+            if (segment.startsWith("items")){
+                actualPaths.add("/"+ segment);
+                //takes care of array expression (unless the occurrence is specified (TODO)
+                actualPaths.add("0");
+            }
+            else if (segment.equals("value") && (i < jqueryPaths.size() - 1) && jqueryPaths.get(i + 1).equals("value")){
+                actualPaths.add("/"+ segment);
+            }
+            else
+                actualPaths.add(segment);
+        }
+
+        return "'{"+String.join(",", actualPaths)+"}'";
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/I_RMObjectAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/I_RMObjectAttribute.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.jooq.Field;
+import org.jooq.TableField;
+
+public interface I_RMObjectAttribute {
+    Field<?> sqlField();
+    I_RMObjectAttribute forTableField(TableField tableField);
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/JoinSetup.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/JoinSetup.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.jooq.Table;
+
+/**
+ * this class maintains the state of joins to build depending on the selected attributes
+ */
+public class JoinSetup {
+    //boolean indicating the resulting joins to generate
+    private boolean joinComposition = false;
+    private boolean joinEventContext = false;
+    private boolean joinSubject = false;
+    private boolean joinEhr = false;
+    private boolean joinEhrStatus = false;
+    private boolean joinComposer = false;
+    private boolean joinContextFacility = false;
+    private boolean joinSystem = false;
+    private boolean containsEhrStatus = false;
+
+    protected Table partyJoinRef; //this table reference is used by forTableField() it indicates on which table the join is to be done
+
+    public boolean isJoinComposition() {
+        return joinComposition;
+    }
+
+    public void setJoinComposition(boolean joinComposition) {
+        this.joinComposition = joinComposition;
+    }
+
+    public boolean isJoinEventContext() {
+        return joinEventContext;
+    }
+
+    public void setJoinEventContext(boolean joinEventContext) {
+        this.joinEventContext = joinEventContext;
+    }
+
+    public boolean isJoinSubject() {
+        return joinSubject;
+    }
+
+    public void setJoinSubject(boolean joinSubject) {
+        this.joinSubject = joinSubject;
+    }
+
+    public boolean isJoinEhr() {
+        return joinEhr;
+    }
+
+    public void setJoinEhr(boolean joinEhr) {
+        this.joinEhr = joinEhr;
+    }
+
+    public boolean isJoinEhrStatus() {
+        return joinEhrStatus;
+    }
+
+    public void setJoinEhrStatus(boolean joinEhrStatus) {
+        this.joinEhrStatus = joinEhrStatus;
+    }
+
+    public boolean isJoinComposer() {
+        return joinComposer;
+    }
+
+    public void setJoinComposer(boolean joinComposer) {
+        this.joinComposer = joinComposer;
+    }
+
+    public boolean isJoinContextFacility() {
+        return joinContextFacility;
+    }
+
+    public void setJoinContextFacility(boolean joinContextFacility) {
+        this.joinContextFacility = joinContextFacility;
+    }
+
+    public boolean isContainsEhrStatus() {
+        return containsEhrStatus;
+    }
+
+    public void setContainsEhrStatus(boolean containsEhrStatus) {
+        this.containsEhrStatus = containsEhrStatus;
+    }
+
+    public Table getPartyJoinRef() {
+        return partyJoinRef;
+    }
+
+    public void setPartyJoinRef(Table partyJoinRef) {
+        this.partyJoinRef = partyJoinRef;
+    }
+
+    public void setJoinSystem(boolean b) {
+        this.joinSystem = true;
+    }
+
+    public boolean isJoinSystem() {
+        return joinSystem;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMAttributeResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMAttributeResolver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.jooq.TableField;
+
+public interface RMAttributeResolver {
+
+    TableField NULL_FIELD = null;
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMObjectAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMObjectAttribute.java
@@ -18,6 +18,8 @@
 package org.ehrbase.aql.sql.queryImpl.attribute;
 
 import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.DefaultColumnId;
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
 import org.ehrbase.aql.sql.queryImpl.attribute.composition.CompositionIdFieldSetup;
 import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrSetup;
 import org.jooq.Field;
@@ -37,14 +39,32 @@ public abstract class RMObjectAttribute implements I_RMObjectAttribute, I_JoinBi
         this.joinSetup = joinSetup;
     }
 
+    protected Field<?> as(Field field){
+        if (fieldContext.isWithAlias())
+            return aliased(field);
+        else {
+            if (!fieldContext.getClause().equals(I_QueryImpl.Clause.WHERE))
+                return defaultAliased(field);
+            else
+                return field;
+        }
+    }
+
     protected Field<?> aliased(Field field){
         return field.as(effectiveAlias());
     }
 
     protected String effectiveAlias(){
         return (fieldContext.getVariableDefinition().getAlias() == null || !fieldContext.getVariableDefinition().getAlias().isEmpty())
-                ? fieldContext.getColumnAlias()
-                : fieldContext.getVariableDefinition().getAlias();
+                ? "/"+fieldContext.getColumnAlias()
+                : "/"+fieldContext.getVariableDefinition().getAlias();
+    }
+
+    protected Field<?> defaultAliased(Field field){
+        if (fieldContext.getClause().equals(I_QueryImpl.Clause.WHERE))
+            return field;
+        else
+            return field.as(new DefaultColumnId().value(fieldContext.getVariableDefinition()));
     }
 
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMObjectAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/RMObjectAttribute.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.composition.CompositionIdFieldSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrSetup;
+import org.jooq.Field;
+
+public abstract class RMObjectAttribute implements I_RMObjectAttribute, I_JoinBinder {
+
+    protected FilterSetup filterSetup = new FilterSetup();
+    protected CompositionIdFieldSetup compositionIdFieldSetup = new CompositionIdFieldSetup();
+    protected EhrSetup ehrSetup = new EhrSetup();
+
+    protected final JoinSetup joinSetup;
+    protected final FieldResolutionContext fieldContext;
+
+
+    protected RMObjectAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        this.fieldContext = fieldContext;
+        this.joinSetup = joinSetup;
+    }
+
+    protected Field<?> aliased(Field field){
+        return field.as(effectiveAlias());
+    }
+
+    protected String effectiveAlias(){
+        return (fieldContext.getVariableDefinition().getAlias() == null || !fieldContext.getVariableDefinition().getAlias().isEmpty())
+                ? fieldContext.getColumnAlias()
+                : fieldContext.getVariableDefinition().getAlias();
+    }
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/SuffixedPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/SuffixedPath.java
@@ -1,0 +1,17 @@
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+/**
+ * utility to encode a jsonb path from a standard AQL expression
+ */
+public class SuffixedPath {
+
+    private String path;
+
+    public SuffixedPath(String path) {
+        this.path = path;
+    }
+
+
+
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/TemporalWithTimeZone.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/TemporalWithTimeZone.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.SimpleEventContextAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import java.sql.Timestamp;
+
+public class TemporalWithTimeZone extends SimpleEventContextAttribute {
+
+    private Field timeZoneField;
+
+    public TemporalWithTimeZone(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    public Field<?> sqlField() {
+        if (fieldContext.isWithAlias()) {
+            return aliased(DSL.field(prettyDateTime(tableField, timeZoneField) + "||" + tzNoZulu(timeZoneField)));
+        } else
+            return DSL.field(prettyDateTime(tableField, timeZoneField) + "||" + tzNoZulu(timeZoneField));
+    }
+
+    public TemporalWithTimeZone useTimeZone(TableField tableField){
+        this.timeZoneField = tableField;
+        return this;
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        if (timeZoneField == null){
+            String tzFieldName = tableField.getName().toUpperCase()+"_TZID"; //conventionally
+            timeZoneField = DSL.field(tableField.getTable().getName()+"."+tzFieldName);
+        }
+        return this;
+    }
+
+    private Field<?> tzNoZulu(Field<String> field) {
+        return DSL.field(DSL.decode().when(field.equal("UTC"), "Z").otherwise(field));
+    }
+
+    private Field<?> prettyDateTime(Field<Timestamp> dateTime, Field<String> timeZone) {
+        return DSL.field("to_char(" + dateTimeOffsetTimezone(dateTime, timeZone) + ",'YYYY-MM-DD\"T\"HH24:MI:SS')");
+    }
+
+    //sql expression adjusting the date with the timezone. Ignore literals and null timezone
+    private Field<?> dateTimeOffsetTimezone(Field<Timestamp> dateTime, Field<String> timeZone) {
+        return DSL.field("(" + dateTime + "::timestamptz AT TIME ZONE 'UTC'" +
+                " + (case when left(" + timeZone + ",1)='+'" +
+                " then \"interval\"(" + timeZone + ")" +
+                " else \"interval\"('+00:00')" +
+                " end))");
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/TemporalWithTimeZone.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/TemporalWithTimeZone.java
@@ -33,10 +33,7 @@ public class TemporalWithTimeZone extends SimpleEventContextAttribute {
     }
 
     public Field<?> sqlField() {
-        if (fieldContext.isWithAlias()) {
-            return aliased(DSL.field(prettyDateTime(tableField, timeZoneField) + "||" + tzNoZulu(timeZoneField)));
-        } else
-            return DSL.field(prettyDateTime(tableField, timeZoneField) + "||" + tzNoZulu(timeZoneField));
+        return as(DSL.field(prettyDateTime(tableField, timeZoneField) + "||" + tzNoZulu(timeZoneField)));
     }
 
     public TemporalWithTimeZone useTimeZone(TableField tableField){

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composer/ComposerResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composer/ComposerResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composer;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.partyref.PartyRefResolver;
+import org.jooq.Field;
+
+import static org.ehrbase.aql.sql.binding.I_JoinBinder.composerRef;
+
+public class ComposerResolver extends PartyRefResolver
+{
+
+    public ComposerResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        joinSetup.setJoinComposer(true);
+        joinSetup.setPartyJoinRef(composerRef);
+
+        return super.sqlField(path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/ArchetypeNodeId.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/ArchetypeNodeId.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+
+import static org.ehrbase.jooq.pg.Tables.ENTRY;
+
+public class ArchetypeNodeId extends SimpleCompositionAttribute {
+
+
+    public ArchetypeNodeId(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+        forTableField(ENTRY.ARCHETYPE_ID);
+    }
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionAttribute.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+
+public abstract class CompositionAttribute extends RMObjectAttribute {
+
+    public CompositionAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup){
+        super(fieldContext, joinSetup);
+        joinSetup.setJoinComposition(true);
+        compositionIdFieldSetup.setCompositionIdField(false);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionIdFieldSetup.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionIdFieldSetup.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+
+/**
+ * maintain the condition of a query containing the composition id
+ */
+public class CompositionIdFieldSetup {
+
+
+    private boolean compositionIdField = false;
+
+    public boolean isCompositionIdField() {
+        return compositionIdField;
+    }
+
+    public void setCompositionIdField(boolean compositionIdField) {
+        this.compositionIdField = compositionIdField;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionName.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionName.java
@@ -47,7 +47,7 @@ public class CompositionName extends CompositionAttribute {
             if (fieldContext.getClause().equals(I_QueryImpl.Clause.WHERE)) {
                 trimName = "(SELECT " + trimName + ")";
             }
-            return DSL.field(trimName);
+            return defaultAliased(DSL.field(trimName));
         }
     }
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionName.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionName.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.Tables.ENTRY;
+
+public class CompositionName extends CompositionAttribute {
+
+    public CompositionName(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField(){
+        //extract the composition name from the jsonb root key
+        String trimName = "trim(LEADING '''' FROM (trim(TRAILING ''']' FROM\n" +
+                " (regexp_split_to_array((select root_json_key from jsonb_object_keys(" + ENTRY.ENTRY_ + ") root_json_key where root_json_key like '/composition%')," +
+                " 'and name/value=')) [2])))";
+        //postgresql equivalent expression
+        if (fieldContext.isWithAlias()) {
+            Field<?> select = aliased(DSL.field(trimName));
+            return select;
+        } else {
+            if (fieldContext.getClause().equals(I_QueryImpl.Clause.WHERE)) {
+                trimName = "(SELECT " + trimName + ")";
+            }
+            return DSL.field(trimName);
+        }
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributePath;
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.setting.SettingResolver;
+import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.Tables.COMPOSITION;
+import static org.ehrbase.jooq.pg.Tables.ENTRY;
+
+public class CompositionResolver extends AttributeResolver
+{
+
+    public CompositionResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        if (path.startsWith("category"))
+            return new SettingResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("category").redux(path));
+
+
+        switch (path){
+            case "uid/value":
+                return new CompositionUidValue(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+            case "name/value":
+                return new CompositionName(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+            case "archetype_node_id":
+                return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(ENTRY.ARCHETYPE_ID).sqlField();
+            case "template_id":
+                return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(ENTRY.TEMPLATE_ID).sqlField();
+            case "language/value":
+                return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(COMPOSITION.LANGUAGE).sqlField();
+            case "territory/value":
+                return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(COMPOSITION.TERRITORY).sqlField();
+            case "archetype_details/template_id/value":
+                return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(ENTRY.TEMPLATE_ID).sqlField();
+        }
+        throw new IllegalArgumentException("Unresolved composition attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionResolver.java
@@ -36,6 +36,9 @@ public class CompositionResolver extends AttributeResolver
 
     public Field<?> sqlField(String path){
 
+        if (path == null || path.isEmpty())
+            return new FullCompositionJson(fieldResolutionContext, joinSetup).sqlField();
+
         if (path.startsWith("category"))
             return new SettingResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("category").redux(path));
 
@@ -56,6 +59,8 @@ public class CompositionResolver extends AttributeResolver
             case "archetype_details/template_id/value":
                 return new SimpleCompositionAttribute(fieldResolutionContext, joinSetup).forTableField(ENTRY.TEMPLATE_ID).sqlField();
         }
-        throw new IllegalArgumentException("Unresolved composition attribute path:"+path);
+        //else assume a partial json path
+
+        return new FullCompositionJson(fieldResolutionContext, joinSetup).forJsonPath(path).sqlField();
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionUidValue.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionUidValue.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.SelectQuery;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+
+import java.util.UUID;
+
+import static org.ehrbase.jooq.pg.Tables.COMPOSITION_HISTORY;
+
+public class CompositionUidValue extends CompositionAttribute {
+
+    public CompositionUidValue(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField(){
+        if (fieldContext.getClause() == I_QueryImpl.Clause.WHERE)
+            filterSetup.setCompositionIdFiltered(true);
+        else
+            compositionIdFieldSetup.setCompositionIdField(true);
+
+        joinSetup.setJoinComposition(true);
+
+        if (fieldContext.isWithAlias())
+            return uid();
+        else
+            return rawUid();
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+
+    private Field<?> uid() {
+
+        //use inline SQL as it seems coalesce is not going through with POSTGRES dialect
+        SelectQuery<?> subSelect = fieldContext.getContext().selectQuery();
+        subSelect.addSelect(DSL.count());
+        subSelect.addFrom(COMPOSITION_HISTORY);
+        subSelect.addConditions(I_JoinBinder.compositionRecordTable.field("id", UUID.class).eq(COMPOSITION_HISTORY.ID));
+        subSelect.addGroupBy(COMPOSITION_HISTORY.ID);
+
+        String coalesceVersion = "1 + COALESCE(\n(" + subSelect + "), 0)";
+
+        Field<?> select = aliased(DSL.field(I_JoinBinder.compositionRecordTable.field("id")
+                        + "||"
+                        + DSL.val("::")
+                        + "||"
+                        + DSL.val(fieldContext.getServerNodeId())
+                        + "||"
+                        + DSL.val("::")
+                        + "||"
+                        + DSL.field(coalesceVersion)
+                , SQLDataType.VARCHAR));
+
+        return select;
+    }
+
+    private Field<?> rawUid() {
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class)));
+        else
+            return DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class));
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionUidValue.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/CompositionUidValue.java
@@ -84,9 +84,6 @@ public class CompositionUidValue extends CompositionAttribute {
     }
 
     private Field<?> rawUid() {
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class)));
-        else
-            return DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class));
+        return as(DSL.field(I_JoinBinder.compositionRecordTable.field("id", UUID.class)));
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
@@ -57,7 +57,7 @@ public class FullCompositionJson extends CompositionAttribute {
         if (fieldContext.isWithAlias())
             return aliased(DSL.field(jsonFullComposition));
         else
-            return DSL.field(jsonFullComposition);
+            return DSL.field(jsonFullComposition).as(fieldContext.getIdentifier());
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.EventContextAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
+
+public class FullCompositionJson extends CompositionAttribute {
+
+    public FullCompositionJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        //query the json representation of EVENT_CONTEXT and cast the result as TEXT
+        Field jsonContextField = DSL.field("ehr.js_context("+EVENT_CONTEXT.ID+")::text");
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(jsonContextField));
+        else
+            return DSL.field(jsonContextField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
@@ -42,10 +42,9 @@ public class SimpleCompositionAttribute extends CompositionAttribute {
         if (tableField.getTable().equals(COMPOSITION)) {
             actualField = DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName());
         }
-        if (fieldContext.isWithAlias())
-            return aliased(actualField);
-        else
-            return actualField;
+
+        return as(actualField);
+
 
     }
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+public class SimpleCompositionAttribute extends CompositionAttribute {
+
+    protected TableField tableField;
+
+    public SimpleCompositionAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName()));
+        else
+            return DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName());
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/SimpleCompositionAttribute.java
@@ -25,6 +25,8 @@ import org.jooq.Field;
 import org.jooq.TableField;
 import org.jooq.impl.DSL;
 
+import static org.ehrbase.jooq.pg.Tables.COMPOSITION;
+
 public class SimpleCompositionAttribute extends CompositionAttribute {
 
     protected TableField tableField;
@@ -35,10 +37,16 @@ public class SimpleCompositionAttribute extends CompositionAttribute {
 
     @Override
     public Field<?> sqlField() {
+        Field actualField = DSL.field(tableField);
+
+        if (tableField.getTable().equals(COMPOSITION)) {
+            actualField = DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName());
+        }
         if (fieldContext.isWithAlias())
-            return aliased(DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName()));
+            return aliased(actualField);
         else
-            return DSL.field(I_JoinBinder.compositionRecordTable.getName()+"."+tableField.getName());
+            return actualField;
+
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/TemplateId.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/TemplateId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.composition;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+
+import static org.ehrbase.jooq.pg.Tables.ENTRY;
+
+public class TemplateId extends SimpleCompositionAttribute {
+
+    public TemplateId(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+        forTableField(ENTRY.TEMPLATE_ID);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrAttribute.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
+
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+
+public abstract class EhrAttribute extends RMObjectAttribute {
+
+    public EhrAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup){
+        super(fieldContext, joinSetup);
+        if (fieldContext.getClause().equals(I_QueryImpl.Clause.FROM))
+            filterSetup.setEhrIdFiltered(true);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrIdValue.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrIdValue.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.Tables.EHR_;
+
+public class EhrIdValue extends EhrAttribute {
+
+    public EhrIdValue(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField(){
+        ehrSetup.setContainsEhrId(true);
+        ehrSetup.setEhrIdAlias(effectiveAlias());
+        if (fieldContext.getPathResolver().hasPathExpression()) {
+            joinSetup.setJoinEhr(true);
+            if (fieldContext.isWithAlias()) {
+                Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
+                return select;
+            } else
+                return DSL.field(I_JoinBinder.ehrRecordTable.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
+        } else if (!joinSetup.isContainsEhrStatus()) {
+            joinSetup.setJoinEhr(true);
+            if (fieldContext.isWithAlias()) {
+                Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
+                return select;
+            } else
+                return DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName()));
+        } else {
+            if (fieldContext.isWithAlias()) {
+                Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
+                return select;
+            } else
+                return DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName()));
+        }
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrIdValue.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrIdValue.java
@@ -43,20 +43,20 @@ public class EhrIdValue extends EhrAttribute {
                 Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
                 return select;
             } else
-                return DSL.field(I_JoinBinder.ehrRecordTable.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
+                return defaultAliased(DSL.field(I_JoinBinder.ehrRecordTable.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName()))));
         } else if (!joinSetup.isContainsEhrStatus()) {
             joinSetup.setJoinEhr(true);
             if (fieldContext.isWithAlias()) {
                 Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
                 return select;
             } else
-                return DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName()));
+                return defaultAliased(DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
         } else {
             if (fieldContext.isWithAlias()) {
                 Field<?> select = aliased(DSL.field("{0}", I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
                 return select;
             } else
-                return DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName()));
+                return defaultAliased(DSL.field(I_JoinBinder.ehrRecordTable.field(EHR_.ID.getName())));
         }
     }
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
@@ -42,8 +42,8 @@ public class EhrResolver extends AttributeResolver
         if (path.startsWith("ehr_status")) {
             return new StatusResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("ehr_status").redux(path));
         }
-        else if (path.startsWith("system"))
-            return new SystemResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("system").redux(path));
+        else if (path.startsWith("system_id"))
+            return new SystemResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("system_id").redux(path));
 
         switch (path){
             case "ehr_id":
@@ -51,7 +51,11 @@ public class EhrResolver extends AttributeResolver
                 return new GenericJsonField(fieldResolutionContext, joinSetup).jsonField("HIER_OBJECT_ID", "ehr.js_canonical_hier_object_id", I_JoinBinder.ehrRecordTable.field(EHR_.ID));
             case "ehr_id/value":
                 return new EhrIdValue(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
-            case "date_created":
+            case "time_created":
+                joinSetup.setJoinEhr(true);
+                return new GenericJsonField(fieldResolutionContext, joinSetup)
+                        .jsonField("DV_DATE_TIME", "ehr.js_dv_date_time", I_JoinBinder.ehrRecordTable.field(EHR_.DATE_CREATED), I_JoinBinder.ehrRecordTable.field(EHR_.DATE_CREATED_TZID));
+            case "time_created/value":
                 joinSetup.setJoinEhr(true);
                 return new SimpleAttribute(fieldResolutionContext, joinSetup)
                         .forTableField("TEXT", I_JoinBinder.ehrRecordTable.field(EHR_.DATE_CREATED))

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
@@ -17,13 +17,16 @@
  */
 package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
 
-import org.ehrbase.aql.sql.queryImpl.attribute.AttributePath;
-import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
-import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
-import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.*;
 import org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus.StatusResolver;
 import org.ehrbase.aql.sql.queryImpl.attribute.system.SystemResolver;
+import org.ehrbase.aql.sql.queryImpl.value_field.GenericJsonField;
+import org.ehrbase.jooq.pg.tables.Ehr;
 import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.Ehr.EHR;
+import static org.ehrbase.jooq.pg.Tables.EHR_;
 
 public class EhrResolver extends AttributeResolver
 {
@@ -41,6 +44,9 @@ public class EhrResolver extends AttributeResolver
             return new SystemResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("system").redux(path));
 
         switch (path){
+            case "ehr_id":
+                joinSetup.setJoinEhr(true);
+                return new GenericJsonField(fieldResolutionContext, joinSetup).jsonField("HIER_OBJECT_ID", "ehr.js_canonical_hier_object_id", I_JoinBinder.ehrRecordTable.field(EHR_.ID));
             case "ehr_id/value":
                 return new EhrIdValue(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
@@ -19,9 +19,11 @@ package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
 
 import org.ehrbase.aql.sql.binding.I_JoinBinder;
 import org.ehrbase.aql.sql.queryImpl.attribute.*;
+import org.ehrbase.aql.sql.queryImpl.attribute.composition.SimpleCompositionAttribute;
 import org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus.StatusResolver;
 import org.ehrbase.aql.sql.queryImpl.attribute.system.SystemResolver;
 import org.ehrbase.aql.sql.queryImpl.value_field.GenericJsonField;
+import org.ehrbase.aql.sql.queryImpl.value_field.SimpleAttribute;
 import org.ehrbase.jooq.pg.tables.Ehr;
 import org.jooq.Field;
 
@@ -49,6 +51,11 @@ public class EhrResolver extends AttributeResolver
                 return new GenericJsonField(fieldResolutionContext, joinSetup).jsonField("HIER_OBJECT_ID", "ehr.js_canonical_hier_object_id", I_JoinBinder.ehrRecordTable.field(EHR_.ID));
             case "ehr_id/value":
                 return new EhrIdValue(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+            case "date_created":
+                joinSetup.setJoinEhr(true);
+                return new SimpleAttribute(fieldResolutionContext, joinSetup)
+                        .forTableField("TEXT", I_JoinBinder.ehrRecordTable.field(EHR_.DATE_CREATED))
+                        .sqlField();
 
         }
         throw new IllegalArgumentException("Unresolved ehr attribute path:"+path);

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributePath;
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus.StatusResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.system.SystemResolver;
+import org.jooq.Field;
+
+public class EhrResolver extends AttributeResolver
+{
+
+    public EhrResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        if (path.startsWith("ehr_status")) {
+            return new StatusResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("ehr_status").redux(path));
+        }
+        else if (path.startsWith("system"))
+            return new SystemResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("system").redux(path));
+
+        switch (path){
+            case "ehr_id/value":
+                return new EhrIdValue(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+
+        }
+        throw new IllegalArgumentException("Unresolved ehr attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrSetup.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/EhrSetup.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr;
+
+/**
+ * maintain context for EHR attribute and querying
+ */
+public class EhrSetup {
+
+    private boolean containsEhrId = false;
+    private String ehrIdAlias;
+
+    public boolean isContainsEhrId() {
+        return containsEhrId;
+    }
+
+    public void setContainsEhrId(boolean containsEhrId) {
+        this.containsEhrId = containsEhrId;
+    }
+
+    public String getEhrIdAlias() {
+        return ehrIdAlias;
+    }
+
+    public void setEhrIdAlias(String ehrIdAlias) {
+        this.ehrIdAlias = ehrIdAlias;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusAttribute.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrAttribute;
+
+public abstract class EhrStatusAttribute extends EhrAttribute {
+
+    public EhrStatusAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup){
+        super(fieldContext, joinSetup);
+        joinSetup.setJoinEhrStatus(true);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusJson.java
@@ -49,10 +49,8 @@ public class EhrStatusJson extends EhrStatusAttribute {
         else
             jsonEhrStatusField = DSL.field("ehr.js_ehr_status("+ I_JoinBinder.statusRecordTable.field(STATUS.EHR_ID)+")::text");
 
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(jsonEhrStatusField));
-        else
-            return DSL.field(jsonEhrStatusField);
+
+        return as(DSL.field(jsonEhrStatusField));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusJson.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.Tables.STATUS;
+
+public class EhrStatusJson extends EhrStatusAttribute {
+
+    public EhrStatusJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        //query the json representation of EVENT_CONTEXT and cast the result as TEXT
+        Field jsonContextField = DSL.field("ehr.js_ehr_status("+ I_JoinBinder.statusRecordTable.field(STATUS.EHR_ID)+")::text");
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(jsonContextField));
+        else
+            return DSL.field(jsonContextField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
@@ -34,6 +34,7 @@ public class EhrStatusOtherDetails extends EhrStatusAttribute {
 
     @Override
     public Field<?> sqlField(){
+        fieldContext.setJsonDatablock(true);
         String variablePath = fieldContext.getVariableDefinition().getPath().substring("ehr_status/other_details".length() + 1);
         Field<?> field = new JsonbEntryQuery(fieldContext.getContext(), fieldContext.getIntrospectCache(), fieldContext.getPathResolver(), fieldContext.getEntry_root())
                 .makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_DETAILS, null, fieldContext.getVariableDefinition().getAlias(), variablePath, fieldContext.isWithAlias());

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus;
+
+
+import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+
+public class EhrStatusOtherDetails extends EhrStatusAttribute {
+
+    public EhrStatusOtherDetails(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+        joinSetup.setContainsEhrStatus(true);
+    }
+
+    @Override
+    public Field<?> sqlField(){
+        String variablePath = fieldContext.getVariableDefinition().getPath().substring("ehr_status/other_details".length() + 1);
+        Field<?> field = new JsonbEntryQuery(fieldContext.getContext(), fieldContext.getIntrospectCache(), fieldContext.getPathResolver(), fieldContext.getEntry_root())
+                .makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_DETAILS, null, fieldContext.getVariableDefinition().getAlias(), variablePath, fieldContext.isWithAlias());
+        return field;
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/StatusResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/StatusResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributePath;
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus.subject.SubjectResolver;
+import org.jooq.Field;
+
+public class StatusResolver extends AttributeResolver
+{
+
+    public StatusResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        if (path.startsWith("other_details")) {
+            return new EhrStatusOtherDetails(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+        }
+        else if (path.startsWith("subject")){
+            return new SubjectResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("subject").redux(path));
+        }
+        else if (path.isEmpty()){
+            return new EhrStatusJson(fieldResolutionContext, joinSetup).sqlField();
+        }
+        else
+            throw new IllegalArgumentException("Unresolved ehr attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/subject/SubjectResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/subject/SubjectResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.ehr.ehrstatus.subject;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.partyref.PartyRefResolver;
+import org.jooq.Field;
+
+import static org.ehrbase.aql.sql.binding.I_JoinBinder.subjectRef;
+
+public class SubjectResolver extends PartyRefResolver
+{
+
+    public SubjectResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+        joinSetup.setPartyJoinRef(subjectRef);
+        joinSetup.setJoinSubject(true);
+
+        return super.sqlField(path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextOtherContext.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextOtherContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+
+import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+
+public class ContextOtherContext extends EventContextAttribute {
+
+    public ContextOtherContext(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        String variablePath = fieldContext.getVariableDefinition().getPath().substring("context/other_context".length() + 1);
+        variablePath = variablePath.substring(variablePath.indexOf("]") + 1);
+        String otherContextPath = "/" + fieldContext.getVariableDefinition().getPath().substring(0, fieldContext.getVariableDefinition().getPath().indexOf("]") + 1);
+        Field<?> field = new JsonbEntryQuery(
+                fieldContext.getContext(),
+                fieldContext.getIntrospectCache(),
+                fieldContext.getPathResolver(),
+                fieldContext.getEntry_root())
+                .makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_CONTEXT, null, fieldContext.getVariableDefinition().getAlias(), variablePath, fieldContext.isWithAlias());
+        return field;
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextOtherContext.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextOtherContext.java
@@ -25,6 +25,8 @@ import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
 import org.jooq.Field;
 import org.jooq.TableField;
 
+import static org.ehrbase.jooq.pg.Tables.EVENT_CONTEXT;
+
 public class ContextOtherContext extends EventContextAttribute {
 
     public ContextOtherContext(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
@@ -33,16 +35,12 @@ public class ContextOtherContext extends EventContextAttribute {
 
     @Override
     public Field<?> sqlField() {
-        String variablePath = fieldContext.getVariableDefinition().getPath().substring("context/other_context".length() + 1);
-        variablePath = variablePath.substring(variablePath.indexOf("]") + 1);
-        String otherContextPath = "/" + fieldContext.getVariableDefinition().getPath().substring(0, fieldContext.getVariableDefinition().getPath().indexOf("]") + 1);
-        Field<?> field = new JsonbEntryQuery(
-                fieldContext.getContext(),
-                fieldContext.getIntrospectCache(),
-                fieldContext.getPathResolver(),
-                fieldContext.getEntry_root())
-                .makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_CONTEXT, null, fieldContext.getVariableDefinition().getAlias(), variablePath, fieldContext.isWithAlias());
-        return field;
+        String variablePath = fieldContext.getVariableDefinition().getPath().substring("context/other_context".length());
+
+
+        if (variablePath.startsWith("/"))
+            variablePath = variablePath.substring(1);
+        return new EventContextJson(fieldContext, joinSetup).forJsonPath("other_context/"+variablePath).forTableField(EVENT_CONTEXT.OTHER_CONTEXT).sqlField();
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextSetup.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/ContextSetup.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+/**
+ * maintain context for EHR attribute and querying
+ */
+public class ContextSetup {
+    private boolean containsOtherContext = false;
+
+    public boolean isContainsOtherContext() {
+        return containsOtherContext;
+    }
+
+    public void setContainsOtherContext(boolean containsOtherContext) {
+        this.containsOtherContext = containsOtherContext;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextAttribute.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+
+public abstract class EventContextAttribute extends RMObjectAttribute {
+
+    public EventContextAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup){
+        super(fieldContext, joinSetup);
+        joinSetup.setJoinEventContext(true);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextJson.java
@@ -25,9 +25,13 @@ import org.jooq.Field;
 import org.jooq.TableField;
 import org.jooq.impl.DSL;
 
+import java.util.Optional;
+
 import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
 
 public class EventContextJson extends EventContextAttribute {
+
+    protected Optional<String> jsonPath = Optional.empty();
 
     public EventContextJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
         super(fieldContext, joinSetup);
@@ -36,11 +40,23 @@ public class EventContextJson extends EventContextAttribute {
     @Override
     public Field<?> sqlField() {
         //query the json representation of EVENT_CONTEXT and cast the result as TEXT
-        return new GenericJsonField(fieldContext, joinSetup).jsonField("ehr.js_context", EVENT_CONTEXT.ID);
+        if (jsonPath.isPresent())
+            return new GenericJsonField(fieldContext, joinSetup).forJsonPath(jsonPath.get()).jsonField("EVENT_CONTEXT","ehr.js_context", EVENT_CONTEXT.ID);
+        else
+            return new GenericJsonField(fieldContext, joinSetup).jsonField("EVENT_CONTEXT","ehr.js_context", EVENT_CONTEXT.ID);
     }
 
     @Override
     public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+
+    public EventContextJson forJsonPath(String jsonPath){
+        if (jsonPath == null || jsonPath.isEmpty()) {
+            this.jsonPath = Optional.empty();
+            return this;
+        }
+        this.jsonPath = Optional.of(jsonPath);
         return this;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextJson.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
+
+public class EventContextJson extends EventContextAttribute {
+
+    public EventContextJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        //query the json representation of EVENT_CONTEXT and cast the result as TEXT
+        Field jsonContextField = DSL.field("ehr.js_context("+EVENT_CONTEXT.ID+")::text");
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(jsonContextField));
+        else
+            return DSL.field(jsonContextField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextResolver.java
@@ -21,6 +21,7 @@ package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
 import org.ehrbase.aql.sql.queryImpl.attribute.*;
 import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.facility.FacilityResolver;
 import org.ehrbase.aql.sql.queryImpl.attribute.setting.SettingResolver;
+import org.ehrbase.aql.sql.queryImpl.value_field.GenericJsonField;
 import org.jooq.Field;
 
 import static org.ehrbase.jooq.pg.Tables.EVENT_CONTEXT;
@@ -37,12 +38,25 @@ public class EventContextResolver extends AttributeResolver
             return new ContextOtherContext(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
         }
 
+
+        if (path.equals("context/health_care_facility")){
+            return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("health_care_facility").sqlField();
+        }
+
+        if (path.equals("context/health_care_facility/external_ref")){
+            return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("health_care_facility/external_ref").sqlField();
+        }
+
+        if (path.equals("context/health_care_facility/external_ref/id")){
+            return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("health_care_facility/external_ref/id").sqlField();
+        }
+
         if (path.startsWith("context/health_care_facility")) {
             return new FacilityResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/health_care_facility").redux(path));
         }
 
         if (path.startsWith("context/facility")) {
-            return new FacilityResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/facility").redux(path));
+            return new FacilityResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/health_care_facility").redux(path));
         }
 
         if (path.startsWith("context/setting")) {
@@ -52,8 +66,12 @@ public class EventContextResolver extends AttributeResolver
         switch (path){
             case "context":
                 return new EventContextJson(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+            case "context/start_time":
+                return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("start_time").forTableField(EVENT_CONTEXT.START_TIME).sqlField();
             case "context/start_time/value":
                 return new TemporalWithTimeZone(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.START_TIME).sqlField();
+            case "context/end_time":
+                return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("end_time").forTableField(EVENT_CONTEXT.END_TIME).sqlField();
             case "context/end_time/value":
                 return new TemporalWithTimeZone(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.END_TIME).sqlField();
             case "context/location":

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/EventContextResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+
+import org.ehrbase.aql.sql.queryImpl.attribute.*;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.facility.FacilityResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.setting.SettingResolver;
+import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.Tables.EVENT_CONTEXT;
+
+public class EventContextResolver extends AttributeResolver
+{
+    public EventContextResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        if (path.startsWith("context/other_context")) {
+            return new ContextOtherContext(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+        }
+
+        if (path.startsWith("context/health_care_facility")) {
+            return new FacilityResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/health_care_facility").redux(path));
+        }
+
+        if (path.startsWith("context/facility")) {
+            return new FacilityResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/facility").redux(path));
+        }
+
+        if (path.startsWith("context/setting")) {
+            return new SettingResolver(fieldResolutionContext, joinSetup).sqlField(new AttributePath("context/setting").redux(path));
+        }
+
+        switch (path){
+            case "context":
+                return new EventContextJson(fieldResolutionContext, joinSetup).forTableField(NULL_FIELD).sqlField();
+            case "context/start_time/value":
+                return new TemporalWithTimeZone(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.START_TIME).sqlField();
+            case "context/end_time/value":
+                return new TemporalWithTimeZone(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.END_TIME).sqlField();
+            case "context/location":
+                return new SimpleEventContextAttribute(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.LOCATION).sqlField();
+            case "context/setting":
+                return new SimpleEventContextAttribute(fieldResolutionContext, joinSetup).forTableField(EVENT_CONTEXT.LOCATION).sqlField();
+
+
+        }
+        throw new IllegalArgumentException("Unresolved context path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+public class SimpleEventContextAttribute extends EventContextAttribute {
+
+    protected Field tableField;
+
+    public SimpleEventContextAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(tableField));
+        else
+            return DSL.field(tableField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
@@ -37,10 +37,7 @@ public class SimpleEventContextAttribute extends EventContextAttribute {
 
     @Override
     public Field<?> sqlField() {
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(tableField));
-        else
-            return DSL.field(tableField);
+        return as(DSL.field(tableField));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/SimpleEventContextAttribute.java
@@ -17,12 +17,15 @@
  */
 package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
 
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
 import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
 import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
 import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
 import org.jooq.Field;
 import org.jooq.TableField;
 import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.Tables.STATUS;
 
 public class SimpleEventContextAttribute extends EventContextAttribute {
 
@@ -43,6 +46,10 @@ public class SimpleEventContextAttribute extends EventContextAttribute {
     @Override
     public I_RMObjectAttribute forTableField(TableField tableField) {
         this.tableField = tableField;
+        if (tableField.getTable().equals(STATUS)) {
+            joinSetup.setJoinEhrStatus(true);
+            this.tableField = I_JoinBinder.statusRecordTable.field(tableField.getName());
+        }
         return this;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/facility/FacilityResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/eventcontext/facility/FacilityResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.facility;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.partyref.PartyRefResolver;
+import org.jooq.Field;
+
+import static org.ehrbase.aql.sql.binding.I_JoinBinder.facilityRef;
+
+public class FacilityResolver extends PartyRefResolver
+{
+
+    public FacilityResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        joinSetup.setJoinContextFacility(true);
+        joinSetup.setPartyJoinRef(facilityRef);
+
+        return super.sqlField(path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefAttribute.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.partyref;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+
+public abstract class PartyRefAttribute extends RMObjectAttribute {
+
+    public PartyRefAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup){
+        super(fieldContext, joinSetup);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefJson.java
@@ -15,28 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.aql.sql.queryImpl.attribute.eventcontext;
+package org.ehrbase.aql.sql.queryImpl.attribute.partyref;
 
 import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
 import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
 import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.EventContextAttribute;
 import org.ehrbase.aql.sql.queryImpl.value_field.GenericJsonField;
 import org.jooq.Field;
 import org.jooq.TableField;
-import org.jooq.impl.DSL;
 
+import static org.ehrbase.jooq.pg.Tables.PARTY_IDENTIFIED;
 import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
 
-public class EventContextJson extends EventContextAttribute {
+public class PartyRefJson extends PartyRefAttribute {
 
-    public EventContextJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+    public PartyRefJson(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
         super(fieldContext, joinSetup);
     }
 
     @Override
     public Field<?> sqlField() {
         //query the json representation of EVENT_CONTEXT and cast the result as TEXT
-        return new GenericJsonField(fieldContext, joinSetup).jsonField("ehr.js_context", EVENT_CONTEXT.ID);
+        return new GenericJsonField(fieldContext, joinSetup).jsonField("ehr.js_canonical_party_ref",
+                PARTY_IDENTIFIED.PARTY_REF_NAMESPACE,
+                PARTY_IDENTIFIED.PARTY_REF_TYPE,
+                PARTY_IDENTIFIED.PARTY_REF_SCHEME,
+                PARTY_IDENTIFIED.PARTY_REF_VALUE);
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefJson.java
@@ -37,11 +37,11 @@ public class PartyRefJson extends PartyRefAttribute {
     @Override
     public Field<?> sqlField() {
         //query the json representation of EVENT_CONTEXT and cast the result as TEXT
-        return new GenericJsonField(fieldContext, joinSetup).jsonField("ehr.js_canonical_party_ref",
-                PARTY_IDENTIFIED.PARTY_REF_NAMESPACE,
-                PARTY_IDENTIFIED.PARTY_REF_TYPE,
-                PARTY_IDENTIFIED.PARTY_REF_SCHEME,
-                PARTY_IDENTIFIED.PARTY_REF_VALUE);
+        return new GenericJsonField(fieldContext, joinSetup).jsonField("PARTY_REF","ehr.js_canonical_party_ref",
+                joinSetup.getPartyJoinRef().field(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE),
+                joinSetup.getPartyJoinRef().field(PARTY_IDENTIFIED.PARTY_REF_TYPE),
+                joinSetup.getPartyJoinRef().field(PARTY_IDENTIFIED.PARTY_REF_SCHEME),
+                joinSetup.getPartyJoinRef().field(PARTY_IDENTIFIED.PARTY_REF_VALUE));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.partyref;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.Tables.PARTY_IDENTIFIED;
+
+public class PartyRefResolver extends AttributeResolver
+{
+
+    public PartyRefResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        switch (path){
+            case "name/value":
+            case "name":
+                return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.NAME).sqlField();
+            case "external_ref/type":
+                return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_TYPE).sqlField();
+            case "external_ref/namespace":
+                return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_NAMESPACE).sqlField();
+            case "external_ref/scheme":
+                return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_SCHEME).sqlField();
+            case "external_ref/id":
+                return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_VALUE).sqlField();
+
+        }
+        throw new IllegalArgumentException("Unresolved party_identified external_ref attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/PartyRefResolver.java
@@ -45,6 +45,8 @@ public class PartyRefResolver extends AttributeResolver
                 return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_SCHEME).sqlField();
             case "external_ref/id":
                 return new SimplePartyRefAttribute(fieldResolutionContext, joinSetup).forTableField(PARTY_IDENTIFIED.PARTY_REF_VALUE).sqlField();
+            case "external_ref":
+                return new PartyRefJson(fieldResolutionContext, joinSetup).sqlField();
 
         }
         throw new IllegalArgumentException("Unresolved party_identified external_ref attribute path:"+path);

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/SimplePartyRefAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/SimplePartyRefAttribute.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.partyref;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+public class SimplePartyRefAttribute extends PartyRefAttribute {
+
+    protected Field tableField;
+
+    public SimplePartyRefAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(tableField));
+        else
+            return DSL.field(tableField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = joinSetup.getPartyJoinRef().field(tableField);
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/SimplePartyRefAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/partyref/SimplePartyRefAttribute.java
@@ -34,10 +34,7 @@ public class SimplePartyRefAttribute extends PartyRefAttribute {
 
     @Override
     public Field<?> sqlField() {
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(tableField));
-        else
-            return DSL.field(tableField);
+        return as(DSL.field(tableField));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingAttribute.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.setting;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.EventContextAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+public class SettingAttribute extends EventContextAttribute {
+
+    protected Field tableField;
+    protected String jsonPath;
+
+    public SettingAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        Field jsonContextField = DSL.field("ehr.js_context_setting("+tableField+")::json #>>"+jsonPath);
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(jsonContextField));
+        else
+            return DSL.field(jsonContextField);
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        return this;
+    }
+
+    public I_RMObjectAttribute forJsonPath(String jsonPath){
+        this.jsonPath = jsonPath;
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingAttribute.java
@@ -47,10 +47,8 @@ public class SettingAttribute extends EventContextAttribute {
             return new GenericJsonField(fieldContext, joinSetup).forJsonPath(jsonPath.get()).jsonField("EVENT_CONTEXT","ehr.js_context", EVENT_CONTEXT.ID);
 
         Field jsonContextField = DSL.field("ehr.js_context_setting("+tableField+")::json #>>"+new GenericJsonPath(jsonPath.get()).jqueryPath());
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(jsonContextField));
-        else
-            return DSL.field(jsonContextField);
+
+        return as(DSL.field(jsonContextField));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingResolver.java
@@ -20,6 +20,8 @@ package org.ehrbase.aql.sql.queryImpl.attribute.setting;
 import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
 import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
 import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.eventcontext.EventContextJson;
+import org.ehrbase.aql.sql.queryImpl.value_field.GenericJsonField;
 import org.jooq.Field;
 
 import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
@@ -33,14 +35,19 @@ public class SettingResolver extends AttributeResolver
 
     public Field<?> sqlField(String path){
 
+        if (path.isEmpty())
+            return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("setting").sqlField();
+
         switch (path){
             case "value":
-                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{value}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath(path).forTableField(EVENT_CONTEXT.SETTING).sqlField();
+            case "defining_code":
+                return new EventContextJson(fieldResolutionContext, joinSetup).forJsonPath("setting/"+path).forTableField(EVENT_CONTEXT.SETTING).sqlField();
             case "defining_code/terminology_id":
             case "defining_code/terminology_id/value":
-                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{defining_code,terminology_id,value}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath(path).forTableField(EVENT_CONTEXT.SETTING).sqlField();
             case "defining_code/code_string":
-                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{defining_code,code_string}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath(path).forTableField(EVENT_CONTEXT.SETTING).sqlField();
 
 
         }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/setting/SettingResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.setting;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
+
+public class SettingResolver extends AttributeResolver
+{
+
+    public SettingResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+    }
+
+    public Field<?> sqlField(String path){
+
+        switch (path){
+            case "value":
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{value}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+            case "defining_code/terminology_id":
+            case "defining_code/terminology_id/value":
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{defining_code,terminology_id,value}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+            case "defining_code/code_string":
+                return new SettingAttribute(fieldResolutionContext, joinSetup).forJsonPath("'{defining_code,code_string}'").forTableField(EVENT_CONTEXT.SETTING).sqlField();
+
+
+        }
+        throw new IllegalArgumentException("Unresolved context/facility attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemAttribute.java
@@ -36,10 +36,7 @@ public class SystemAttribute extends RMObjectAttribute {
 
     @Override
     public Field<?> sqlField() {
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(I_JoinBinder.systemRecordTable.getName()+"."+tableField.getName()));
-        else
-            return DSL.field(I_JoinBinder.systemRecordTable.getName()+"."+tableField.getName());
+        return as(DSL.field(I_JoinBinder.systemRecordTable.getName()+"."+tableField.getName()));
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemAttribute.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.system;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+public class SystemAttribute extends RMObjectAttribute {
+
+    protected TableField tableField;
+
+    public SystemAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(I_JoinBinder.systemRecordTable.getName()+"."+tableField.getName()));
+        else
+            return DSL.field(I_JoinBinder.systemRecordTable.getName()+"."+tableField.getName());
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.attribute.system;
+
+import org.ehrbase.aql.sql.queryImpl.attribute.AttributeResolver;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.jooq.Field;
+
+import static org.ehrbase.jooq.pg.tables.System.SYSTEM;
+
+public class SystemResolver extends AttributeResolver
+{
+
+    public SystemResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
+        super(fieldResolutionContext, joinSetup);
+        joinSetup.setJoinSystem(true);
+    }
+
+    public Field<?> sqlField(String path){
+
+        switch (path){
+            case "value":
+                return new SystemAttribute(fieldResolutionContext, joinSetup).forTableField(SYSTEM.SETTINGS).sqlField();
+            case "description":
+                return new SystemAttribute(fieldResolutionContext, joinSetup).forTableField(SYSTEM.DESCRIPTION).sqlField();
+        }
+        throw new IllegalArgumentException("Unresolved system attribute path:"+path);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/system/SystemResolver.java
@@ -30,6 +30,7 @@ public class SystemResolver extends AttributeResolver
     public SystemResolver(FieldResolutionContext fieldResolutionContext, JoinSetup joinSetup) {
         super(fieldResolutionContext, joinSetup);
         joinSetup.setJoinSystem(true);
+        joinSetup.setJoinEhr(true);
     }
 
     public Field<?> sqlField(String path){

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/GenericJsonField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/GenericJsonField.java
@@ -1,0 +1,37 @@
+package org.ehrbase.aql.sql.queryImpl.value_field;
+
+import org.apache.commons.lang3.StringUtils;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.RMObjectAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+
+public class GenericJsonField extends RMObjectAttribute {
+
+    public GenericJsonField(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    public Field jsonField(String plpgsqlFunction, TableField... tableFields){
+        //query the json representation of a node and cast the result as TEXT
+        Field jsonContextField = DSL.field(plpgsqlFunction+"("+StringUtils.join(tableFields, ",")+")::TEXT");
+        if (fieldContext.isWithAlias())
+            return aliased(DSL.field(jsonContextField));
+        else
+            return DSL.field(jsonContextField);
+    }
+
+    @Override
+    public Field sqlField(){
+        return null;
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/GenericJsonField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/GenericJsonField.java
@@ -32,10 +32,7 @@ public class GenericJsonField extends RMObjectAttribute {
         else
             jsonContextField = DSL.field(plpgsqlFunction+"("+StringUtils.join(tableFields, ",")+")::text");
 
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(jsonContextField));
-        else
-            return DSL.field(jsonContextField);
+        return as(DSL.field(jsonContextField));
     }
 
     public Field jsonField(String rmType, String plpgsqlFunction, Field... fields){
@@ -48,10 +45,9 @@ public class GenericJsonField extends RMObjectAttribute {
         else
             jsonContextField = DSL.field(plpgsqlFunction+"("+StringUtils.join(fields, ",")+")::text");
 
-        if (fieldContext.isWithAlias())
-            return aliased(DSL.field(jsonContextField));
-        else
-            return DSL.field(jsonContextField);
+
+        return as(DSL.field(jsonContextField));
+
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/SimpleAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/SimpleAttribute.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryImpl.value_field;
+
+import org.ehrbase.aql.sql.binding.I_JoinBinder;
+import org.ehrbase.aql.sql.queryImpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryImpl.attribute.I_RMObjectAttribute;
+import org.ehrbase.aql.sql.queryImpl.attribute.JoinSetup;
+import org.ehrbase.aql.sql.queryImpl.attribute.composition.CompositionAttribute;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import java.util.Optional;
+
+import static org.ehrbase.jooq.pg.Tables.COMPOSITION;
+
+public class SimpleAttribute extends CompositionAttribute {
+
+    protected Field tableField;
+    Optional<String> type = Optional.empty();
+
+    public SimpleAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        Field actualField;
+
+        if (type.isPresent())
+            actualField = DSL.field(tableField+"::"+type.get());
+        else
+            actualField = DSL.field(tableField);
+
+        if (fieldContext.isWithAlias())
+            return aliased(actualField);
+        else
+            return actualField;
+
+    }
+
+    @Override
+    public I_RMObjectAttribute forTableField(TableField tableField) {
+        return forTableField(tableField);
+    }
+
+    public SimpleAttribute forTableField(String pgtype, Field tableField) {
+        if (pgtype != null)
+            type = Optional.of(pgtype);
+
+        this.tableField = tableField;
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/SimpleAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/value_field/SimpleAttribute.java
@@ -48,10 +48,7 @@ public class SimpleAttribute extends CompositionAttribute {
         else
             actualField = DSL.field(tableField);
 
-        if (fieldContext.isWithAlias())
-            return aliased(actualField);
-        else
-            return actualField;
+        return as(actualField);
 
     }
 

--- a/service/src/main/java/org/ehrbase/dao/access/jooq/AqlQueryHandler.java
+++ b/service/src/main/java/org/ehrbase/dao/access/jooq/AqlQueryHandler.java
@@ -69,7 +69,7 @@ public class AqlQueryHandler extends DataAccess {
         //add the variable from statements
         Map<String, String> variables = new HashMap();
         for (I_VariableDefinition variableDefinition: statements.getVariables()) {
-            variables.put(variableDefinition.getAlias(), variableDefinition.getPath());
+            variables.put(variableDefinition.getAlias(), "/"+variableDefinition.getPath());
         }
         aqlResult.setVariables(variables);
         return aqlResult;

--- a/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
@@ -18,7 +18,10 @@
 
 package org.ehrbase.service;
 
+import com.google.gson.JsonElement;
 import org.ehrbase.api.definitions.QueryMode;
+import org.ehrbase.api.definitions.StructuredString;
+import org.ehrbase.api.definitions.StructuredStringFormat;
 import org.ehrbase.api.dto.QueryDefinitionResultDto;
 import org.ehrbase.api.dto.QueryResultDto;
 import org.ehrbase.api.exception.GeneralRequestProcessingException;
@@ -99,7 +102,11 @@ public class QueryServiceImp extends BaseService implements QueryService {
         for (Record record : aqlResult.getRecords()) {
             Map<String, Object> fieldMap = new HashMap<>();
             for (Field field : record.fields()) {
-                fieldMap.put(field.getName(), record.getValue(field));
+                if (record.getValue(field) instanceof JsonElement){
+                    fieldMap.put(field.getName(), new StructuredString(((JsonElement) record.getValue(field)).toString(), StructuredStringFormat.JSON));
+                }
+                else
+                    fieldMap.put(field.getName(), record.getValue(field));
             }
 
             resultList.add(fieldMap);
@@ -123,7 +130,7 @@ public class QueryServiceImp extends BaseService implements QueryService {
         } catch (IllegalArgumentException iae){
             throw new IllegalArgumentException(iae.getMessage());
         } catch (Exception e){
-            throw new IllegalArgumentException("Could not retrieve stored query, reason:" + e);
+            throw new IllegalArgumentException("Could not process query, reason:" + e);
         }
     }
 

--- a/service/src/test/java/org/ehrbase/aql/definition/I_VariableDefinitionHelper.java
+++ b/service/src/test/java/org/ehrbase/aql/definition/I_VariableDefinitionHelper.java
@@ -71,6 +71,16 @@ public class I_VariableDefinitionHelper {
             public List<FuncParameter> getFuncParameters() {
                 return null;
             }
+
+            @Override
+            public I_VariableDefinition clone() {
+                return I_VariableDefinitionHelper.build(path, alias, identifier, distinct, function, extension);
+            }
+
+            @Override
+            public void setPath(String path) {
+
+            }
         };
     }
 

--- a/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
@@ -101,7 +101,7 @@ public class QueryProcessorTest {
         //   Select expectedSql column  from ehr
         testCases.add(new AqlTestCase(1,
                 "select e/ehr_id/value from EHR e",
-                "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+                "select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\"",
@@ -113,7 +113,7 @@ public class QueryProcessorTest {
         testCases.add(new AqlTestCase(2,
                 "select e/ehr_id/value from EHR e " +
                         "where e/ehr_id/value = '30580007' ",
-                "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+                "select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\"" +
@@ -125,7 +125,7 @@ public class QueryProcessorTest {
         testCases.add(new AqlTestCase(3,
                 "select c/composer/name from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]",
-                "select \"composer_ref\".\"name\" as \"composer/name\" " +
+                "select \"composer_ref\".\"name\" as \"/composer/name\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "join \"ehr\".\"party_identified\" as \"composer_ref\" on \"composition_join\".\"composer\" = \"composer_ref\".\"id\" where \"ehr\".\"entry\".\"template_id\" = ?",
@@ -136,7 +136,7 @@ public class QueryProcessorTest {
                 "select c/composer/name from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1] " +
                         "order by c/context/start_time/value DESC",
-                "select \"composer_ref\".\"name\" as \"composer/name\" " +
+                "select \"composer_ref\".\"name\" as \"/composer/name\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "join \"ehr\".\"party_identified\" as \"composer_ref\" on \"composition_join\".\"composer\" = \"composer_ref\".\"id\" " +
@@ -148,7 +148,7 @@ public class QueryProcessorTest {
         testCases.add(new AqlTestCase(5,
                 "select a/description[at0001]/items[at0002]/value/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
@@ -171,7 +171,7 @@ public class QueryProcessorTest {
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
                         "where a/description[at0001]/items[at0002]/value/value = 'Hepatitis A'",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary'']\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0002]\".#.\"/value\".\"value\"=\"Hepatitis A\" '::jsquery))",
@@ -180,7 +180,7 @@ public class QueryProcessorTest {
         // select full composition
         testCases.add(new AqlTestCase(8,
                 "select c from EHR e contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]",
-                "select ehr.js_composition(composition_join.id, 'local')::text from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
+                "select ehr.js_composition(composition_join.id, 'local')::text as \"c\" from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 
@@ -190,35 +190,35 @@ public class QueryProcessorTest {
                 "select a from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"FIELD_0\"" +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\"" +
                         "from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 
         // select Limit and Offset
         testCases.add(new AqlTestCase(10,
                 "select e/ehr_id/value from EHR e LIMIT 10 OFFSET 5",
-                "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+                "select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                         "from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
                         "limit ? offset ?",
                 false));
 
         // select TOP
-        testCases.add(new AqlTestCase(10,
+        testCases.add(new AqlTestCase(11,
                 "select TOP 5 e/ehr_id/value from EHR e ",
-                "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+                "select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                         "from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
                         "limit ?",
                 false));
 
         // where clausal json column from entry  with matches
-        testCases.add(new AqlTestCase(11,
+        testCases.add(new AqlTestCase(12,
                 "select e/ehr_id/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
                         "where a/description[at0001]/items[at0002]/value/value matches {'Hepatitis A','Hepatitis B'} ",
-                "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+                "select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
@@ -227,7 +227,7 @@ public class QueryProcessorTest {
                 true));
 
         // select with function
-        testCases.add(new AqlTestCase(12,
+        testCases.add(new AqlTestCase(13,
                 "select  max (d/description[at0001]/items[at0004]/value/magnitude) as max_magnitude from EHR e  contains COMPOSITION  contains ACTION d[openEHR-EHR-ACTION.immunisation_procedure.v1]",
                 "select max(\"max_magnitude\") as \"max_magnitude\" " +
                         "from (select ((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"max_magnitude\" " +
@@ -237,7 +237,7 @@ public class QueryProcessorTest {
                 true));
 
         // Select  from unknown  composition
-        testCases.add(new AqlTestCase(13,
+        testCases.add(new AqlTestCase(14,
                 "select c/composer/name from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.unknown.v1]",
                 //Do to the way the query is build it is not possible to build sql if the AQL contains only compositions which have no instances in the DB. Thus we must manual handle this case.

--- a/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
@@ -145,23 +145,21 @@ public class QueryProcessorTest {
 
 
         // Select json column  from entry
-        //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
         testCases.add(new AqlTestCase(5,
-                "select a/description[at0001]/items[at0002]/value from EHR e " +
+                "select a/description[at0001]/items[at0002]/value/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 
         // order  by clause json column  from entry with alias
-        //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
         testCases.add(new AqlTestCase(6,
-                "select a/description[at0001]/items[at0002]/value as description from EHR e " +
+                "select a/description[at0001]/items[at0002]/value/value as description from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
                         "order by description ASC",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"description\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"description\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ? " +
                         "order by description asc",
@@ -169,11 +167,11 @@ public class QueryProcessorTest {
 
         // where  clause json column  from entry
         testCases.add(new AqlTestCase(7,
-                "select a/description[at0001]/items[at0002]/value from EHR e " +
+                "select a/description[at0001]/items[at0002]/value/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
                         "where a/description[at0001]/items[at0002]/value/value = 'Hepatitis A'",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
                         "from \"ehr\".\"entry\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary'']\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0002]\".#.\"/value\".\"value\"=\"Hepatitis A\" '::jsquery))",

--- a/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
@@ -180,8 +180,7 @@ public class QueryProcessorTest {
         // select full composition
         testCases.add(new AqlTestCase(8,
                 "select c from EHR e contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]",
-                "select \"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary'']}' as \"FIELD_0\" " +
-                        "from \"ehr\".\"entry\" " +
+                "select ehr.js_composition(composition_join.id, 'local')::text from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 
@@ -191,7 +190,7 @@ public class QueryProcessorTest {
                 "select a from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"FIELD_0\", \"ehr\".\"entry\".\"template_id\" as \"_TEMPLATE_ID\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"FIELD_0\"" +
                         "from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 

--- a/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
@@ -145,21 +145,23 @@ public class QueryProcessorTest {
 
 
         // Select json column  from entry
+        //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
         testCases.add(new AqlTestCase(5,
                 "select a/description[at0001]/items[at0002]/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?",
                 true));
 
         // order  by clause json column  from entry with alias
+        //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
         testCases.add(new AqlTestCase(6,
                 "select a/description[at0001]/items[at0002]/value as description from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
                         "order by description ASC",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"description\" " +
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"description\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ? " +
                         "order by description asc",
@@ -170,8 +172,8 @@ public class QueryProcessorTest {
                 "select a/description[at0001]/items[at0002]/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
-                        "where a/description[at0001]/items[at0002]/value = 'Hepatitis A'",
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\" " +
+                        "where a/description[at0001]/items[at0002]/value/value = 'Hepatitis A'",
+                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\" " +
                         "from \"ehr\".\"entry\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary'']\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0002]\".#.\"/value\".\"value\"=\"Hepatitis A\" '::jsquery))",
@@ -218,7 +220,7 @@ public class QueryProcessorTest {
                 "select e/ehr_id/value from EHR e " +
                         "contains COMPOSITION c[openEHR-EHR-COMPOSITION.health_summary.v1]  " +
                         "contains ACTION a[openEHR-EHR-ACTION.immunisation_procedure.v1]" +
-                        "where a/description[at0001]/items[at0002]/value matches {'Hepatitis A','Hepatitis B'} ",
+                        "where a/description[at0001]/items[at0002]/value/value matches {'Hepatitis A','Hepatitis B'} ",
                 "select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
@@ -72,7 +72,9 @@ public class SelectBinderTest {
             SelectBinder cut = new SelectBinder(context, introspectCache, pathResolver, variableDefinitions, where, "local", entryRoot);
 
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
-            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"FIELD_0\"");
+
+            //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
+            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\"");
         }
 
         // select from EHR

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
@@ -74,7 +74,7 @@ public class SelectBinderTest {
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
 
             //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
-            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"/description[at0001]/items[at0002]/value\"");
         }
 
         // select from EHR
@@ -90,7 +90,7 @@ public class SelectBinderTest {
             SelectBinder cut = new SelectBinder(context, introspectCache, pathResolver, variableDefinitions, where, "local", entryRoot);
 
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
-            assertThat(selectQuery.getSQL()).isEqualTo("select \"ehr_join\".\"id\" as \"ehr_id/value\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select \"ehr_join\".\"id\" as \"/ehr_id/value\"");
         }
 
         // select from Composition
@@ -107,7 +107,7 @@ public class SelectBinderTest {
             SelectBinder cut = new SelectBinder(context, introspectCache, pathResolver, variableDefinitions, where, "local", entryRoot);
 
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
-            assertThat(selectQuery.getSQL()).isEqualTo("select \"composer_ref\".\"name\" as \"composer/name\", \"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}' as \"FIELD_1\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select \"composer_ref\".\"name\" as \"/composer/name\", \"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}' as \"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\"");
         }
     }
 

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
@@ -74,7 +74,7 @@ public class SelectBinderTest {
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
 
             //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
-            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\", \"ehr\".\"entry\".\"template_id\" as \"_TEMPLATE_ID\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\"");
         }
 
         // select from EHR

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
@@ -74,7 +74,7 @@ public class SelectBinderTest {
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
 
             //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
-            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"FIELD_0\", \"ehr\".\"entry\".\"template_id\" as \"_TEMPLATE_ID\"");
         }
 
         // select from EHR

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/WhereBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/WhereBinderTest.java
@@ -94,7 +94,8 @@ public class WhereBinderTest {
             CompositionAttributeQuery compositionAttributeQuery = new CompositionAttributeQuery(context, pathResolver, "local", "entry_root", introspectCache);
 
             //represents where a/composer/name =  'Tony Stark' and  d/description[at0001]/items[at0002]/value = 'Hepatitis A'
-            List where = Arrays.asList(I_VariableDefinitionHelper.build("composer/name", null, "a", false, false, false), "=", "'Tony Stark'", "and", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value", null, "d", false, false, false), "=", "'Hepatitis A'");
+            //CCH 191016: EHR-163 required trailing '/value' as now the query allows canonical json return
+            List where = Arrays.asList(I_VariableDefinitionHelper.build("composer/name", null, "a", false, false, false), "=", "'Tony Stark'", "and", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value/value", null, "d", false, false, false), "=", "'Hepatitis A'");
 
             WhereBinder cut = new WhereBinder(jsonbEntryQuery, compositionAttributeQuery, where, identifierMapper);
 

--- a/service/src/test/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQueryTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQueryTest.java
@@ -55,7 +55,8 @@ public class JsonbEntryQueryTest {
         String entryRoot = "/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value='Immunisation summary']";
         JsonbEntryQuery cut = new JsonbEntryQuery(context, introspectCache, pathResolver, entryRoot);
 
-        Field<?> actual = cut.makeField("IDCR - Immunisation summary.v0", UUID.randomUUID(), "d", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value", null, "d", false, false, false), false, I_QueryImpl.Clause.SELECT);
+        //CCH 191016: EHR-163 required trailing '/value' as now the query allows canonical json return
+        Field<?> actual = cut.makeField("IDCR - Immunisation summary.v0", UUID.randomUUID(), "d", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value/value", null, "d", false, false, false), false, I_QueryImpl.Clause.SELECT);
 
         assertThat(actual.toString()).isEqualTo("(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}')");
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQueryTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQueryTest.java
@@ -56,9 +56,10 @@ public class JsonbEntryQueryTest {
         JsonbEntryQuery cut = new JsonbEntryQuery(context, introspectCache, pathResolver, entryRoot);
 
         //CCH 191016: EHR-163 required trailing '/value' as now the query allows canonical json return
-        Field<?> actual = cut.makeField("IDCR - Immunisation summary.v0", UUID.randomUUID(), "d", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value/value", null, "d", false, false, false), false, I_QueryImpl.Clause.SELECT);
+        Field<?> actual = cut.makeField("IDCR - Immunisation summary.v0", UUID.randomUUID(), "d", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value/value", "test", "d", false, false, false), I_QueryImpl.Clause.SELECT);
 
-        assertThat(actual.toString()).isEqualTo("(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}')");
+//        assertThat(actual.toString()).isEqualTo("(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}')");
+        assertThat(actual.toString()).isEqualTo("\"test\"");
     }
 
 }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryImpl/VariableAqlPathTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryImpl/VariableAqlPathTest.java
@@ -1,0 +1,45 @@
+package org.ehrbase.aql.sql.queryImpl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VariableAqlPathTest {
+
+    @Test
+    public void getSuffix() {
+
+        String aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/value";
+
+        assertEquals("value", new VariableAqlPath(aPath).getSuffix());
+
+    }
+
+    @Test
+    public void getInfix() {
+
+        String aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/value";
+
+        assertEquals("data[at0001]/events[at0002]/data[at0003]/items[at0007]", new VariableAqlPath(aPath).getInfix());
+    }
+
+    @Test
+    public void testIsPartialAqlDataValuePath(){
+        String aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/value";
+
+        assertTrue(new VariableAqlPath(aPath).isPartialAqlDataValuePath());
+
+        aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/value/magnitude";
+
+        assertFalse(new VariableAqlPath(aPath).isPartialAqlDataValuePath());
+
+        aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/name";
+
+        assertTrue(new VariableAqlPath(aPath).isPartialAqlDataValuePath());
+
+        aPath = "data[at0001]/events[at0002]/data[at0003]/items[at0007]/time";
+
+        assertTrue(new VariableAqlPath(aPath).isPartialAqlDataValuePath());
+
+    }
+}

--- a/service/src/test/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPathTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPathTest.java
@@ -1,0 +1,19 @@
+package org.ehrbase.aql.sql.queryImpl.attribute;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GenericJsonPathTest {
+
+    @Test
+    public void jqueryPath() {
+
+        assertEquals("'{health_care_facility,external_ref,id}'", new GenericJsonPath("health_care_facility/external_ref/id").jqueryPath());
+        assertEquals("'{setting,defining_code}'", new GenericJsonPath("setting/defining_code").jqueryPath());
+        assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]").jqueryPath());
+        assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0,/items[at0001],0}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]/items[at0001]").jqueryPath());
+        assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0,/items[at0001],0,/value,value}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]/items[at0001]/value,value").jqueryPath());
+
+    }
+}

--- a/service/src/test/java/org/ehrbase/dao/access/jooq/AqlQueryHandlerTest.java
+++ b/service/src/test/java/org/ehrbase/dao/access/jooq/AqlQueryHandlerTest.java
@@ -46,7 +46,7 @@ public class AqlQueryHandlerTest {
         }), testFolder, cacheRule), true);
         AqlResult aqlResult = cut.process("select e/ehr_id/value from EHR e LIMIT 10 OFFSET 5");
         assertThat(aqlResult.getExplain().get(0)).hasSize(3).contains("10", "5");
-        assertThat(aqlResult.getExplain().get(0).get(0)).isEqualToIgnoringWhitespace("select \"ehr_join\".\"id\" as \"ehr_id/value\" " +
+        assertThat(aqlResult.getExplain().get(0).get(0)).isEqualToIgnoringWhitespace("select \"ehr_join\".\"id\" as \"/ehr_id/value\" " +
                 "from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" " +
                 "right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
                 "limit ? offset ?");

--- a/test-data/src/main/resources/composition/canonical_json/full_composition.json
+++ b/test-data/src/main/resources/composition/canonical_json/full_composition.json
@@ -1,0 +1,1617 @@
+{
+  "@class": "COMPOSITION",
+  "content": {
+    "/content[openEHR-EHR-SECTION.adhoc.v1]": [
+      {
+        "/$CLASS$": [
+          "Section"
+        ],
+        "/items[openEHR-EHR-ACTION.procedure.v1]": [
+          {
+            "/name": [
+              {
+                "value": "Procedure"
+              }
+            ],
+            "/time": {
+              "/name": [
+                {
+                  "value": "Procedure"
+                }
+              ],
+              "/value": {
+                "value": "2015-12-02T17:41:56.813Z",
+                "epoch_offset": 1449078116
+              },
+              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/time",
+              "/$CLASS$": "DvDateTime"
+            },
+            "/$CLASS$": "Action",
+            "/protocol[at0053]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at0054]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Requestor order identifier"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Ident. 38"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/protocol[at0053]/items[at0054]",
+                  "/$CLASS$": "DvText"
+                }
+              ],
+              "/items[at0056]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Receiver order identifier"
+                    }
+                  ],
+                  "/value": {
+                    "id": "8fb20ec3-b285-4ab8-acd4-25bcd58cbd24",
+                    "type": "Prescription",
+                    "issuer": "Issuer",
+                    "assigner": "Assigner"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/protocol[at0053]/items[at0056]",
+                  "/$CLASS$": "DvIdentifier"
+                }
+              ],
+              "/items[openEHR-EHR-CLUSTER.person_name.v1]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Person name"
+                    }
+                  ],
+                  "/$CLASS$": [
+                    "Cluster"
+                  ],
+                  "/items[at0001]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Unstructured name"
+                        }
+                      ],
+                      "/value": {
+                        "value": "Unstructured name 16"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/protocol[at0053]/items[openEHR-EHR-CLUSTER.person_name.v1 and name/value='Person name']/items[at0001]",
+                      "/$CLASS$": "DvText"
+                    }
+                  ],
+                  "/items[at0006]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Name type"
+                        }
+                      ],
+                      "/value": {
+                        "value": "AKA",
+                        "definingCode": {
+                          "codeString": "at0010",
+                          "terminologyId": {
+                            "name": "local",
+                            "value": "local"
+                          }
+                        }
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/protocol[at0053]/items[openEHR-EHR-CLUSTER.person_name.v1 and name/value='Person name']/items[at0006]",
+                      "/$CLASS$": "DvCodedText"
+                    }
+                  ],
+                  "/items[at0022]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Preferred name"
+                        }
+                      ],
+                      "/value": {
+                        "value": true
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/protocol[at0053]/items[openEHR-EHR-CLUSTER.person_name.v1 and name/value='Person name']/items[at0022]",
+                      "/$CLASS$": "DvBoolean"
+                    }
+                  ]
+                }
+              ]
+            },
+            "/description[at0001]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at0002]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Procedure name"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Procedure name 40"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/description[at0001]/items[at0002]",
+                  "/$CLASS$": "DvText"
+                }
+              ],
+              "/items[at0065]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Run-time coded name",
+                      "defining_code": {
+                        "codeString": "70901006",
+                        "terminologyId": {
+                          "name": "SNOMED-CT",
+                          "value": "SNOMED-CT"
+                        }
+                      }
+                    }
+                  ],
+                  "/value": {
+                    "value": "Method 0"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/description[at0001]/items[at0065]",
+                  "/$CLASS$": "DvText"
+                },
+                {
+                  "/name": [
+                    {
+                      "value": "Method #1"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Method #1 94"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/description[at0001]/items[at0065]",
+                  "/$CLASS$": "DvText"
+                }
+              ],
+              "/items[at0066]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Scheduled date/time"
+                    }
+                  ],
+                  "/value": {
+                    "value": "2015-12-02T17:41:56",
+                    "epoch_offset": 1449078116
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ACTION.procedure.v1 and name/value='Procedure']/description[at0001]/items[at0066]",
+                  "/$CLASS$": "DvDateTime"
+                }
+              ]
+            }
+          }
+        ],
+        "/items[openEHR-EHR-OBSERVATION.demo.v1]": [
+          {
+            "/name": [
+              {
+                "value": "Demonstration"
+              }
+            ],
+            "/$CLASS$": "Observation",
+            "/data[at0001]": {
+              "/name": [
+                {
+                  "value": "Event Series"
+                }
+              ],
+              "/events": {
+                "/events[at0002]": [
+                  {
+                    "/name": [
+                      {
+                        "value": "Any event"
+                      }
+                    ],
+                    "/time": {
+                      "/name": [
+                        {
+                          "value": "Any event"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56.809Z",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/time",
+                      "/$CLASS$": "DvDateTime"
+                    },
+                    "/$CLASS$": "PointEvent",
+                    "/data[at0003]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[at0004]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Heading1"
+                            }
+                          ],
+                          "/$CLASS$": [
+                            "Cluster"
+                          ],
+                          "/items[at0005]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Free text or coded"
+                                }
+                              ],
+                              "/value": {
+                                "value": "Free text or coded 33"
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0005]",
+                              "/$CLASS$": "DvText"
+                            }
+                          ],
+                          "/items[at0006]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Text that uses Internal codes"
+                                }
+                              ],
+                              "/value": {
+                                "value": "Reclining",
+                                "definingCode": {
+                                  "codeString": "at0008",
+                                  "terminologyId": {
+                                    "name": "local",
+                                    "value": "local"
+                                  }
+                                }
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0006]",
+                              "/$CLASS$": "DvCodedText"
+                            }
+                          ],
+                          "/items[at0011]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Text that is sourced from an external terminology"
+                                }
+                              ],
+                              "/value": {
+                                "value": "T.38 description",
+                                "definingCode": {
+                                  "codeString": "T.38",
+                                  "terminologyId": {
+                                    "name": "external_terminology",
+                                    "value": "external_terminology"
+                                  }
+                                }
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0011]",
+                              "/$CLASS$": "DvCodedText"
+                            }
+                          ],
+                          "/items[at0012]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Quantity"
+                                }
+                              ],
+                              "/value": {
+                                "units": "cm",
+                                "magnitude": 96.63,
+                                "precision": 1,
+                                "otherReferenceRanges": []
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0012]",
+                              "/$CLASS$": "DvQuantity"
+                            }
+                          ],
+                          "/items[at0013]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Count"
+                                }
+                              ],
+                              "/value": {
+                                "magnitude": 908,
+                                "otherReferenceRanges": []
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0013]",
+                              "/$CLASS$": "DvCount"
+                            }
+                          ],
+                          "/items[at0014]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Date/Time"
+                                }
+                              ],
+                              "/value": {
+                                "value": "2015-12-02T17:41:56",
+                                "epoch_offset": 1449078116
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0014]",
+                              "/$CLASS$": "DvDateTime"
+                            }
+                          ],
+                          "/items[at0015]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Ordinal"
+                                }
+                              ],
+                              "/value": {
+                                "value": 1,
+                                "symbol": {
+                                  "value": "Slight pain",
+                                  "definingCode": {
+                                    "codeString": "at0039",
+                                    "terminologyId": {
+                                      "name": "local",
+                                      "value": "local"
+                                    }
+                                  }
+                                },
+                                "otherReferenceRanges": []
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0015]",
+                              "/$CLASS$": "DvOrdinal"
+                            }
+                          ],
+                          "/items[at0021]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Duration"
+                                }
+                              ],
+                              "/value": {
+                                "value": "PT11H11M"
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0021]",
+                              "/$CLASS$": "DvDuration"
+                            }
+                          ],
+                          "/items[at0022]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Interval of Integer"
+                                }
+                              ],
+                              "/value": {
+                                "interval": {
+                                  "lower": {
+                                    "magnitude": 4,
+                                    "otherReferenceRanges": []
+                                  },
+                                  "upper": {
+                                    "magnitude": 10,
+                                    "otherReferenceRanges": []
+                                  },
+                                  "lowerIncluded": true,
+                                  "upperIncluded": true,
+                                  "lowerUnbounded": false,
+                                  "upperUnbounded": false
+                                }
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0022]",
+                              "/$CLASS$": "DvInterval<DvCount>"
+                            }
+                          ],
+                          "/items[at0023]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Interval of Quantity"
+                                }
+                              ],
+                              "/value": {
+                                "interval": {
+                                  "lower": {
+                                    "units": "cm",
+                                    "magnitude": 5.66,
+                                    "otherReferenceRanges": []
+                                  },
+                                  "upper": {
+                                    "units": "cm",
+                                    "magnitude": 62.91,
+                                    "otherReferenceRanges": []
+                                  },
+                                  "lowerIncluded": true,
+                                  "upperIncluded": true,
+                                  "lowerUnbounded": false,
+                                  "upperUnbounded": false
+                                }
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0023]",
+                              "/$CLASS$": "DvInterval<DvQuantity>"
+                            }
+                          ],
+                          "/items[at0024]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Interval of Date"
+                                }
+                              ],
+                              "/value": {
+                                "interval": {
+                                  "lower": {
+                                    "value": "2015-12-02T17:41:56",
+                                    "epoch_offset": 1449078116
+                                  },
+                                  "upper": {
+                                    "value": "2015-12-02T17:41:56",
+                                    "epoch_offset": 1449078116
+                                  },
+                                  "lowerIncluded": true,
+                                  "upperIncluded": true,
+                                  "lowerUnbounded": false,
+                                  "upperUnbounded": false
+                                }
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0024]",
+                              "/$CLASS$": "DvInterval<DvDateTime>"
+                            }
+                          ],
+                          "/items[at0026]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Multimedia"
+                                }
+                              ],
+                              "/value": {
+                                "uri": {
+                                  "value": "http://med.tube.com/sample"
+                                },
+                                "size": 504903212,
+                                "mediaType": {
+                                  "codeString": "text/xml",
+                                  "terminologyId": {
+                                    "name": "IANA_media-types",
+                                    "value": "IANA_media-types"
+                                  }
+                                },
+                                "alternateText": "alternate text"
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0026]",
+                              "/$CLASS$": "DvMultimedia"
+                            }
+                          ],
+                          "/items[at0027]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "URI - resource identifier"
+                                }
+                              ],
+                              "/value": {
+                                "value": "http://example.com/path/resource"
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0027]",
+                              "/$CLASS$": "DvURI"
+                            }
+                          ],
+                          "/items[at0028]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Proportion"
+                                }
+                              ],
+                              "/value": {
+                                "type": 2,
+                                "numerator": 58.0,
+                                "precision": 0,
+                                "denominator": 100.0,
+                                "otherReferenceRanges": []
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0028]",
+                              "/$CLASS$": "DvProportion"
+                            }
+                          ],
+                          "/items[at0044]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "Identifier"
+                                }
+                              ],
+                              "/value": {
+                                "id": "0ffc464a-d954-46f0-9f77-05ed6877ccf5",
+                                "type": "Prescription",
+                                "issuer": "Issuer",
+                                "assigner": "Assigner"
+                              },
+                              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/events[at0002 and name/value='Any event']/data[at0003]/items[at0004 and name/value='Heading1']/items[at0044]",
+                              "/$CLASS$": "DvIdentifier"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "/origin": {
+                "/name": [
+                  {
+                    "value": "Event Series"
+                  }
+                ],
+                "/value": {
+                  "value": "2015-12-02T17:41:56.809Z",
+                  "epoch_offset": 1449078116
+                },
+                "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.demo.v1 and name/value='Demonstration']/data[at0001]/origin",
+                "/$CLASS$": "DvDateTime"
+              },
+              "/$CLASS$": "History"
+            }
+          }
+        ],
+        "/items[openEHR-EHR-OBSERVATION.pulse.v1]": [
+          {
+            "/name": [
+              {
+                "value": "Pulse"
+              }
+            ],
+            "/$CLASS$": "Observation",
+            "/data[at0002]": {
+              "/name": [
+                {
+                  "value": "history"
+                }
+              ],
+              "/events": {
+                "/events[at0003]": [
+                  {
+                    "/name": [
+                      {
+                        "value": "First event"
+                      }
+                    ],
+                    "/time": {
+                      "/name": [
+                        {
+                          "value": "First event"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56.809Z",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='First event']/time",
+                      "/$CLASS$": "DvDateTime"
+                    },
+                    "/$CLASS$": "PointEvent",
+                    "/data[at0001]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[at0004]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Pulse Rate",
+                              "defining_code": {
+                                "codeString": "at1026",
+                                "terminologyId": {
+                                  "name": "local",
+                                  "value": "local"
+                                }
+                              }
+                            }
+                          ],
+                          "/value": {
+                            "units": "/min",
+                            "magnitude": 53.0,
+                            "precision": 0,
+                            "otherReferenceRanges": []
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='First event']/data[at0001]/items[at0004]",
+                          "/$CLASS$": "DvQuantity"
+                        }
+                      ],
+                      "/items[at0005]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Regularity"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Regularly Irregular",
+                            "definingCode": {
+                              "codeString": "at0007",
+                              "terminologyId": {
+                                "name": "local",
+                                "value": "local"
+                              }
+                            }
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='First event']/data[at0001]/items[at0005]",
+                          "/$CLASS$": "DvCodedText"
+                        }
+                      ],
+                      "/items[at1022]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Clinical Description"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Clinical Description 14"
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='First event']/data[at0001]/items[at1022]",
+                          "/$CLASS$": "DvText"
+                        }
+                      ],
+                      "/items[at1023]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Clinical Interpretation"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Clinical Interpretation 23"
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='First event']/data[at0001]/items[at1023]",
+                          "/$CLASS$": "DvText"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "/name": [
+                      {
+                        "value": "Second event"
+                      }
+                    ],
+                    "/time": {
+                      "/name": [
+                        {
+                          "value": "Second event"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56.809Z",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='Second event']/time",
+                      "/$CLASS$": "DvDateTime"
+                    },
+                    "/$CLASS$": "PointEvent",
+                    "/data[at0001]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[at0004]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Pulse Rate",
+                              "defining_code": {
+                                "codeString": "at1026",
+                                "terminologyId": {
+                                  "name": "local",
+                                  "value": "local"
+                                }
+                              }
+                            }
+                          ],
+                          "/value": {
+                            "units": "/min",
+                            "magnitude": 3.0,
+                            "precision": 0,
+                            "otherReferenceRanges": []
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='Second event']/data[at0001]/items[at0004]",
+                          "/$CLASS$": "DvQuantity"
+                        }
+                      ],
+                      "/items[at0005]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Regularity"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Regularly Irregular",
+                            "definingCode": {
+                              "codeString": "at0007",
+                              "terminologyId": {
+                                "name": "local",
+                                "value": "local"
+                              }
+                            }
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='Second event']/data[at0001]/items[at0005]",
+                          "/$CLASS$": "DvCodedText"
+                        }
+                      ],
+                      "/items[at1005]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Pulse Presence"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Present",
+                            "definingCode": {
+                              "codeString": "at1024",
+                              "terminologyId": {
+                                "name": "local",
+                                "value": "local"
+                              }
+                            }
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='Second event']/data[at0001]/items[at1005]",
+                          "/$CLASS$": "DvCodedText"
+                        }
+                      ],
+                      "/items[at1023]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Clinical Interpretation"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Clinical Interpretation 34"
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at0003 and name/value='Second event']/data[at0001]/items[at1023]",
+                          "/$CLASS$": "DvText"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "/events[at1036]": [
+                  {
+                    "/name": [
+                      {
+                        "value": "Maximum"
+                      }
+                    ],
+                    "/time": {
+                      "/name": [
+                        {
+                          "value": "Maximum"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56.809Z",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/time",
+                      "/$CLASS$": "DvDateTime"
+                    },
+                    "/width": {
+                      "/name": [
+                        {
+                          "value": "Maximum"
+                        }
+                      ],
+                      "/value": {
+                        "value": "PT11H11M"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/width",
+                      "/$CLASS$": "DvDuration"
+                    },
+                    "/$CLASS$": "IntervalEvent",
+                    "/data[at0001]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[at0004]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Heart Rate",
+                              "defining_code": {
+                                "codeString": "at1027",
+                                "terminologyId": {
+                                  "name": "local",
+                                  "value": "local"
+                                }
+                              }
+                            }
+                          ],
+                          "/value": {
+                            "units": "/min",
+                            "magnitude": 16.0,
+                            "precision": 0,
+                            "otherReferenceRanges": []
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/data[at0001]/items[at0004]",
+                          "/$CLASS$": "DvQuantity"
+                        }
+                      ]
+                    },
+                    "/math_function": {
+                      "/name": [
+                        {
+                          "value": "Maximum"
+                        }
+                      ],
+                      "/value": {
+                        "value": "maximum",
+                        "definingCode": {
+                          "codeString": "144",
+                          "terminologyId": {
+                            "name": "openehr",
+                            "value": "openehr"
+                          }
+                        }
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/math_function",
+                      "/$CLASS$": "DvCodedText"
+                    },
+                    "/state[at0012]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[at0013]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Position"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Sitting",
+                            "definingCode": {
+                              "codeString": "at1001",
+                              "terminologyId": {
+                                "name": "local",
+                                "value": "local"
+                              }
+                            }
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/state[at0012]/items[at0013]",
+                          "/$CLASS$": "DvCodedText"
+                        }
+                      ],
+                      "/items[at1018]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Confounding Factors"
+                            }
+                          ],
+                          "/value": {
+                            "value": "Confounding Factors 16"
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/events[at1036 and name/value='Maximum']/state[at0012]/items[at1018]",
+                          "/$CLASS$": "DvText"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "/origin": {
+                "/name": [
+                  {
+                    "value": "history"
+                  }
+                ],
+                "/value": {
+                  "value": "2015-12-02T17:41:56.809Z",
+                  "epoch_offset": 1449078116
+                },
+                "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/data[at0002]/origin",
+                "/$CLASS$": "DvDateTime"
+              },
+              "/$CLASS$": "History"
+            },
+            "/protocol[at0010]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at1019]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Method"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Device",
+                    "definingCode": {
+                      "codeString": "at1034",
+                      "terminologyId": {
+                        "name": "local",
+                        "value": "local"
+                      }
+                    }
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[at1019]",
+                  "/$CLASS$": "DvCodedText"
+                }
+              ],
+              "/items[at1037]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Findings Location"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Femoral Artery - Left",
+                    "definingCode": {
+                      "codeString": "at1043",
+                      "terminologyId": {
+                        "name": "local",
+                        "value": "local"
+                      }
+                    }
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[at1037]",
+                  "/$CLASS$": "DvCodedText"
+                }
+              ],
+              "/items[openEHR-EHR-CLUSTER.device.v1]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Medical Device"
+                    }
+                  ],
+                  "/$CLASS$": [
+                    "Cluster"
+                  ],
+                  "/items[at0001]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Device name"
+                        }
+                      ],
+                      "/value": {
+                        "value": "Device name 33"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[openEHR-EHR-CLUSTER.device.v1 and name/value='Medical Device']/items[at0001]",
+                      "/$CLASS$": "DvText"
+                    }
+                  ],
+                  "/items[at0004]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Manufacturer"
+                        }
+                      ],
+                      "/value": {
+                        "value": "Manufacturer 6"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[openEHR-EHR-CLUSTER.device.v1 and name/value='Medical Device']/items[at0004]",
+                      "/$CLASS$": "DvText"
+                    }
+                  ],
+                  "/items[at0005]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Date of manufacture"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[openEHR-EHR-CLUSTER.device.v1 and name/value='Medical Device']/items[at0005]",
+                      "/$CLASS$": "DvDateTime"
+                    }
+                  ],
+                  "/items[at0021]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Unique device identifier (UDI)"
+                        }
+                      ],
+                      "/value": {
+                        "id": "59466e78-d15c-4765-87da-20e56f1413a6",
+                        "type": "Prescription",
+                        "issuer": "Issuer",
+                        "assigner": "Assigner"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-OBSERVATION.pulse.v1 and name/value='Pulse']/protocol[at0010]/items[openEHR-EHR-CLUSTER.device.v1 and name/value='Medical Device']/items[at0021]",
+                      "/$CLASS$": "DvIdentifier"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "/items[openEHR-EHR-EVALUATION.cpr_decision_uk.v1]": [
+          {
+            "/name": [
+              {
+                "value": "CPR decision"
+              }
+            ],
+            "/$CLASS$": "Evaluation",
+            "/data[at0001]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at0002]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Date of CPR decision"
+                    }
+                  ],
+                  "/value": {
+                    "value": "2015-12-02T17:41:56",
+                    "epoch_offset": 1449078116
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-EVALUATION.cpr_decision_uk.v1 and name/value='CPR decision']/data[at0001]/items[at0002]",
+                  "/$CLASS$": "DvDateTime"
+                }
+              ],
+              "/items[at0003]": [
+                {
+                  "/name": [
+                    {
+                      "value": "CPR decision"
+                    }
+                  ],
+                  "/value": {
+                    "value": "CPR decision status unknown",
+                    "definingCode": {
+                      "codeString": "at0022",
+                      "terminologyId": {
+                        "name": "local",
+                        "value": "local"
+                      }
+                    }
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-EVALUATION.cpr_decision_uk.v1 and name/value='CPR decision']/data[at0001]/items[at0003]",
+                  "/$CLASS$": "DvCodedText"
+                }
+              ]
+            },
+            "/protocol[at0010]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at0009]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Date for review of CPR decision"
+                    }
+                  ],
+                  "/value": {
+                    "value": "2015-12-02T17:41:56",
+                    "epoch_offset": 1449078116
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-EVALUATION.cpr_decision_uk.v1 and name/value='CPR decision']/protocol[at0010]/items[at0009]",
+                  "/$CLASS$": "DvDateTime"
+                }
+              ],
+              "/items[at0014]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Discussion with informal carer"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Resuscitation not discussed with informal carer",
+                    "definingCode": {
+                      "codeString": "at0024",
+                      "terminologyId": {
+                        "name": "local",
+                        "value": "local"
+                      }
+                    }
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-EVALUATION.cpr_decision_uk.v1 and name/value='CPR decision']/protocol[at0010]/items[at0014]",
+                  "/$CLASS$": "DvCodedText"
+                }
+              ]
+            }
+          }
+        ],
+        "/items[openEHR-EHR-INSTRUCTION.request-procedure.v1]": [
+          {
+            "/uid": {
+              "/name": [
+                {
+                  "value": "9a3871f8-8105-44f9-a06c-5626acaf40a3"
+                }
+              ],
+              "/value": {
+                "value": "9a3871f8-8105-44f9-a06c-5626acaf40a3"
+              },
+              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/uid",
+              "/$CLASS$": "HierObjectId"
+            },
+            "/name": [
+              {
+                "value": "Procedure request"
+              }
+            ],
+            "/$CLASS$": "Instruction",
+            "/narrative": {
+              "/name": [
+                {
+                  "value": "Procedure request"
+                }
+              ],
+              "/value": {
+                "value": "Human readable instruction narrative"
+              },
+              "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/narrative",
+              "/$CLASS$": "DvText"
+            },
+            "/activities": {
+              "/$CLASS$": [
+                "Activity"
+              ],
+              "/activities[at0001]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Request"
+                    }
+                  ],
+                  "/timing": {
+                    "/value": {
+                      "value": "R2/2015-12-02T17:00:00Z/P3M",
+                      "formalism": "timing"
+                    },
+                    "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request']/timing",
+                    "/$CLASS$": "DvParsable"
+                  },
+                  "/$CLASS$": "Activity",
+                  "/action_archetype_id": "/.*/",
+                  "/description[at0009]": {
+                    "/$CLASS$": [
+                      "ItemTree"
+                    ],
+                    "/items[at0076]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Supplementary information to follow"
+                          }
+                        ],
+                        "/value": {
+                          "value": true
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request']/description[at0009]/items[at0076]",
+                        "/$CLASS$": "DvBoolean"
+                      }
+                    ],
+                    "/items[at0121]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Procedure requested"
+                          }
+                        ],
+                        "/value": {
+                          "value": "Procedure requested 79"
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request']/description[at0009]/items[at0121]",
+                        "/$CLASS$": "DvText"
+                      }
+                    ],
+                    "/items[at0144]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Latest date service required"
+                          }
+                        ],
+                        "/value": {
+                          "value": "2015-12-02T17:41:56",
+                          "epoch_offset": 1449078116
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request']/description[at0009]/items[at0144]",
+                        "/$CLASS$": "DvDateTime"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "/name": [
+                    {
+                      "value": "Request #3"
+                    }
+                  ],
+                  "/timing": {
+                    "/value": {
+                      "value": "R2/2015-12-02T17:00:00Z/P1M",
+                      "formalism": "timing"
+                    },
+                    "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request #3']/timing",
+                    "/$CLASS$": "DvParsable"
+                  },
+                  "/$CLASS$": "Activity",
+                  "/action_archetype_id": "/.*/",
+                  "/description[at0009]": {
+                    "/$CLASS$": [
+                      "ItemTree"
+                    ],
+                    "/items[at0076]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Supplementary information to follow"
+                          }
+                        ],
+                        "/value": {
+                          "value": true
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request #3']/description[at0009]/items[at0076]",
+                        "/$CLASS$": "DvBoolean"
+                      }
+                    ],
+                    "/items[at0121]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Procedure requested"
+                          }
+                        ],
+                        "/value": {
+                          "value": "Procedure requested 84"
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request #3']/description[at0009]/items[at0121]",
+                        "/$CLASS$": "DvText"
+                      }
+                    ],
+                    "/items[at0144]": [
+                      {
+                        "/name": [
+                          {
+                            "value": "Latest date service required"
+                          }
+                        ],
+                        "/value": {
+                          "value": "2015-12-02T17:41:56",
+                          "epoch_offset": 1449078116
+                        },
+                        "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/activities[at0001 and name/value='Request #3']/description[at0009]/items[at0144]",
+                        "/$CLASS$": "DvDateTime"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "/protocol[at0008]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[openEHR-EHR-CLUSTER.distribution.v1]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Distribution"
+                    }
+                  ],
+                  "/$CLASS$": [
+                    "Cluster"
+                  ],
+                  "/items[at0006]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Date sent"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2015-12-02T17:41:56",
+                        "epoch_offset": 1449078116
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/protocol[at0008]/items[openEHR-EHR-CLUSTER.distribution.v1 and name/value='Distribution']/items[at0006]",
+                      "/$CLASS$": "DvDateTime"
+                    }
+                  ],
+                  "/items[at0008]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Group category"
+                        }
+                      ],
+                      "/value": {
+                        "value": "Group category 26"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/protocol[at0008]/items[openEHR-EHR-CLUSTER.distribution.v1 and name/value='Distribution']/items[at0008]",
+                      "/$CLASS$": "DvText"
+                    }
+                  ],
+                  "/items[at0012]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "Urgent"
+                        }
+                      ],
+                      "/value": {
+                        "value": true
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/protocol[at0008]/items[openEHR-EHR-CLUSTER.distribution.v1 and name/value='Distribution']/items[at0012]",
+                      "/$CLASS$": "DvBoolean"
+                    }
+                  ]
+                }
+              ]
+            },
+            "/other_participations": [
+              {
+                "mode": {
+                  "value": "not specified",
+                  "definingCode": {
+                    "codeString": "193",
+                    "terminologyId": {
+                      "name": "openehr",
+                      "value": "openehr"
+                    }
+                  }
+                },
+                "/name": [
+                  {
+                    "value": {
+                      "value": "other participation"
+                    }
+                  }
+                ],
+                "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-INSTRUCTION.request-procedure.v1 and name/value='Procedure request']/other_participations",
+                "/$CLASS$": "Participation",
+                "function": {
+                  "value": "performer"
+                },
+                "performer": {
+                  "name": "Nurse Bailey",
+                  "/$CLASS$": "PartyIdentified"
+                }
+              }
+            ]
+          }
+        ],
+        "/items[openEHR-EHR-ADMIN_ENTRY.inpatient_admission_uk.v1]": [
+          {
+            "/name": [
+              {
+                "value": "Inpatient admission"
+              }
+            ],
+            "/$CLASS$": "AdminEntry",
+            "/data[at0001]": {
+              "/$CLASS$": [
+                "ItemTree"
+              ],
+              "/items[at0002]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Date of admission"
+                    }
+                  ],
+                  "/value": {
+                    "value": "2015-12-02T17:41:56",
+                    "epoch_offset": 1449078116
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ADMIN_ENTRY.inpatient_admission_uk.v1 and name/value='Inpatient admission']/data[at0001]/items[at0002]",
+                  "/$CLASS$": "DvDateTime"
+                }
+              ],
+              "/items[at0003]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Admission method"
+                    }
+                  ],
+                  "/value": {
+                    "value": "D.80 description",
+                    "definingCode": {
+                      "codeString": "D.80",
+                      "terminologyId": {
+                        "name": "external_terminology",
+                        "value": "external_terminology"
+                      }
+                    }
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ADMIN_ENTRY.inpatient_admission_uk.v1 and name/value='Inpatient admission']/data[at0001]/items[at0003]",
+                  "/$CLASS$": "DvCodedText"
+                }
+              ],
+              "/items[at0009]": [
+                {
+                  "/name": [
+                    {
+                      "value": "Source of admission"
+                    }
+                  ],
+                  "/value": {
+                    "value": "Source of admission 42"
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-SECTION.adhoc.v1 and name/value='Ad hoc heading']/items[openEHR-EHR-ADMIN_ENTRY.inpatient_admission_uk.v1 and name/value='Inpatient admission']/data[at0001]/items[at0009]",
+                  "/$CLASS$": "DvText"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "context": {
+    "@class": "EVENT_CONTEXT",
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "other care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "code_string": "238",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        }
+      }
+    },
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "1970-01-01T07:00:00Z"
+    },
+    "other_context": {
+      "/$CLASS$": [
+        "ItemTree"
+      ],
+      "/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]": [
+        {
+          "/name": [
+            {
+              "value": "Context detail"
+            }
+          ],
+          "/$CLASS$": [
+            "Cluster"
+          ],
+          "/items[at0001]": [
+            {
+              "/name": [
+                {
+                  "value": "Period of care identifier"
+                }
+              ],
+              "/value": {
+                "value": "Ident. 52"
+              },
+              "/$PATH$": "/items[at0001 and name/value='Tree']/items[openEHR-EHR-CLUSTER.composition_context_detail.v1 and name/value='Context detail']/items[at0001]",
+              "/$CLASS$": "DvText"
+            }
+          ],
+          "/items[at0008]": [
+            {
+              "/name": [
+                {
+                  "value": "Tags"
+                }
+              ],
+              "/value": {
+                "value": "Tags 96"
+              },
+              "/$PATH$": "/items[at0001 and name/value='Tree']/items[openEHR-EHR-CLUSTER.composition_context_detail.v1 and name/value='Context detail']/items[at0008]",
+              "/$CLASS$": "DvText"
+            },
+            {
+              "/name": [
+                {
+                  "value": "Tags #2"
+                }
+              ],
+              "/value": {
+                "value": "Tags 96"
+              },
+              "/$PATH$": "/items[at0001 and name/value='Tree']/items[openEHR-EHR-CLUSTER.composition_context_detail.v1 and name/value='Context detail']/items[at0008]",
+              "/$CLASS$": "DvText"
+            }
+          ],
+          "/items[at0009]": [
+            {
+              "/name": [
+                {
+                  "value": "Attachment"
+                }
+              ],
+              "/value": {
+                "uri": {
+                  "value": "http://med.tube.com/sample"
+                },
+                "size": 504903212,
+                "mediaType": {
+                  "codeString": "video/mp4",
+                  "terminologyId": {
+                    "name": "IANA_media-types",
+                    "value": "IANA_media-types"
+                  }
+                },
+                "alternateText": "alternate text"
+              },
+              "/$PATH$": "/items[at0001 and name/value='Tree']/items[openEHR-EHR-CLUSTER.composition_context_detail.v1 and name/value='Context detail']/items[at0009]",
+              "/$CLASS$": "DvMultimedia"
+            }
+          ]
+        }
+      ]
+    },
+    "health_care_facility": {
+      "name": "Hospital",
+      "_type": "PARTY_IDENTIFIED",
+      "external_ref": {
+        "id": {
+          "_type": "GENERIC_ID",
+          "value": "9091",
+          "scheme": "HOSPITAL-NS"
+        },
+        "_type": "PARTY_REF",
+        "namespace": "HOSPITAL-NS"
+      }
+    }
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "Event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "code_string": "433",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      }
+    }
+  },
+  "composer": {
+    "name": "Silvia Blake",
+    "_type": "PARTY_IDENTIFIED"
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "code_string": "en",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    }
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "code_string": "GB",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    }
+  }
+}

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_composition.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_composition.json
@@ -1,0 +1,769 @@
+{
+  "uid": {
+    "_type": "OBJECT_VERSION_ID",
+    "value": "77dfa5f6-1ada-47e1-acd8-1e50c95ae8f7::local.ethercis.com::1"
+  },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "_type": "COMPOSITION",
+  "content": {
+    "/content[openEHR-EHR-SECTION.test_all_types.v1]": [
+      {
+        "/$CLASS$": [
+          "Section"
+        ],
+        "/items[at0001]": [
+          {
+            "/$CLASS$": [
+              "Section"
+            ],
+            "/items[at0002]": [
+              {
+                "/$CLASS$": [
+                  "Section"
+                ],
+                "/items[openEHR-EHR-ACTION.test_all_types.v1]": [
+                  {
+                    "/name": [
+                      {
+                        "value": "Test all types"
+                      }
+                    ],
+                    "/time": {
+                      "/name": [
+                        {
+                          "value": "Test all types"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2019-01-28T21:22:50.154Z",
+                        "epoch_offset": 1548710570
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-ACTION.test_all_types.v1 and name/value='Test all types']/time",
+                      "/$CLASS$": "DvDateTime"
+                    },
+                    "/$CLASS$": "Action",
+                    "/description[at0001]": {
+                      "/$CLASS$": [
+                        "ItemTree"
+                      ],
+                      "/items[openEHR-EHR-CLUSTER.test_all_types.v1]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Test all types"
+                            }
+                          ],
+                          "/$CLASS$": [
+                            "Cluster"
+                          ],
+                          "/items[at0001]": [
+                            {
+                              "/name": [
+                                {
+                                  "value": "cluster 5"
+                                }
+                              ],
+                              "/$CLASS$": [
+                                "Cluster",
+                                "Cluster"
+                              ],
+                              "/items[at0002]": [
+                                {
+                                  "/name": [
+                                    {
+                                      "value": "cluster 6"
+                                    }
+                                  ],
+                                  "/$CLASS$": [
+                                    "Cluster",
+                                    "Cluster"
+                                  ],
+                                  "/items[at0003]": [
+                                    {
+                                      "/name": [
+                                        {
+                                          "value": "boolean 2"
+                                        }
+                                      ],
+                                      "/value": {
+                                        "value": true
+                                      },
+                                      "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-ACTION.test_all_types.v1 and name/value='Test all types']/description[at0001]/items[openEHR-EHR-CLUSTER.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='cluster 5']/items[at0002 and name/value='cluster 6']/items[at0003]",
+                                      "/$CLASS$": "DvBoolean"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "/items[openEHR-EHR-INSTRUCTION.test_all_types.v1]": [
+                  {
+                    "/name": [
+                      {
+                        "value": "Test all types"
+                      }
+                    ],
+                    "/$CLASS$": "Instruction",
+                    "/narrative": {
+                      "/name": [
+                        {
+                          "value": "Test all types"
+                        }
+                      ],
+                      "/value": {
+                        "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-INSTRUCTION.test_all_types.v1 and name/value='Test all types']/narrative",
+                      "/$CLASS$": "DvText"
+                    },
+                    "/activities": {
+                      "/$CLASS$": [
+                        "Activity"
+                      ],
+                      "/activities[at0001]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "Current Activity"
+                            }
+                          ],
+                          "/timing": {
+                            "/value": {
+                              "value": "P1D",
+                              "formalism": "ISO8601"
+                            },
+                            "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-INSTRUCTION.test_all_types.v1 and name/value='Test all types']/activities[at0001 and name/value='Current Activity']/timing",
+                            "/$CLASS$": "DvParsable"
+                          },
+                          "/$CLASS$": "Activity",
+                          "/action_archetype_id": "openEHR-EHR-ACTION\\.test_all_types\\.v1",
+                          "/description[at0002]": {
+                            "/$CLASS$": [
+                              "ItemList"
+                            ],
+                            "/items[at0003]": [
+                              {
+                                "/name": [
+                                  {
+                                    "value": "partial date"
+                                  }
+                                ],
+                                "/value": {
+                                  "value": "2019-01-14",
+                                  "epoch_offset": 17910
+                                },
+                                "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-INSTRUCTION.test_all_types.v1 and name/value='Test all types']/activities[at0001 and name/value='Current Activity']/description[at0002]/items[at0003]",
+                                "/$CLASS$": "DvDate"
+                              }
+                            ],
+                            "/items[at0004]": [
+                              {
+                                "/name": [
+                                  {
+                                    "value": "partial datetime"
+                                  }
+                                ],
+                                "/value": {
+                                  "value": "2019-01-28T21:22:49.426Z",
+                                  "epoch_offset": 1548710569
+                                },
+                                "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[at0002 and name/value='section 3']/items[openEHR-EHR-INSTRUCTION.test_all_types.v1 and name/value='Test all types']/activities[at0001 and name/value='Current Activity']/description[at0002]/items[at0004]",
+                                "/$CLASS$": "DvDateTime"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "/items[openEHR-EHR-ADMIN_ENTRY.test_all_types.v1]": [
+              {
+                "/name": [
+                  {
+                    "value": "Test all types"
+                  }
+                ],
+                "/$CLASS$": "AdminEntry",
+                "/data[at0001]": {
+                  "/$CLASS$": "ItemSingle",
+                  "/items[at0001 and name/value='single']": {
+                    "/name": [
+                      {
+                        "value": "count 3"
+                      }
+                    ],
+                    "/value": {
+                      "magnitude": 123,
+                      "otherReferenceRanges": []
+                    },
+                    "/$PATH$": "/content[openEHR-EHR-SECTION.test_all_types.v1 and name/value='Test all types']/items[at0001 and name/value='section 2']/items[openEHR-EHR-ADMIN_ENTRY.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0002]",
+                    "/$CLASS$": "DvCount"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "/content[openEHR-EHR-EVALUATION.test_all_types.v1]": [
+      {
+        "/name": [
+          {
+            "value": "Test all types"
+          }
+        ],
+        "/$CLASS$": "Evaluation",
+        "/data[at0001]": {
+          "/$CLASS$": [
+            "ItemTree"
+          ],
+          "/items[at0003]": [
+            {
+              "/name": [
+                {
+                  "value": "interval count"
+                }
+              ],
+              "/value": {
+                "interval": {
+                  "lower": {
+                    "magnitude": 123,
+                    "otherReferenceRanges": []
+                  },
+                  "upper": {
+                    "magnitude": 234,
+                    "otherReferenceRanges": []
+                  },
+                  "lowerIncluded": true,
+                  "upperIncluded": true,
+                  "lowerUnbounded": false,
+                  "upperUnbounded": false
+                }
+              },
+              "/$PATH$": "/content[openEHR-EHR-EVALUATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0003]",
+              "/$CLASS$": "DvInterval<DvCount>"
+            }
+          ],
+          "/items[at0004]": [
+            {
+              "/name": [
+                {
+                  "value": "interval quantity"
+                }
+              ],
+              "/value": {
+                "interval": {
+                  "lower": {
+                    "units": "mm[H20]",
+                    "magnitude": 123.123,
+                    "otherReferenceRanges": []
+                  },
+                  "upper": {
+                    "units": "mm[H20]",
+                    "magnitude": 234.234,
+                    "otherReferenceRanges": []
+                  },
+                  "lowerIncluded": true,
+                  "upperIncluded": true,
+                  "lowerUnbounded": false,
+                  "upperUnbounded": false
+                }
+              },
+              "/$PATH$": "/content[openEHR-EHR-EVALUATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0004]",
+              "/$CLASS$": "DvInterval<DvQuantity>"
+            }
+          ],
+          "/items[at0005]": [
+            {
+              "/name": [
+                {
+                  "value": "interval datetime"
+                }
+              ],
+              "/value": {
+                "interval": {
+                  "lower": {
+                    "value": "2019-01-28T21:22:49.426Z",
+                    "epoch_offset": 1548710569
+                  },
+                  "upper": {
+                    "value": "2019-01-28T21:22:49.426Z",
+                    "epoch_offset": 1548710569
+                  },
+                  "lowerIncluded": true,
+                  "upperIncluded": true,
+                  "lowerUnbounded": false,
+                  "upperUnbounded": false
+                }
+              },
+              "/$PATH$": "/content[openEHR-EHR-EVALUATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0005]",
+              "/$CLASS$": "DvInterval<DvDateTime>"
+            }
+          ],
+          "/items[at0006]": [
+            {
+              "/name": [
+                {
+                  "value": "cluster 1"
+                }
+              ],
+              "/$CLASS$": [
+                "Cluster"
+              ],
+              "/items[at0007]": [
+                {
+                  "/name": [
+                    {
+                      "value": "cluster 2"
+                    }
+                  ],
+                  "/$CLASS$": [
+                    "Cluster",
+                    "Cluster"
+                  ],
+                  "/items[at0008]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "cluster 3"
+                        }
+                      ],
+                      "/$CLASS$": [
+                        "Cluster",
+                        "Cluster"
+                      ],
+                      "/items[at0010]": [
+                        {
+                          "/name": [
+                            {
+                              "value": "text 2"
+                            }
+                          ],
+                          "/value": {
+                            "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                          },
+                          "/$PATH$": "/content[openEHR-EHR-EVALUATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0006 and name/value='cluster 1']/items[at0007 and name/value='cluster 2']/items[at0008 and name/value='cluster 3']/items[at0010]",
+                          "/$CLASS$": "DvText"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "/items[at0009]": [
+            {
+              "/name": [
+                {
+                  "value": "choice"
+                }
+              ],
+              "/value": {
+                "units": "mm[H20]",
+                "magnitude": 148.01210165023804,
+                "otherReferenceRanges": []
+              },
+              "/$PATH$": "/content[openEHR-EHR-EVALUATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/items[at0009]",
+              "/$CLASS$": "DvQuantity"
+            }
+          ]
+        }
+      }
+    ],
+    "/content[openEHR-EHR-OBSERVATION.test_all_types.v1]": [
+      {
+        "/name": [
+          {
+            "value": "Test all types"
+          }
+        ],
+        "/$CLASS$": "Observation",
+        "/data[at0001]": {
+          "/name": [
+            {
+              "value": "Event Series"
+            }
+          ],
+          "/events": {
+            "/events[at0002]": [
+              {
+                "/name": [
+                  {
+                    "value": "Cualquier evento"
+                  }
+                ],
+                "/time": {
+                  "/name": [
+                    {
+                      "value": "Cualquier evento"
+                    }
+                  ],
+                  "/value": {
+                    "value": "2019-01-28T21:22:49.332Z",
+                    "epoch_offset": 1548710569
+                  },
+                  "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/time",
+                  "/$CLASS$": "DvDateTime"
+                },
+                "/$CLASS$": "PointEvent",
+                "/data[at0003]": {
+                  "/$CLASS$": [
+                    "ItemTree"
+                  ],
+                  "/items[at0004]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "text"
+                        }
+                      ],
+                      "/value": {
+                        "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0004]",
+                      "/$CLASS$": "DvText"
+                    }
+                  ],
+                  "/items[at0005]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "coded text"
+                        }
+                      ],
+                      "/value": {
+                        "value": "cHAWCHf.Kt.RNIAiZ,FVvBUdKAWQkU",
+                        "definingCode": {
+                          "codeString": "1008204",
+                          "terminologyId": {
+                            "name": "local",
+                            "value": "local"
+                          }
+                        }
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0005]",
+                      "/$CLASS$": "DvCodedText"
+                    }
+                  ],
+                  "/items[at0006]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "coded text terminology"
+                        }
+                      ],
+                      "/value": {
+                        "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                        "definingCode": {
+                          "codeString": "1004034",
+                          "terminologyId": {
+                            "name": "SNOMED-CT",
+                            "value": "SNOMED-CT"
+                          }
+                        }
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0006]",
+                      "/$CLASS$": "DvCodedText"
+                    }
+                  ],
+                  "/items[at0007]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "quantity"
+                        }
+                      ],
+                      "/value": {
+                        "units": "mg",
+                        "magnitude": 636.3397240638733,
+                        "otherReferenceRanges": []
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0007]",
+                      "/$CLASS$": "DvQuantity"
+                    }
+                  ],
+                  "/items[at0008]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "count"
+                        }
+                      ],
+                      "/value": {
+                        "magnitude": 10,
+                        "otherReferenceRanges": []
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0008]",
+                      "/$CLASS$": "DvCount"
+                    }
+                  ],
+                  "/items[at0009]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "date"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2019-01-14",
+                        "epoch_offset": 17910
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0009]",
+                      "/$CLASS$": "DvDate"
+                    }
+                  ],
+                  "/items[at0010]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "datetime"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2019-01-28T21:22:49.426Z",
+                        "epoch_offset": 1548710569
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0010]",
+                      "/$CLASS$": "DvDateTime"
+                    }
+                  ],
+                  "/items[at0011]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "datetime any"
+                        }
+                      ],
+                      "/value": {
+                        "value": "2019-01-28T21:22:49.427Z",
+                        "epoch_offset": 1548710569
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0011]",
+                      "/$CLASS$": "DvDateTime"
+                    }
+                  ],
+                  "/items[at0012]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "time"
+                        }
+                      ],
+                      "/value": {
+                        "value": "18:36:49",
+                        "epoch_offset": "18:36:49"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0012]",
+                      "/$CLASS$": "DvTime"
+                    }
+                  ],
+                  "/items[at0013]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "ordinal"
+                        }
+                      ],
+                      "/value": {
+                        "value": 0,
+                        "symbol": {
+                          "value": "ord1",
+                          "definingCode": {
+                            "codeString": "at0014",
+                            "terminologyId": {
+                              "name": "local",
+                              "value": "local"
+                            }
+                          }
+                        },
+                        "otherReferenceRanges": []
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0013]",
+                      "/$CLASS$": "DvOrdinal"
+                    }
+                  ],
+                  "/items[at0017]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "boolean"
+                        }
+                      ],
+                      "/value": {
+                        "value": true
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0017]",
+                      "/$CLASS$": "DvBoolean"
+                    }
+                  ],
+                  "/items[at0018]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "duration any"
+                        }
+                      ],
+                      "/value": {
+                        "value": "PT30M"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0018]",
+                      "/$CLASS$": "DvDuration"
+                    }
+                  ],
+                  "/items[at0020]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "parsable any"
+                        }
+                      ],
+                      "/value": {
+                        "value": "20170629",
+                        "formalism": "ISO8601"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0020]",
+                      "/$CLASS$": "DvParsable"
+                    }
+                  ],
+                  "/items[at0021]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "identifier"
+                        }
+                      ],
+                      "/value": {
+                        "id": "55175056",
+                        "type": "LOCALID",
+                        "issuer": "Hospital de Clinicas",
+                        "assigner": "Hospital de Clinicas"
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0021]",
+                      "/$CLASS$": "DvIdentifier"
+                    }
+                  ],
+                  "/items[at0022]": [
+                    {
+                      "/name": [
+                        {
+                          "value": "proportion any"
+                        }
+                      ],
+                      "/value": {
+                        "type": 1,
+                        "numerator": 1.5,
+                        "precision": 0,
+                        "denominator": 1.0,
+                        "otherReferenceRanges": []
+                      },
+                      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0022]",
+                      "/$CLASS$": "DvProportion"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "/origin": {
+            "/name": [
+              {
+                "value": "Event Series"
+              }
+            ],
+            "/value": {
+              "value": "2019-01-28T21:22:49.326Z",
+              "epoch_offset": 1548710569
+            },
+            "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/origin",
+            "/$CLASS$": "DvDateTime"
+          },
+          "/$CLASS$": "History"
+        }
+      }
+    ]
+  },
+  "context": {
+    "_time": "EVENT_CONTEXT",
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "code_string": "229",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        }
+      }
+    },
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "1970-01-01T07:00:00Z"
+    }
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "Event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "code_string": "433",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      }
+    }
+  },
+  "composer": {
+    "name": "Dr. House",
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "GENERIC_ID"
+      },
+      "_type": "PARTY_REF",
+      "namespace": "DEMOGRAPHIC"
+    }
+  },
+  "language": {
+    "_type": "CODE_PHRASE",
+    "code_string": "en",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    }
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "code_string": "UY",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    }
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "rm_version": "1.0.2",
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    }
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+}


### PR DESCRIPTION
This is a super set of EHR-450 with fixes to integrate the requested change, plus fixed EHR-163, EHR-159, EHR-160, EHR-145, full composition support.
NB. There are still some issues with AQL expression based on full composition content (f.e. a/content[xyz]) however this is circumvented by querying a known item (f.e. observation, section etc. defined by a contains clause)