### PR TITLE
fix #37 by using LinkedHashMap

### DIFF
--- a/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
@@ -49,7 +49,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -104,7 +104,7 @@ public class QueryServiceImp extends BaseService implements QueryService {
 
         List<Map<String, Object>> resultList = new ArrayList<>();
         for (Record record : aqlResult.getRecords()) {
-            Map<String, Object> fieldMap = new HashMap<>();
+            Map<String, Object> fieldMap = new LinkedHashMap<>();
             for (Field field : record.fields()) {
                 if (record.getValue(field) instanceof JsonElement){
                     fieldMap.put(field.getName(), new StructuredString(((JsonElement) record.getValue(field)).toString(), StructuredStringFormat.JSON));


### PR DESCRIPTION
LinkedHashMap maintains insertion order but still provides access in O(1). I think this is a good way to get a consistent behaviour without any negative effects. 