### PR TITLE
fix #68 by exporting cluster/name/value

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/ArrayClosure.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/ArrayClosure.java
@@ -28,11 +28,13 @@ public class ArrayClosure {
     JsonWriter writer;
     String parentItemsArchetypeNodeId = null;
     String parentItemsType = null;
+    String parentItemsName = null;
 
-    public ArrayClosure(JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType) {
+    public ArrayClosure(JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType, String parentItemsName) {
         this.writer = writer;
         this.parentItemsArchetypeNodeId = parentItemsArchetypeNodeId;
         this.parentItemsType = parentItemsType;
+        this.parentItemsName = parentItemsName;
     }
 
     /**
@@ -41,8 +43,11 @@ public class ArrayClosure {
     public void close() throws IOException {
         if (parentItemsArchetypeNodeId != null)
             writer.name(I_DvTypeAdapter.ARCHETYPE_NODE_ID).value(parentItemsArchetypeNodeId);
-        if (parentItemsType != null)
+        if (parentItemsType != null) {
             writer.name(I_DvTypeAdapter.AT_CLASS).value(parentItemsType);
+            if(parentItemsType.equals("CLUSTER"))
+                writer.name(I_DvTypeAdapter.NAME).beginObject().name(I_DvTypeAdapter.VALUE).value(parentItemsName).endObject();
+        }
     }
 
     public void start() throws IOException {

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
@@ -72,10 +72,12 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
 
         String parentItemsArchetypeNodeId = null;
         String parentItemsType = null;
+        String parentItemsName = null;
 
         if (isItemsOnly || isMultiEvents) {
             //promote archetype node id and type at parent level
             //get the archetype node id
+            //get the items name
             if (map.containsKey(I_DvTypeAdapter.ARCHETYPE_NODE_ID)) {
                 parentItemsArchetypeNodeId = (String) map.get(I_DvTypeAdapter.ARCHETYPE_NODE_ID);
                 map.remove(I_DvTypeAdapter.ARCHETYPE_NODE_ID);
@@ -88,21 +90,24 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
                 parentItemsType = new SnakeCase((String) ((ArrayList) map.get(CompositionSerializer.TAG_CLASS)).get(0)).camelToUpperSnake();
                 map.remove(CompositionSerializer.TAG_CLASS);
             }
+            if (map.containsKey(CompositionSerializer.TAG_NAME)) {
+                parentItemsName = (String)((LinkedTreeMap)((ArrayList) map.get(CompositionSerializer.TAG_NAME)).get(0)).get("value");
+                map.remove(CompositionSerializer.TAG_NAME);
+            }
         } else if (isMultiContent) {
             if (map.containsKey(I_DvTypeAdapter.ARCHETYPE_NODE_ID)) {
                 parentItemsArchetypeNodeId = (String) map.get(I_DvTypeAdapter.ARCHETYPE_NODE_ID);
                 map.remove(I_DvTypeAdapter.ARCHETYPE_NODE_ID);
             }
         }
-
         if (isItemsOnly) {
             //CHC 20191003: Removed archetype_node_id writer since it is serviced by closing the array.
             ArrayList items = new Children(map).items();
-            writeItemInArray(ITEMS, items, writer, parentItemsArchetypeNodeId, parentItemsType);
+            writeItemInArray(ITEMS, items, writer, parentItemsArchetypeNodeId, parentItemsType, parentItemsName);
         } else if (isMultiEvents) {
             //assumed sorted (LinkedTreeMap preserve input order)
             ArrayList events = new Children(map).events();
-            writeItemInArray(EVENTS, events, writer, parentItemsArchetypeNodeId, parentItemsType);
+            writeItemInArray(EVENTS, events, writer, parentItemsArchetypeNodeId, parentItemsType, parentItemsName);
         } else if (isMultiContent) {
 //            Iterator iterator = map.keySet().iterator();
             String key = map.keySet().iterator().next().toString();
@@ -269,8 +274,8 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
      * @return
      * @throws IOException
      */
-    private void writeItemInArray(String heading, ArrayList value, JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType) throws IOException {
-        new ArrayClosure(writer, parentItemsArchetypeNodeId, parentItemsType).start();
+    private void writeItemInArray(String heading, ArrayList value, JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType, String parentItemsName) throws IOException {
+        new ArrayClosure(writer, parentItemsArchetypeNodeId, parentItemsType, parentItemsName).start();
         if (value.isEmpty()) {
             return;
         }


### PR DESCRIPTION
This PR fixes the missing representation of name/value in clusters when using the raw format (XML and JSON).