### PR TITLE
Bugfix for #43 PGObject cannot be cast to ItemStructure

### DIFF
--- a/jooq-pq/pom.xml
+++ b/jooq-pq/pom.xml
@@ -103,7 +103,7 @@
                                     <!-- Add a Java regular expression matching fully-qualified columns. Use the pipe to separate several expressions.
 
                                          If provided, both "includeExpressions" and "includeTypes" must match. -->
-                                    <expression>.*other_details.*</expression>
+                                    <expression>^(other_)?details$</expression>
                                     <!-- TODO tag name was rolled back to older version here, needs to be "includeExpressions" with newer jooq version again -->
 
                                     <!-- Add a Java regular expression matching data types to be forced to
@@ -121,6 +121,7 @@
                                     <types>.*</types>
                                     <!-- TODO tag name was rolled back to older version here, needs to be "includeTypes" with newer jooq version again -->
                                 </forcedType>
+
                             </forcedTypes>
                         </database>
                         <generate>

--- a/service/src/main/java/org/ehrbase/dao/access/interfaces/I_FolderAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/interfaces/I_FolderAccess.java
@@ -110,9 +110,9 @@ public interface I_FolderAccess extends I_SimpleCRUD<I_EntryAccess, UUID> {
 
     void setIsFolderActive(boolean folderActive);
 
-    Object getFolderDetails();
+    ItemStructure getFolderDetails();
 
-    void setFolderDetails(Object folderDetails);
+    void setFolderDetails(ItemStructure folderDetails);
 
     void setFolderSysTransaction(Timestamp folderSysTransaction);
 

--- a/service/src/main/java/org/ehrbase/dao/access/jooq/FolderAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/jooq/FolderAccess.java
@@ -137,7 +137,7 @@ public class FolderAccess extends DataAccess implements I_FolderAccess, Comparab
             }
 
             folderRecord.setSysPeriod(PGObjectParser.parseSysPeriod(folderRecord.getSysPeriod()));
-            folderRecord.setDetails(PGObjectParser.parseDetails(folderRecord.getDetails()));
+            //folderRecord.setDetails(PGObjectParser.parseDetails(folderRecord.getDetails()));
 
 
             /*update items*/
@@ -395,7 +395,7 @@ public class FolderAccess extends DataAccess implements I_FolderAccess, Comparab
      */
     private static FolderAccess buildFolderAccessFromGenericRecord(final Record record_, final I_DomainAccess domainAccess){
 
-        Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, Object, Timestamp, Timestamp> record = (Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, Object, Timestamp, Timestamp>)record_;
+        Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, ItemStructure, Timestamp, Timestamp> record = (Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, ItemStructure, Timestamp, Timestamp>)record_;
         FolderAccess folderAccess = new FolderAccess(domainAccess);
         folderAccess.folderRecord = new FolderRecord();
         folderAccess.folderRecord.setId(record.value1());
@@ -496,10 +496,10 @@ public class FolderAccess extends DataAccess implements I_FolderAccess, Comparab
         }
         //pstmt.setObject(11, jsonObject);
 
-        if (folder.getDetails() != null) {
+        /* if (folder.getDetails() != null) {
             String detailsSerialized = new CanonicalJson().marshal(folder.getDetails());
             folderAccessInstance.getFolderRecord().setDetails(PGObjectParser.parseDetails(detailsSerialized));
-        }
+        } */
 
         if(!folder.getItems().isEmpty()){
             folderAccessInstance.getItems().addAll(folder.getItems());
@@ -796,12 +796,12 @@ public class FolderAccess extends DataAccess implements I_FolderAccess, Comparab
         this.folderRecord.setActive(folderActive);
     }
 
-    public Object getFolderDetails(){
+    public ItemStructure getFolderDetails(){
 
         return this.folderRecord.getDetails();
     }
 
-    public void setFolderDetails(Object folderDetails){
+    public void setFolderDetails(ItemStructure folderDetails){
 
         this.folderRecord.setDetails(folderDetails);
     }

--- a/service/src/test/java/org/ehrbase/dao/access/jooq/FolderAccessTest.java
+++ b/service/src/test/java/org/ehrbase/dao/access/jooq/FolderAccessTest.java
@@ -363,7 +363,22 @@ public class FolderAccessTest {
         fa2.setFolderName("modifiedName");
         fa2.setFolderNArchetypeNodeId("modifiedArchetypeNodeId");
         fa2.setIsFolderActive(false);
-        fa2.setFolderDetails(DSL.field(DSL.val("{\"s\": \"modifiedValue\"}") + "::jsonb"));
+        ItemStructure is = new ItemStructure() {
+            @Override
+            public List getItems() {
+                Item item = new Item() {
+                    @Override
+                    public DvText getName() {
+                        return new DvText("modifiedValue");
+                    }
+                };
+                List<Item> items =  new ArrayList<>();
+                items.add(item);
+                return items;
+            }
+        };
+        //fa2.setFolderDetails(DSL.field(DSL.val("{\"s\": \"modifiedValue\"}") + "::jsonb"));
+        fa2.setFolderDetails(is);
         fa2.setFolderSysTransaction(new Timestamp(DateTime.now().getMillis()));
         fa2.setFolderSysPeriod(DSL.field(DSL.val("[\"2019-07-26 11:28:11.631959+02\",)") + "::tstzrange"));
 

--- a/service/src/test/java/org/ehrbase/dao/access/jooq/FolderMockDataProvider.java
+++ b/service/src/test/java/org/ehrbase/dao/access/jooq/FolderMockDataProvider.java
@@ -18,6 +18,9 @@
 
 package org.ehrbase.dao.access.jooq;
 
+import com.nedap.archie.rm.datastructures.Item;
+import com.nedap.archie.rm.datastructures.ItemStructure;
+import com.nedap.archie.rm.datavalues.DvText;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -29,6 +32,8 @@ import org.jooq.tools.jdbc.MockResult;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -75,11 +80,43 @@ public class FolderMockDataProvider implements MockDataProvider{
                 DateTime expected
                         = DateTime.parse("2019-06-13 18:10:33.76", dateTimeFormatter);
                 MockResult[] mock2 = new MockResult[1];
-                Result<Record8<UUID, UUID, String, String, Boolean, Object, Timestamp, Object>> result2 = create.newResult(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
+                Result<Record8<UUID, UUID, String, String, Boolean, ItemStructure, Timestamp, Object>> result2 = create.newResult(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
 
                 result2.add(create
-                        .newRecord(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                        .values(UUID.fromString("77750555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_4","folder_archetype.v1", true, "{\"details\": \"xxx4\"}", new Timestamp(expected.getMillis()), new Timestamp(expected.getMillis())));
+                        .newRecord(
+                                FOLDER.ID,
+                                FOLDER.IN_CONTRIBUTION,
+                                FOLDER.NAME,
+                                FOLDER.ARCHETYPE_NODE_ID,
+                                FOLDER.ACTIVE,
+                                FOLDER.DETAILS,
+                                FOLDER.SYS_TRANSACTION,
+                                FOLDER.SYS_PERIOD
+                        )
+                        .values(
+                                UUID.fromString("77750555-ec91-4025-838d-09ddb4e999cb"),
+                                UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                "folder_archetype_name_4", "folder_archetype.v1",
+                                true,
+                                //"{\"details\": \"xxx4\"}",
+                                new ItemStructure() {
+                                    @Override
+                                    public List getItems() {
+                                        Item item = new Item() {
+                                            @Override
+                                            public DvText getName() {
+                                                return new DvText("xxx4");
+                                            }
+                                        };
+                                        List<Item> items =  new ArrayList<>();
+                                        items.add(item);
+                                        return items;
+                                    }
+                                },
+                                new Timestamp(expected.getMillis()),
+                                new Timestamp(expected.getMillis())
+                        )
+                );
 
                 mock2[0] = new MockResult(1, result2);//no rows returned
                 return mock2;
@@ -90,11 +127,43 @@ public class FolderMockDataProvider implements MockDataProvider{
                 DateTime expected
                         = DateTime.parse("2019-06-13 18:10:33.76", dateTimeFormatter);
                 MockResult[] mock2 = new MockResult[1];
-                Result<Record8<UUID, UUID, String, String, Boolean, Object, Timestamp, Object>> result2 = create.newResult(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
+                Result<Record8<UUID, UUID, String, String, Boolean, ItemStructure, Timestamp, Object>> result2 = create.newResult(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
 
                 result2.add(create
-                        .newRecord(FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                        .values(UUID.fromString("8701233c-c8fd-47ba-91b5-ef9ff23c259b"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_5","folder_archetype.v1", true, "{\"details\": \"xxx5\"}", new Timestamp(expected.getMillis()), /*new Timestamp(expected.getMillis())*/null));
+                        .newRecord(
+                                FOLDER.ID,
+                                FOLDER.IN_CONTRIBUTION,
+                                FOLDER.NAME,
+                                FOLDER.ARCHETYPE_NODE_ID,
+                                FOLDER.ACTIVE,
+                                FOLDER.DETAILS,
+                                FOLDER.SYS_TRANSACTION,
+                                FOLDER.SYS_PERIOD
+                        )
+                        .values(
+                                UUID.fromString("8701233c-c8fd-47ba-91b5-ef9ff23c259b"),
+                                UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                "folder_archetype_name_5","folder_archetype.v1",
+                                true,
+                                //"{\"details\": \"xxx5\"}",
+                                new ItemStructure() {
+                                    @Override
+                                    public List getItems() {
+                                        Item item = new Item() {
+                                            @Override
+                                            public DvText getName() {
+                                                return new DvText("xxx5");
+                                            }
+                                        };
+                                        List<Item> items =  new ArrayList<>();
+                                        items.add(item);
+                                        return items;
+                                    }
+                                },
+                                new Timestamp(expected.getMillis()),
+                                /*new Timestamp(expected.getMillis())*/null
+                        )
+                );
 
                 mock2[0] = new MockResult(1, result2);//no rows returned
                 return mock2;
@@ -150,20 +219,192 @@ public class FolderMockDataProvider implements MockDataProvider{
                             = DateTime.parse("2019-06-13 18:10:33.76", dateTimeFormatter);
                     TimeZone.getTimeZone("UTC");
                     MockResult[] mock2 = new MockResult[1];
-                    Result<Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, Object, Timestamp, Object>> result2 = create.newResult(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
+                    Result<Record13<UUID, UUID, UUID, Timestamp, Object, UUID, UUID, String, String, Boolean, ItemStructure, Timestamp, Object>> result2 = create.newResult(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD);
 
                     result2.add(create
-                            .newRecord(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                            .values(UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"), new Timestamp(expected.getMillis()), "xxx1", UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_1", "folder_archetype.v1", true, "{\"details\": \"xxx1\"}", new Timestamp(expected.getMillis()), "[\"2019-08-09 09:56:52.464799+02\",)"));
+                            .newRecord(
+                                    FOLDER_HIERARCHY.PARENT_FOLDER,
+                                    FOLDER_HIERARCHY.CHILD_FOLDER,
+                                    FOLDER_HIERARCHY.IN_CONTRIBUTION,
+                                    FOLDER_HIERARCHY.SYS_TRANSACTION,
+                                    FOLDER_HIERARCHY.SYS_PERIOD,
+                                    FOLDER.ID,
+                                    FOLDER.IN_CONTRIBUTION,
+                                    FOLDER.NAME,
+                                    FOLDER.ARCHETYPE_NODE_ID,
+                                    FOLDER.ACTIVE,
+                                    FOLDER.DETAILS,
+                                    FOLDER.SYS_TRANSACTION,
+                                    FOLDER.SYS_PERIOD
+                            )
+                            .values(
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"),
+                                    new Timestamp(expected.getMillis()),
+                                    "xxx1",
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    "folder_archetype_name_1",
+                                    "folder_archetype.v1",
+                                    true,
+                                    //"{\"details\": \"xxx1\"}",
+                                    new ItemStructure() {
+                                        @Override
+                                        public List getItems() {
+                                            Item item = new Item() {
+                                                @Override
+                                                public DvText getName() {
+                                                    return new DvText("xxx1");
+                                                }
+                                            };
+                                            List<Item> items =  new ArrayList<>();
+                                            items.add(item);
+                                            return items;
+                                        }
+                                    },
+                                    new Timestamp(expected.getMillis()),
+                                    "[\"2019-08-09 09:56:52.464799+02\",)"
+                            )
+                    );
                     result2.add(create
-                            .newRecord(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                            .values(UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"), new Timestamp(expected.getMillis()), "xxx2", UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_2", "folder_archetype.v1", true, "{\"details\": \"xxx2\"}", new Timestamp(expected.getMillis()), "[\"2019-08-09 09:56:52.464799+02\",)"));
+                            .newRecord(
+                                    FOLDER_HIERARCHY.PARENT_FOLDER,
+                                    FOLDER_HIERARCHY.CHILD_FOLDER,
+                                    FOLDER_HIERARCHY.IN_CONTRIBUTION,
+                                    FOLDER_HIERARCHY.SYS_TRANSACTION,
+                                    FOLDER_HIERARCHY.SYS_PERIOD,
+                                    FOLDER.ID,
+                                    FOLDER.IN_CONTRIBUTION,
+                                    FOLDER.NAME,
+                                    FOLDER.ARCHETYPE_NODE_ID,
+                                    FOLDER.ACTIVE,
+                                    FOLDER.DETAILS,
+                                    FOLDER.SYS_TRANSACTION,
+                                    FOLDER.SYS_PERIOD
+                            )
+                            .values(
+                                    UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"),
+                                    new Timestamp(expected.getMillis()),
+                                    "xxx2",
+                                    UUID.fromString("99550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    "folder_archetype_name_2",
+                                    "folder_archetype.v1",
+                                    true,
+                                    // "{\"details\": \"xxx2\"}",
+                                    new ItemStructure() {
+                                        @Override
+                                        public List getItems() {
+                                            Item item = new Item() {
+                                                @Override
+                                                public DvText getName() {
+                                                    return new DvText("xxx2");
+                                                }
+                                            };
+                                            List<Item> items =  new ArrayList<>();
+                                            items.add(item);
+                                            return items;
+                                        }
+                                    },
+                                    new Timestamp(expected.getMillis()),
+                                    "[\"2019-08-09 09:56:52.464799+02\",)"
+                            )
+                    );
                     result2.add(create
-                            .newRecord(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                            .values(UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("77750555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"), new Timestamp(expected.getMillis()), "xxx3", UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_3", "folder_archetype.v1", true, "{\"details\": \"xxx3\"}", new Timestamp(expected.getMillis()), "[\"2019-08-09 09:56:52.464799+02\",)"));
+                            .newRecord(
+                                    FOLDER_HIERARCHY.PARENT_FOLDER,
+                                    FOLDER_HIERARCHY.CHILD_FOLDER,
+                                    FOLDER_HIERARCHY.IN_CONTRIBUTION,
+                                    FOLDER_HIERARCHY.SYS_TRANSACTION,
+                                    FOLDER_HIERARCHY.SYS_PERIOD,
+                                    FOLDER.ID,
+                                    FOLDER.IN_CONTRIBUTION,
+                                    FOLDER.NAME,
+                                    FOLDER.ARCHETYPE_NODE_ID,
+                                    FOLDER.ACTIVE,
+                                    FOLDER.DETAILS,
+                                    FOLDER.SYS_TRANSACTION,
+                                    FOLDER.SYS_PERIOD
+                            )
+                            .values(
+                                    UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("77750555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"),
+                                    new Timestamp(expected.getMillis()),
+                                    "xxx3",
+                                    UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    "folder_archetype_name_3",
+                                    "folder_archetype.v1",
+                                    true,
+                                    // "{\"details\": \"xxx3\"}",
+                                    new ItemStructure() {
+                                        @Override
+                                        public List getItems() {
+                                            Item item = new Item() {
+                                                @Override
+                                                public DvText getName() {
+                                                    return new DvText("xxx3");
+                                                }
+                                            };
+                                            List<Item> items =  new ArrayList<>();
+                                            items.add(item);
+                                            return items;
+                                        }
+                                    },
+                                    new Timestamp(expected.getMillis()),
+                                    "[\"2019-08-09 09:56:52.464799+02\",)"
+                            )
+                    );
                     result2.add(create
-                            .newRecord(FOLDER_HIERARCHY.PARENT_FOLDER, FOLDER_HIERARCHY.CHILD_FOLDER, FOLDER_HIERARCHY.IN_CONTRIBUTION, FOLDER_HIERARCHY.SYS_TRANSACTION, FOLDER_HIERARCHY.SYS_PERIOD, FOLDER.ID, FOLDER.IN_CONTRIBUTION, FOLDER.NAME, FOLDER.ARCHETYPE_NODE_ID, FOLDER.ACTIVE, FOLDER.DETAILS, FOLDER.SYS_TRANSACTION, FOLDER.SYS_PERIOD)
-                            .values(UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("8701233c-c8fd-47ba-91b5-ef9ff23c259b"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"), new Timestamp(expected.getMillis()), "xxx3", UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"), UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"), "folder_archetype_name_3", "folder_archetype.v1", true, "{\"details\": \"xxx3\"}", new Timestamp(expected.getMillis()), "[\"2019-08-09 09:56:52.464799+02\",)"));
+                            .newRecord(
+                                    FOLDER_HIERARCHY.PARENT_FOLDER,
+                                    FOLDER_HIERARCHY.CHILD_FOLDER,
+                                    FOLDER_HIERARCHY.IN_CONTRIBUTION,
+                                    FOLDER_HIERARCHY.SYS_TRANSACTION,
+                                    FOLDER_HIERARCHY.SYS_PERIOD,
+                                    FOLDER.ID,
+                                    FOLDER.IN_CONTRIBUTION,
+                                    FOLDER.NAME,
+                                    FOLDER.ARCHETYPE_NODE_ID,
+                                    FOLDER.ACTIVE,
+                                    FOLDER.DETAILS,
+                                    FOLDER.SYS_TRANSACTION,
+                                    FOLDER.SYS_PERIOD
+                            )
+                            .values(
+                                    UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("8701233c-c8fd-47ba-91b5-ef9ff23c259b"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e473cb"),
+                                    new Timestamp(expected.getMillis()),
+                                    "xxx3",
+                                    UUID.fromString("33550555-ec91-4025-838d-09ddb4e999cb"),
+                                    UUID.fromString("00550555-ec91-4025-838d-09ddb4e999cb"),
+                                    "folder_archetype_name_3",
+                                    "folder_archetype.v1",
+                                    true,
+                                    // "{\"details\": \"xxx3\"}",
+                                    new ItemStructure() {
+                                        @Override
+                                        public List getItems() {
+                                            Item item = new Item() {
+                                                @Override
+                                                public DvText getName() {
+                                                    return new DvText("xxx3");
+                                                }
+                                            };
+                                            List<Item> items =  new ArrayList<>();
+                                            items.add(item);
+                                            return items;
+                                        }
+                                    },
+                                    new Timestamp(expected.getMillis()),
+                                    "[\"2019-08-09 09:56:52.464799+02\",)"
+                            )
+                    );
 
                     mock2[0] = new MockResult(1, result2);//no rows returned
                     return mock2;


### PR DESCRIPTION
- Extended Jakes OtherDetailsJsonbBinder to also bew aware of details column for folders
- Replaced usage of PGObectParser by new binded ItemStructure
- Updated Tests for usage of ItemStructure.

@jakesmolka: 
Please give a short feedback if I correctly understand the usage of the binder. I added the regular expression as discussed. I also made them more strict since the regex `.*details.*` would break the generation of "audit_details". If we want to add more ItemStructure columns here, we must add them to the regular expression.

@lmarcoruiz: 
This seems to be the solution for the ItemStructure and also a pattern we can reuse for the SysPeriod columns of all tables.
Can you look over the FolderAccess and FolderAccessTest if the adaptions to the usage of ItemStructure instead of Object and String is correct there?
