### PR TITLE
detect duplicate aliases in aql select

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/compiler/QueryCompilerPass2.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/QueryCompilerPass2.java
@@ -24,6 +24,7 @@ package org.ehrbase.aql.compiler;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ehrbase.aql.definition.*;
@@ -73,7 +74,7 @@ public class QueryCompilerPass2 extends AqlBaseListener {
 
         if (identifiedPathContext != null) {
             VariableDefinition variableDefinition = new IdentifiedPathVariable(identifiedPathContext, selectExprContext, isDistinct).definition();
-            variableStack.push(variableDefinition);
+            pushVariableDefinition(variableDefinition);
         } else if (selectExprContext.stdExpression() != null) {
             //function handling
             logger.debug("Found standard expression");
@@ -93,7 +94,7 @@ public class QueryCompilerPass2 extends AqlBaseListener {
                     if (pathTree instanceof AqlParser.IdentifiedPathContext) {
                         AqlParser.IdentifiedPathContext pathContext = (AqlParser.IdentifiedPathContext) pathTree;
                         VariableDefinition variableDefinition = new IdentifiedPathVariable(pathContext, selectExprContext, false).definition();
-                        variableStack.push(variableDefinition);
+                        pushVariableDefinition(variableDefinition);
                         parameters.add(new FuncParameter(FuncParameterType.VARIABLE, variableDefinition.getAlias()));
                     } else if (pathTree instanceof AqlParser.OperandContext) {
                         parameters.add(new FuncParameter(FuncParameterType.OPERAND, pathTree.getText()));
@@ -105,7 +106,7 @@ public class QueryCompilerPass2 extends AqlBaseListener {
                 String alias = selectExprContext.IDENTIFIER() == null ? name : selectExprContext.IDENTIFIER().getText();
                 String path = functionContext.getText();
                 FunctionDefinition definition = new FunctionDefinition(name, alias, path, parameters);
-                variableStack.push(definition);
+                pushVariableDefinition(definition);
             }
             if (selectExprContext.stdExpression().extension() != null) {
                 logger.debug("Found extension");
@@ -114,11 +115,34 @@ public class QueryCompilerPass2 extends AqlBaseListener {
                 String parsableExpression = extensionContext.getChild(4).getText();
                 String alias = selectExprContext.IDENTIFIER() == null ? "_alias_" + Math.abs(new Random().nextLong()) : selectExprContext.IDENTIFIER().getText();
                 ExtensionDefinition definition = new ExtensionDefinition(context, parsableExpression, alias);
-                variableStack.push(definition);
+                pushVariableDefinition(definition);
             }
 
         } else
             throw new IllegalArgumentException("Could not interpret select context");
+    }
+
+    private void pushVariableDefinition(I_VariableDefinition variableDefinition){
+        isUnique(variableDefinition);
+        variableStack.push(variableDefinition);
+    }
+
+    /**
+     * check if a variable definition is unique (e.g. new aliase)
+     * @param variableDefinition
+     */
+    private void isUnique(I_VariableDefinition variableDefinition) {
+
+        //allow duplicate aliases whe used in function expressions
+        if (variableDefinition.isFunction())
+            return;
+
+        String alias = variableDefinition.getAlias();
+
+        for (I_VariableDefinition stackedVariableDefinition: variableStack){
+            if (!StringUtils.isEmpty(stackedVariableDefinition.getAlias()) && stackedVariableDefinition.getAlias().equals(alias))
+                throw new IllegalArgumentException("Duplicated alias detected:"+alias);
+        }
     }
 
 //    @Override

--- a/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
@@ -26,6 +26,7 @@ import org.jooq.DSLContext;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Created by christian on 4/1/2016.
@@ -84,6 +85,25 @@ public class AqlExpressionTest {
         assertThat(statements.getVariables()).isNotNull();
         assertThat(statements.getWhereClause()).isNotNull();
 
+    }
+
+    @Test
+    public void testRejectDuplicateAliases() {
+
+        String query = "SELECT o/data[at0002]/events[at0003] AS value, o/data[at0003]/events[at0004] as value\n" +
+                "FROM EHR [ehr_id/value='1234'] \n" +
+                "CONTAINS COMPOSITION c [openEHR-EHR-COMPOSITION.encounter.v1] \n" +
+                "CONTAINS OBSERVATION o [openEHR-EHR-OBSERVATION.blood_pressure.v1]";
+
+        AqlExpression cut = new AqlExpression().parse(query);
+
+        try {
+            new Statements(cut.getParseTree(), new Contains(cut.getParseTree()).process().getIdentifierMapper()).process();
+            fail("duplicate alias has not been detected");
+        }
+        catch (IllegalArgumentException e){
+
+        }
     }
 
 


### PR DESCRIPTION
duplicated aliases in select are now rejected unless used in a function.