### PR TITLE
ehrbase/project_management#68

### DIFF
--- a/api/src/main/java/org/ehrbase/api/service/ContributionService.java
+++ b/api/src/main/java/org/ehrbase/api/service/ContributionService.java
@@ -32,6 +32,14 @@ import java.util.UUID;
 public interface ContributionService extends BaseService {
 
     /**
+     * Check if given contribution exists and is part of given EHR.
+     * @param ehrId ID of EHR
+     * @param contributionId ID of contribution
+     * @return True if exists and part of EHR, false if not
+     */
+    boolean hasContribution(UUID ehrId, UUID contributionId);
+
+    /**
      * Return the Contribution with given id in given EHR.
      * @param ehrId ID of EHR
      * @param contributionId ID of contribution

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/BaseController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/BaseController.java
@@ -126,6 +126,17 @@ public abstract class BaseController {
         return extractUUIDFromStringWithError(compositionVersionedObjectUidString, "composition", "Composition not found, in fact, only UUID-type versionedObjectUids are supported");
     }
 
+    /**
+     * Helper to allow string UUID input from controllers, which throws an ObjectNotFound exception when no UUID representation
+     * can be created. This case is equal to no matching object.
+     * @param compositionVersionedObjectUidString Input String representation
+     * @throws ObjectNotFoundException when no UUID can't be created from input
+     * @return UUID representation
+     */
+    protected UUID getContributionVersionedObjectUidString(String compositionVersionedObjectUidString) {
+        return extractUUIDFromStringWithError(compositionVersionedObjectUidString, "contribution", "Contribution not found, in fact, only UUID-type versionedObjectUids are supported");
+    }
+
     // Internal abstraction layer helper, so calling methods above can invoke with meaningful error messages depending on context.
     private UUID extractUUIDFromStringWithError(String uuidString, String type, String error) {
         UUID uuid = null;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/OpenehrContributionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/OpenehrContributionController.java
@@ -121,7 +121,7 @@ public class OpenehrContributionController extends BaseController {
                                              @ApiParam(value = "", required = true) @PathVariable(value = "contribution_uid") String contributionUidString) {
 
         UUID ehrId = getEhrUuid(ehrIdString);
-        UUID contributionUid = getCompositionVersionedObjectUidString(contributionUidString);
+        UUID contributionUid = getContributionVersionedObjectUidString(contributionUidString);
 
         URI uri = URI.create(this.encodePath(getBaseEnvLinkURL() + "/rest/openehr/v1/ehr/" + ehrId.toString() + "/contribution/" + contributionUid.toString()));
 

--- a/service/src/main/java/org/ehrbase/service/ContributionServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/ContributionServiceImp.java
@@ -33,6 +33,7 @@ import org.ehrbase.api.definitions.CompositionFormat;
 import org.ehrbase.api.definitions.ServerConfig;
 import org.ehrbase.api.dto.CompositionDto;
 import org.ehrbase.api.dto.ContributionDto;
+import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
 import org.ehrbase.api.exception.UnexpectedSwitchCaseException;
 import org.ehrbase.api.service.CompositionService;
@@ -75,11 +76,33 @@ public class ContributionServiceImp extends BaseService implements ContributionS
     }
 
     @Override
-    public Optional<ContributionDto> getContribution(UUID ehrId, UUID contributionId) {
+    public boolean hasContribution(UUID ehrId, UUID contributionId) {
         //pre-step: check for valid ehrId
         if (ehrService.hasEhr(ehrId).equals(Boolean.FALSE)) {
             throw new ObjectNotFoundException("ehr", "No EHR found with given ID: " + ehrId.toString());
         }
+
+        I_ContributionAccess contributionAccess;
+        // doesn't exist on error
+        try {
+            contributionAccess = I_ContributionAccess.retrieveInstance(this.getDataAccess(), contributionId);
+        } catch (InternalServerException e) {
+            return false;
+        }
+
+        // doesn't exist on empty result, too
+        if (contributionAccess == null)
+            return false;
+        
+        // with both pre-checks about only checking of contribution is part of EHR is left
+        return contributionAccess.getEhrId().equals(ehrId);
+    }
+
+    @Override
+    public Optional<ContributionDto> getContribution(UUID ehrId, UUID contributionId) {
+        //pre-step: check for valid ehr and contribution ID
+        if (!hasContribution(ehrId, contributionId))
+            throw new ObjectNotFoundException("contribution", "Contribution with given ID does not exist");
 
         ContributionDto contribution = new ContributionDto(contributionId, retrieveUuidsOfContributionObjects(contributionId), retrieveAuditDetails(contributionId));
 


### PR DESCRIPTION
Fixes proper return status code on GET contribution with non-existing
contribution ID. Also added correct handling of non-existing EHR ID and
non-matching pair of both ID, i.e. contribution is not part of given
EHR.

fixes ehrbase/project_management#68