### PR TITLE
Feature/update test exec instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ commands:
                       --xunit junit-output.xml --xunitskipnoncritical \
                       --log NONE \
                       --report NONE \
-                      results/ehrbase-test-output.xml
+                      results/EHRbase-output.xml
       - persist-tests-folder
       - store_test_results:
             path: ~/project/tests/results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,9 +413,9 @@ commands:
                       --removekeywords wuks \
                       --loglevel TRACE \
                       --noncritical not-ready \
-                      --output ehrbase-test-output.xml \
-                      --log ehrbase-test-log.html \
-                      --report ehrbase-test-report.html \
+                      --output EHRbase-output.xml \
+                      --log EHRbase-log.html \
+                      --report EHRbase-report.html \
                       results/*/*.xml
       - run:
             name: GENERATE TEST SUMMARY

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-# EHRBASE Integration Tests with Robot Framework
+# EHRbase Integration Tests with Robot Framework
 
 ## How to run test locally
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,9 +22,19 @@ robot ./robot/
 
 # Windows
 robot .\robot\
+
+
+# QUICK COPY/PASTE EXAMPLES TO RUN ONLY A SPECIFIC TEST-SUITE
+
+robot -i composition    -d results --noncritical not-ready -L TRACE robot/COMPOSITION_TESTS/
+robot -i contribution   -d results --noncritical not-ready -L TRACE robot/CONTRIBUTION_TESTS/
+robot -i directory      -d results --noncritical not-ready -L TRACE robot/DIRECTORY_TESTS/
+robot -i ehr_service    -d results --noncritical not-ready -L TRACE robot/EHR_SERVICE_TESTS/
+robot -i knowledge      -d results --noncritical not-ready -L TRACE robot/KNOWLEDGE_TESTS/
+robot -i aql            -d results --noncritical not-ready -L TRACE robot/QUERY_SERVICE_TESTS/
 ```
 
-The execution of **all** integration tests takes about 30 minutes (on a fast dev machine). To avoid waiting for all results you can specify exactly which test-suite you want to execute. There are six test-suites from which you can choose by passing the proper TAG to `robot` command via the `--include` (or short `-i`) option: 
+Execution of **all** integration tests takes **about 30 minutes** (on a fast dev machine). To avoid waiting for all results you can specify exactly which test-suite or even which subset of it you want to execute. There are six test-suites to choose from by passing proper TAG to `robot` command via the `--include` (or short `-i`) option: 
 
 
 TEST SUITE | SUPER TAG | SUB TAG(s) | EXAMPLE(s)

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,7 +90,7 @@ You will see `[WARN]` and `[ERROR]` in console output and in log.html
 
 After each test run Robot creates a report.html (summary) and a log.html
 (details) in results folder. The files are overwritten after each run by default.
-If you want to prevent this behavior you can [time-stamp](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#timestamping-output-files) the output files.
+If you want to keep history of your test runs you can [time-stamp](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#timestamping-output-files) the output files.
 
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@
 >
 > - Docker, Python 3 with Pip are installed
 > - RF dependencies are installed (`cd tests/`, `pip install -r requirements.txt`)
-> - No DB / no server running!
-> - ports `8080` and `5432` not used by any other application!
+> - **No DB / no server running!**
+> - ports `8080` and `5432` not used by any other application! (`netstat -tulpn`)
 
 
 ## Execution of tests under Linux, Mac and Windows

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,27 @@
 > - ports `8080` and `5432` not used by any other application!
 
 
-### Execution of tests under Linux, Mac and Windows
+## Execution of tests under Linux, Mac and Windows
+Local execution of all integration tests takes about 30 minutes. To avoid waiting for all results you can specify exactly which test-suite you want to execute. There are six test-suites from which you can choose by passing the proper TAG to `robot` command: 
+
+TEST SUITE | SUPER TAG | SUB TAGs | EXAMPLE
+-- | -- | -- | --
+COMPOSITION_TESTS   | composition   | json, json1, <br>json2, xml, <br>xml1, xml2 | `robot -i composition`
+CONTRIBUTION_TESTS  | contribution  | 0     | 21
+DIRECTORY_TESTS     | directory     | 18    | 19
+KNOWLEDGE_TESTS     | knowledge     | 24    | 4
+QUERY_SERVICE_TESTS | AQL           | 0     | 2
+EHR_SERVICE_TESTS   | ehr_service   | 9     | 10
+
+- COMPOSITION_TESTS (TAG: composition)
+- CONTRIBUTION_TESTS (TAG: )
+- DIRECTORY_TESTS (TAG: )
+- EHR_SERVICE_TESTS (TAG: )
+- KNOWLEDGE_TESTS (TAG)
+- QUERY_SERVICE_TESTS
+
+
+
 
 ```bash
 . run_local_tests.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,14 +26,17 @@ robot .\robot\
 
 The execution of **all** integration tests takes about 30 minutes (on a fast dev machine). To avoid waiting for all results you can specify exactly which test-suite you want to execute. There are six test-suites from which you can choose by passing the proper TAG to `robot` command via the `--include` (or short `-i`) option: 
 
-TEST SUITE          | SUPER TAG     | SUB TAG(s)    | EXAMPLE(s)
----                 | ---           | ---           | ---
+
+TEST SUITE | SUPER TAG | SUB TAG(s) | EXAMPLE(s)
+:----------|:----------|:-----------|:----------
 COMPOSITION_TESTS   | composition   | json, json1, json2, <br> xml, xml1, xml2 | `robot --include composition` <br> `robot -i composition` <br> `robot -i compositionANDjson`
 CONTRIBUTION_TESTS  | contribution  | commit_contribution, <br> list_contributions, <br> has_contribution, <br> get_contribution | `robot -i contribution`
 DIRECTORY_TESTS     | directory     | create_directory, <br> update_directory, <br> get_directory, <br> delete_directory, <br> get_directory_@time, <br> ...   | `robot -i composition` <br> `robot -i create_directoryORupdate_directory`
 EHR_SERVICE_TESTS   | ehr_service   | create_ehr, update_ehr, <br> has_ehr, get_ehr, <br>  ehr_status | `robot -i ehr_service`
 KNOWLEDGE_TESTS     | knowledge     | opt14 | `robot -i knowledge`
 QUERY_SERVICE_TESTS | aql           | adhoc-query, <br> stored-query, <br> register-query, <br> list-query   | `robot -i adhoc-query`
+
+
 
 The **SUPER TAG** is meant to reference *all* tests from related test-suite. The **SUB TAGs** can be used (in combination with a SUPER TAG) to further narrow down which tests to include into execution. As you can see from the examples in the table above it is possible to combine TAGs with `AND` and `OR` operators. Tags themself are case insensitive but the operators have to be upper case. In addition to `--include` or `-i` option there is also an `--exclude` / `-e` option. It is possible to combine `-i` and `-e` in one call, i.e.
 ```bash
@@ -42,7 +45,6 @@ robot -i ehr_serviceANDget_ehr -e future robot/EHR_SERVICE_TESTS/
 [Using TAGs to include/exclude tests] from execution is very well documented in [Robot Framework's User Guide].
 
 There is also a prepared [shell script] which you can use to run **all** available tests at once. You can also use it as a reference to see which [command line options] are available to the `robot` command. Check examples below to see how to execute that script on your OS: 
-
 
 ```bash
 # Linux
@@ -77,8 +79,11 @@ robot --include get_contribution \
 ## ERRORS and WARNINGS
 
 You will see `[WARN]` and `[ERROR]` in console output and in log.html
+
 `[ERROR]` --> take a closer look, probably important
+
 `[WARN]`  --> minor issues like wrong status code or keyword deprecation warning.
+
 
 > NOTE: `[WARN]	Response body content is not JSON. Content-Type is: text/html`
 >

--- a/tests/run_local_tests.sh
+++ b/tests/run_local_tests.sh
@@ -18,9 +18,114 @@
 
 
 
-# Run with localy installed RF and libraies
-robot -e libtest -e future -e circleci -e obsolete -d results --noncritical not-ready -e BDD -L TRACE robot/
+# Set desired loglevel: NONE, INFO, DEBUG, TRACE (most details)
+export LOG_LEVEL=TRACE
 
+
+# # UNCOMMENT NEXT LINE & COMMENT-OUT ALL OTHERS BELOW TO RUN ONLY 'XXX' TESTS
+# robot --include XXX --outputdir results -L $LOG_LEVEL robot/
+
+
+
+# RUN CONTRIBUTION SERVICE TESTS
+robot -i CONTRIBUTION -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/CONTRIBUTION_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name CONTRI \
+      robot/CONTRIBUTION_TESTS/
+
+# RUN COMPOSITION SERVICE TESTS
+robot -i COMPOSITION -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/COMPOSITION_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name COMPO \
+      robot/COMPOSITION_TESTS/
+
+# RUN DIRECTORY SERVICE TESTS
+robot -i directory -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/DIRECTORY_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name DIR \
+      robot/DIRECTORY_TESTS/
+
+# RUN EHR SERVICE TESTS
+robot -i EHR_SERVICE -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/EHR_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name EHR \
+      robot/EHR_SERVICE_TESTS/
+
+# RUN KNOWLEDGE SERVICE TESTS
+robot -i KNOWLEDGE -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/KNOWLEDGE_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name KNOWLEDGE \
+      robot/KNOWLEDGE_TESTS/
+
+# RUN QUERY SERVICE TESTS
+robot -i AQL -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/QUERY_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name AQL \
+      robot/QUERY_SERVICE_TESTS/
+
+
+
+# POST PROCESS & MERGE OUTPUTS
+
+# Create Log/Report with ALL DETAILS
+rebot --outputdir results \
+      --name EHRbase \
+      --exclude TODO -e future -e obsolete -e libtest \
+      --removekeywords for \
+      --removekeywords wuks \
+      --loglevel TRACE \
+      --noncritical not-ready \
+      --timestampoutputs \
+      --output EHRbase-output.xml \
+      --log EHRbase-log.html \
+      --report EHRbase-report.html \
+      results/test-suites/*/*.xml
+
+
+
+
+
+
+
+#   ██████╗  █████╗  ██████╗██╗  ██╗██╗   ██╗██████╗
+#   ██╔══██╗██╔══██╗██╔════╝██║ ██╔╝██║   ██║██╔══██╗
+#   ██████╔╝███████║██║     █████╔╝ ██║   ██║██████╔╝
+#   ██╔══██╗██╔══██║██║     ██╔═██╗ ██║   ██║██╔═══╝
+#   ██████╔╝██║  ██║╚██████╗██║  ██╗╚██████╔╝██║
+#   ╚═════╝ ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝
+#
+#   [ BACKUP ]
+#
 # NOTE: below stuff not usable with the recent pre/postcondition implementation
 # # Run with Docker | no need to install anything
 # docker run --rm -it --env HOST_UID=$(id -u) --env HOST_GID=$(id -g) --network host \
@@ -37,4 +142,4 @@ robot -e libtest -e future -e circleci -e obsolete -d results --noncritical not-
 # ## 2. Restart PostgreSQL DB container
 # docker run -e POSTGRES_USER=postgres \
 #            -e POSTGRES_PASSWORD=postgres \
-#            -d -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
+#            -d -p 5432:5432 rippleosi/ethercis-database-docker

--- a/tests/run_local_tests.sh
+++ b/tests/run_local_tests.sh
@@ -142,4 +142,4 @@ rebot --outputdir results \
 # ## 2. Restart PostgreSQL DB container
 # docker run -e POSTGRES_USER=postgres \
 #            -e POSTGRES_PASSWORD=postgres \
-#            -d -p 5432:5432 rippleosi/ethercis-database-docker
+#            -d -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5


### PR DESCRIPTION
Some enhancements to README in tests/ folder

- added quick copy/paste examples to run specific tests only
- added a table containing almost all available TAGs with examples of how to include into test run
- added OS specific notes
- added examples of `robot` command CLI options
- separate reports/logs for each test-suite for local test runs
- timestamped combined EHRbase report

