### PR TITLE
Adds RF keywords for DB operations - ehrbase/project_management#30

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -85,8 +85,8 @@ Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0):
 - Dockerfile Maven (https://github.com/spotify/dockerfile-maven)
 - RobotFramework (https://robotframework.org)
 - Selenium (https://www.seleniumhq.org/)
-- Json Diff (https://github.com/zgrossbart/jdd)
 - RestInstance (https://github.com/asyrjasalo/RESTinstance)
+- Robotframework-Database-Library (http://franz-see.github.io/Robotframework-Database-Library/)
 
 BSD License:
 - ANTLR 4 (http://www.antlr.org), The BSD License (see below)
@@ -110,6 +110,7 @@ Others:
 - Bouncy Castle (http://www.bouncycastle.org), Bouncy Castle Licence (see below)
 - Reflections (http://github.com/ronmamo/reflections), Do What the Fuck You Want to Public License (see http://www.wtfpl.net/)
 - JsQuery – json query language with GIN indexing support (https://github.com/postgrespro/jsquery), PostgreSQL License (see below)
+- psycopg2 - Python-PostgreSQL Database Adapter (https://github.com/psycopg/psycopg2), GNU Lesser General Public License
 	
 
 ----
@@ -563,5 +564,39 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----
+
+psycopg2 License: 
+
+GNU Lesser General Public License
+
+Copyright (c) 2010—2019 — Daniele Varrazzo
+
+psycopg2 is free software: you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+License for more details.
+
+In addition, as a special exception, the copyright holders give
+permission to link this program with the OpenSSL library (or with
+modified versions of OpenSSL that use the same license as OpenSSL),
+and distribute linked combinations including the two.
+
+You must obey the GNU Lesser General Public License in all respects for
+all of the code used other than OpenSSL. If you modify file(s) with this
+exception, you may extend this exception to your version of the file(s),
+but you are not obligated to do so. If you do not wish to do so, delete
+this exception statement from your version. If you delete this exception
+statement from all source files in the program, then also delete it here.
+
+You should have received a copy of the GNU Lesser General Public License
+along with psycopg2 (see the doc/ directory.)
+If not, see <https://www.gnu.org/licenses/>.
 
 ----

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -40,6 +40,14 @@ tasks:
         #- grep -m 1 "Started EhrBase in" <(tail -f log)   # FAIL!
         # https://github.com/go-task/task/issues/270
   
+  starteb-nocache:
+      desc: START EHRBASE SERVER WITHOUT CACHE
+      cmds:
+        - echo ... staring EHRbase server ...
+        - java -jar ../application/target/application-0.9.0.jar --cache.enabled=false > log &
+        - sleep 20
+        - echo ... EHRbase server started.
+  
   stopeb:
     desc: KILL EHRBASE SERVER
     cmds:
@@ -61,5 +69,6 @@ tasks:
     desc: RUN TESTS
     cmds:
       # adjust this part to the needs of your current test session
-      - robot -e future -i xxx -d results -L TRACE --noncritical not-ready robot/CONTRIBUTION_TESTS
+      - robot -e future -e circleci -e TODO -e obsolete -d results -L TRACE --noncritical not-ready robot/QUERY_SERVICE_TESTS
+      # example of "execute single test by it's test-case name" (wildcards accepted):
       # - robot -t "*commit CONTRIBUTIONS versioning persistent COMPOSITION" -d results -L TRACE robot/CONTRIBUTION_TESTS

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,14 @@
 robotframework == 3.1.2
 
 robotframework-jsonlibrary == 0.3.1
-# git+https://github.com/adiralashiva8/robotframework-metrics@v3.1.4
 robotframework-requests == 0.4.7
 robotframework-seleniumlibrary == 3.3.1
+robotframework-databaselibrary == 1.2.4
 RESTinstance == 1.0.0
+
 docker == 4.0.2
-# jsondiff == 1.1.2
 deepdiff == 4.0.6
+psycopg2-binary == 2.8.4
+
 # pyjwt
+# git+https://github.com/adiralashiva8/robotframework-metrics@v3.1.4

--- a/tests/robot/COMPOSITION_TESTS/JSON1/__init__.robot
+++ b/tests/robot/COMPOSITION_TESTS/JSON1/__init__.robot
@@ -27,11 +27,12 @@ Documentation    COMPOSITION TEST SUITE
 
 Resource    ${CURDIR}${/}../../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/generic_keywords.robot
+Resource    ${CURDIR}${/}../../_resources/keywords/db_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/composition_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/template_opt1.4_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/ehr_keywords.robot
 
-Suite Setup  startup SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup SUT
+# Suite Teardown  shutdown SUT
 
 Force Tags    JSON1

--- a/tests/robot/COMPOSITION_TESTS/JSON2/B.8.c_alternative_flow_1_delete_non_existent_COMPOSITION.robot
+++ b/tests/robot/COMPOSITION_TESTS/JSON2/B.8.c_alternative_flow_1_delete_non_existent_COMPOSITION.robot
@@ -44,4 +44,4 @@ Alternative flow 2 delete non existent COMPOSITION
 
     delete non-existent composition
 
-    # [Teardown]    restart SUT
+    [Teardown]    restart SUT

--- a/tests/robot/COMPOSITION_TESTS/JSON2/__init__.robot
+++ b/tests/robot/COMPOSITION_TESTS/JSON2/__init__.robot
@@ -27,11 +27,12 @@ Documentation    COMPOSITION TEST SUITE
 
 Resource    ${CURDIR}${/}../../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/generic_keywords.robot
+Resource    ${CURDIR}${/}../../_resources/keywords/db_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/composition_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/template_opt1.4_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/ehr_keywords.robot
 
-Suite Setup  startup SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup SUT
+# Suite Teardown  shutdown SUT
 
 Force Tags    JSON2

--- a/tests/robot/COMPOSITION_TESTS/XML1/__init__.robot
+++ b/tests/robot/COMPOSITION_TESTS/XML1/__init__.robot
@@ -27,11 +27,12 @@ Documentation    COMPOSITION TEST SUITE
 
 Resource    ${CURDIR}${/}../../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/generic_keywords.robot
+Resource    ${CURDIR}${/}../../_resources/keywords/db_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/composition_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/template_opt1.4_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/ehr_keywords.robot
 
-Suite Setup  startup SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup SUT
+# Suite Teardown  shutdown SUT
 
 Force Tags    XML1

--- a/tests/robot/COMPOSITION_TESTS/XML2/__init__.robot
+++ b/tests/robot/COMPOSITION_TESTS/XML2/__init__.robot
@@ -27,11 +27,12 @@ Documentation    COMPOSITION TEST SUITE
 
 Resource    ${CURDIR}${/}../../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/generic_keywords.robot
+Resource    ${CURDIR}${/}../../_resources/keywords/db_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/composition_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/template_opt1.4_keywords.robot
 Resource    ${CURDIR}${/}../../_resources/keywords/ehr_keywords.robot
 
-Suite Setup  startup SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup SUT
+# Suite Teardown  shutdown SUT
 
 Force Tags    XML2

--- a/tests/robot/COMPOSITION_TESTS/__init__.robot
+++ b/tests/robot/COMPOSITION_TESTS/__init__.robot
@@ -27,11 +27,12 @@ Documentation    COMPOSITION TEST SUITE
 
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/generic_keywords.robot
+Resource    ${CURDIR}${/}../_resources/keywords/db_keywords.robot
 Resource    ${CURDIR}${/}../_resources/keywords/composition_keywords.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 Resource    ${CURDIR}${/}../_resources/keywords/ehr_keywords.robot
 
-# Suite Setup  startup SUT
-# Suite Teardown  shutdown SUT
+Suite Setup  startup SUT
+Suite Teardown  shutdown SUT
 
 Force Tags    COMPOSITION

--- a/tests/robot/KNOWLEDGE_TESTS/C.1.a_validate_valid_OPTs.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.1.a_validate_valid_OPTs.robot
@@ -38,8 +38,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14    future
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.1.b_validate_invalid_OPTs.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.1.b_validate_invalid_OPTs.robot
@@ -39,8 +39,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14    future
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.2.a_upload_valid_OPTs.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.2.a_upload_valid_OPTs.robot
@@ -38,8 +38,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.2.b_upload_invalid_OPTs.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.2.b_upload_invalid_OPTs.robot
@@ -39,8 +39,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.2.c_upload_valid_OPT_twice_with_conflict.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.2.c_upload_valid_OPT_twice_with_conflict.robot
@@ -41,8 +41,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.3.a_retrieve_single_OPT.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.3.a_retrieve_single_OPT.robot
@@ -40,8 +40,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.3.b_empty_server_OPT_retrieve_fail_test.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.3.b_empty_server_OPT_retrieve_fail_test.robot
@@ -39,8 +39,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.3.c_retrieve_last_version_of_versioned_OPT.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.3.c_retrieve_last_version_of_versioned_OPT.robot
@@ -41,7 +41,7 @@ Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
 # Suite Setup  startup OPT SUT
-# Suite Teardown  shutdown SUT
+# Suite Teardown  Delete All Templates
 
 Force Tags   OPT14    future
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.3.d_retrieve_specific_version_of_versioned_OPT.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.3.d_retrieve_specific_version_of_versioned_OPT.robot
@@ -41,7 +41,7 @@ Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
 # Suite Setup  startup OPT SUT
-# Suite Teardown  shutdown SUT
+# Suite Teardown  Delete All Templates
 
 Force Tags   OPT14    future
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.4.a_retrieve_all_loaded_OPTs.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.4.a_retrieve_all_loaded_OPTs.robot
@@ -40,8 +40,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14    refactor
 

--- a/tests/robot/KNOWLEDGE_TESTS/C.4.b_retrieve_all_loaded_OPTs_when_none_is_loaded.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/C.4.b_retrieve_all_loaded_OPTs_when_none_is_loaded.robot
@@ -38,8 +38,8 @@ Documentation   OPT1.4 integration tests
 Resource    ${CURDIR}${/}../_resources/suite_settings.robot
 Resource    ${CURDIR}${/}../_resources/keywords/template_opt1.4_keywords.robot
 
-Suite Setup  startup OPT SUT
-Suite Teardown  shutdown SUT
+# Suite Setup  startup OPT SUT
+Suite Teardown  Delete All Templates
 
 Force Tags   OPT14
 

--- a/tests/robot/KNOWLEDGE_TESTS/__init__.robot
+++ b/tests/robot/KNOWLEDGE_TESTS/__init__.robot
@@ -25,12 +25,16 @@ Documentation    KNOWLEDGE TEST SUITE
 ...             https://docs.google.com/document/d/1wdklJROuC2UQQK6x1cjPkF1l9Na2spfEIBjRbNVK-Q0
 ...             https://vitasystemsgmbh.atlassian.net/wiki/spaces/ETHERCIS/pages/520912897/Knowledge+Test+Suite
 ...
-...             integration tests
-...             opt = operational template
+...             OPT = operational template
 ...
 ...             Precondtions for (manual) exectuion:
-...               1. file_repo/knowledge/operational_templates folder is empty
 ...               2. DB container started
 ...               3. openehr-server started
-...
+
+Resource    ${CURDIR}${/}../_resources/suite_settings.robot
+Resource    ${CURDIR}${/}../_resources/keywords/generic_keywords.robot
+
+Suite Setup  startup SUT
+Suite Teardown  shutdown SUT
+
 Force Tags    KNOWLEDGE  DEFINITION

--- a/tests/robot/_resources/keywords/db_keywords.robot
+++ b/tests/robot/_resources/keywords/db_keywords.robot
@@ -1,0 +1,76 @@
+# Copyright (c) 2019 Wladislaw Wagner (Vitasystems GmbH), Pablo Pazos (Hannover Medical School).
+#
+# This file is part of Project EHRbase
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+*** Settings ***
+Library           DatabaseLibrary
+Library           OperatingSystem
+Library           Collections
+
+
+
+*** Variables ***
+${DBHost}         localhost
+${DBName}         ehrbase
+${DBPass}         postgres
+${DBPort}         5432
+${DBUser}         postgres
+
+
+
+*** Keywords ***
+Connect With DB
+    [Documentation]     Establishes a database connection over psycopg2 PostgreSQL adapter.
+
+                        Connect To Database    psycopg2    ${DBName}    ${DBUser}    ${DBPass}
+                        ...                                ${DBHost}    ${DBPort}
+
+Delete All Templates
+    [Documentation]     Deletes all templates from ehr.template_store table.
+    ...                 Is meant to be used with EHRbase server started with disabled Cache
+    ...                 e.g. `java -jar ehrbase-server.jar --cache.enabled=false`
+
+                        Connect With DB
+                        Delete All Rows From Table    ehr.template_store
+
+    [Teardown]          Disconnect From Database
+
+
+Get Information About DB Table
+    [Documentation]     Provides infos about columns and their types of given table.
+    ...                 table name exaples:
+    ...                 ehr.ehr
+    ...                 ehr.composition
+    ...                 ehr.contribution
+    ...                 ehr.folder
+    ...                 ehr.template_store
+
+    [Arguments]         ${table_name}
+
+    @{output} =         Description    SELECT * FROM ${table_name}
+                        Log Many    @${output}
+
+
+Count Rows In DB Table
+    [Documentation]     Provides infos about amout of rows in given table.
+    [Arguments]         ${table_name}
+
+    ${rowCount}	=       Row Count    SELECT * FROM ${table_name}
+                        Log    ${rowCount}
+
+# check https://github.com/franz-see/Robotframework-Database-Library/blob/master/test/PostgreSQL_DB_Tests.robot
+# for more examples

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -127,11 +127,12 @@ compare json-file with json-string
 
 
 restart SUT
-    stop openehr server
-    stop and remove ehrdb
-    empty operational_templates folder
-    start ehrdb
-    start openehr server
+    # stop openehr server
+    # stop and remove ehrdb
+    # empty operational_templates folder
+    # start ehrdb
+    # start openehr server
+    Delete All Templates
 
 
 get application version
@@ -180,13 +181,16 @@ start openehr server
 
 
 start server process without coverage
-    ${result}=  Start Process  java  -jar  ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
-    ...                              alias=ehrserver  cwd=${PROJECT_ROOT}  stdout=stdout.txt
+    ${result}=          Start Process  java  -jar  ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
+                        ...                  --cache.enabled\=false    alias=ehrserver 
+                        ...                    cwd=${PROJECT_ROOT}    stdout=stdout.txt    stderr=stderr.txt
 
 
 start server process with coverage
-    ${result}=  Start Process  java  -javaagent:${JACOCO_LIB_PATH}/jacocoagent.jar\=output\=tcpserver,address\=127.0.0.1  -jar  ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
-    ...                              alias=ehrserver  cwd=${PROJECT_ROOT}  stdout=stdout.txt  stderr=stderr.txt
+    ${result}=          Start Process  java  -javaagent:${JACOCO_LIB_PATH}/jacocoagent.jar\=output\=tcpserver,address\=127.0.0.1
+                        ...                  -jar    ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
+                        ...                  --cache.enabled\=false    alias=ehrserver
+                        ...                    cwd=${PROJECT_ROOT}    stdout=stdout.txt    stderr=stderr.txt
 
 
 wait until openehr server is ready

--- a/tests/robot/_resources/keywords/template_opt1.4_keywords.robot
+++ b/tests/robot/_resources/keywords/template_opt1.4_keywords.robot
@@ -31,18 +31,6 @@ ${INVALID DATA SETS}   ${PROJECT_ROOT}${/}tests${/}robot${/}_resources${/}test_d
 
 
 *** Keywords ***
-startup OPT SUT
-    [Documentation]     Test-Suite Setup for ADL 1.4 OPT tests
-    ...                 This keyword overrides the one with same name from
-    ...                 "generic_keywords.robot" file
-
-                        get application version
-			                  unzip file_repo_content.zip
-                        empty operational_templates folder
-                        start ehrdb
-                        start openehr server
-
-
 get valid OPT file
     [Arguments]         ${opt file}
     [Documentation]     Gets an OPT file from test_data_sets/valid_templates folder

--- a/tests/robot/_resources/suite_settings.robot
+++ b/tests/robot/_resources/suite_settings.robot
@@ -33,6 +33,7 @@ Library    DateTime
 Library    ${CURDIR}${/}../_resources/libraries/dockerlib.py
 Library    ${CURDIR}${/}../_resources/libraries/jsonlib.py
 Resource   ${CURDIR}${/}../_resources/keywords/generic_keywords.robot
+Resource   ${CURDIR}${/}../_resources/keywords/db_keywords.robot
 
 
 


### PR DESCRIPTION
- created db_keywords resource file with first DB keywords:
  - Connect With DB
  - Delete All Templates
  - Get Information About DB Table
  - Count Rows In DB Table
- changed "restart SUT" behaviour to do only one thing: Delete All Templates
- disabled ehrbase server cache during test execution
- added robotframework-databaselibrary and required dependencies
- added license information of new test dependencies
- added new task to Taskfile.yml: start ehrbase server without cache
- adjusted some __init__ files and tests  to work with new "restart SUT" behavior
- updated KNOWLEDGE tests
  - removed obsolete SUT restarts to speed up test execution
  - replaced restarts with "Delete All Templates" kw