### PR TITLE
json blocks as strings, correct archetype node and names id in contents

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/ItemStack.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/ItemStack.java
@@ -42,9 +42,9 @@ public class ItemStack {
     private Logger log = LoggerFactory.getLogger(this.getClass());
 
     //contains the ADL path to an element
-    private Stack<String> pathStack = new Stack<String>();
+    private Stack<String> pathStack = new Stack<>();
     //contains the named path to an element (used to bind Flat JSON)
-    private Stack<String> namedStack = new Stack<String>();
+    private Stack<String> namedStack = new Stack<>();
 
 
     //used to resolve and index containments
@@ -52,7 +52,7 @@ public class ItemStack {
         private String label;
         private String fullPath; //full path
 
-        public ContainmentStruct(String archetype, String path) {
+        ContainmentStruct(String archetype, String path) {
             this.label = archetype;
             this.fullPath = path;
         }
@@ -61,21 +61,18 @@ public class ItemStack {
             return label;
         }
 
-        public String getFullPath() {
+        String getFullPath() {
             return fullPath;
         }
     }
 
-    private Stack<ContainmentStruct> containmentStack = new Stack<ContainmentStruct>();
+    private Stack<ContainmentStruct> containmentStack = new Stack<>();
 
     private Map<String, String> ltreeMap = new TreeMap<>();
 
     public Map<String, String> getLtreeMap() {
         return ltreeMap;
     }
-
-    private int floorPathStack = 0;
-    private int floorNamedStack = 0;
 
     //replace all dots by underscore and keep only the archetype name part
     public static String normalizeLabel(String path) {
@@ -86,7 +83,9 @@ public class ItemStack {
 
         //replace all dots by underscores since it is used as delimiter in a dotted labels expression for ltree
         //only A-Za-z0-9_ are allowed to express a label
-        label = label.replaceAll("\\.", "_").replaceAll("\\-", "_");
+        label = label.replaceAll("\\.", "_").replaceAll("-", "_");
+        if (label.endsWith("]"))
+            label = label.substring(0, label.indexOf("]"));
         return label;
     }
 
@@ -104,9 +103,7 @@ public class ItemStack {
         //get the last element on stack
         ContainmentStruct containmentStruct = containmentStack.lastElement();
 //        System.out.println(containmentStruct.getLabel() + "-->" + containmentStruct.getFullPath());
-        if (ltreeMap.containsKey(containmentStruct.getLabel())) {
-            //log.warn("CONTAINMENT: ltree map already contain key:"+containmentStruct.getLabel());
-        } else
+        if (!ltreeMap.containsKey(containmentStruct.getLabel()))
             ltreeMap.put(containmentStruct.getLabel(), containmentStruct.getFullPath());
     }
 
@@ -153,56 +150,34 @@ public class ItemStack {
         popStack(namedStack);
     }
 
-    private void pushStack(Stack stack, String s) {
-//        log.debug("-- PUSH PATH:" + s);
+    private void pushStack(Stack<String> stack, String s) {
         stack.push(s);
-        floorPathStack++;
-//		log.debug("FLOOR:"+floorPathStack+"->"+s);
     }
 
-    private String popStack(Stack stack) {
+    private String popStack(Stack<String> stack) {
         if (!stack.empty()) {
-            String path = (String) stack.pop();
-            floorPathStack--;
-            return path;
-//			log.debug("FLOOR:"+floorPathStack);
+            return stack.pop();
         }
         return null;
     }
 
-//    private void pushNamedStack(String s){
-//        log.debug("-- PUSH NAMED:" + s);
-//        namedStack.push(s);
-//        floorNamedStack++;
-////		log.debug("FLOOR:"+floorNamedStack+"->"+s);
-//    }
-//
-//    private void popNamedStack(){
-//        log.debug("-- POP  NAMED:"+ (namedStack.isEmpty() ? "*empty*":namedStack.lastElement()));
-//        if (!namedStack.empty()){
-//            namedStack.pop();
-//            floorNamedStack--;
-////			log.debug("FLOOR:"+floorPathStack);
-//        }
-//    }
-
-    public String stackDump(Stack stack) {
-        StringBuffer b = new StringBuffer();
+    private String stackDump(Stack stack) {
+        StringBuilder b = new StringBuilder();
         for (Object s : stack.toArray()) b.append((String) s);
         return b.toString();
     }
 
     public String namedStackDump() {
-        StringBuffer b = new StringBuffer();
-        for (Object s : namedStack.toArray()) b.append(s + "/");
+        StringBuilder b = new StringBuilder();
+        for (Object s : namedStack.toArray()) b.append(s).append("/");
         return b.toString();
     }
 
     public String expandedStackDump() {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         int i = 0;
         for (Object s : namedStack.toArray()) {
-            b.append(s + "{{" + pathStack.get(i++) + "}}/");
+            b.append(s).append("{{").append(pathStack.get(i++)).append("}}/");
         }
         return b.toString();
 

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/ArrayClosure.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/ArrayClosure.java
@@ -19,8 +19,6 @@
 package org.ehrbase.ehr.encode.wrappers.json.writer.translator_db2raw;
 
 import com.google.gson.stream.JsonWriter;
-import com.nedap.archie.rm.datastructures.Cluster;
-import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import org.ehrbase.ehr.encode.wrappers.json.I_DvTypeAdapter;
 
 import java.io.IOException;
@@ -28,28 +26,23 @@ import java.io.IOException;
 public class ArrayClosure {
 
     JsonWriter writer;
-    String parentItemsArchetypeNodeId = null;
-    String parentItemsType = null;
-    String parentItemsName = null;
+    private String parentItemsArchetypeNodeId;
+    private String parentItemsType;
 
-    public ArrayClosure(JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType, String parentItemsName) {
+    ArrayClosure(JsonWriter writer, String parentItemsArchetypeNodeId, String parentItemsType) {
         this.writer = writer;
         this.parentItemsArchetypeNodeId = parentItemsArchetypeNodeId;
         this.parentItemsType = parentItemsType;
-        this.parentItemsName = parentItemsName;
     }
 
     /**
      * close an item array
      */
-    public void close() throws IOException {
+    private void close() throws IOException {
         if (parentItemsArchetypeNodeId != null)
             writer.name(I_DvTypeAdapter.ARCHETYPE_NODE_ID).value(parentItemsArchetypeNodeId);
-        if (parentItemsType != null) {
+        if (parentItemsType != null)
             writer.name(I_DvTypeAdapter.AT_CLASS).value(parentItemsType);
-            if(parentItemsType.equals(ArchieRMInfoLookup.getInstance().getTypeInfo(Cluster.class).getRmName()))
-                writer.name(I_DvTypeAdapter.NAME).beginObject().name(I_DvTypeAdapter.VALUE).value(parentItemsName).endObject();
-        }
     }
 
     public void start() throws IOException {

--- a/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
@@ -22,6 +22,7 @@
 package org.ehrbase.aql.sql.postprocessing;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.ehrbase.aql.sql.QuerySteps;
 import org.ehrbase.aql.sql.binding.JsonbBlockDef;
 import org.ehrbase.ehr.knowledge.I_KnowledgeCache;
@@ -47,15 +48,17 @@ public class RawJsonTransform implements I_RawJsonTransform {
         this.context = context;
     }
 
+    @SuppressWarnings("unchecked")
     public static void toRawJson(Result<Record> result, Collection<QuerySteps> querySteps, I_KnowledgeCache knowledgeCache) {
 
         for (QuerySteps queryStep : querySteps) {
             if (queryStep.jsonColumnsSize() > 0) {
-                for (int cursor = 0; cursor < result.size(); cursor++) {
-                    Record record = result.get(cursor);
+                result.forEach(record -> {
                     List<JsonbBlockDef> deleteList = new ArrayList<>();
                     for (JsonbBlockDef jsonbBlockDef : queryStep.getJsonColumns()) {
-                        String jsonbOrigin = (String) record.getValue(jsonbBlockDef.getField());
+
+                        String jsonbOrigin = record.getValue(jsonbBlockDef.getField()).toString();
+
                         if (jsonbOrigin == null)
                             continue;
                         //apply the transformation
@@ -71,10 +74,10 @@ public class RawJsonTransform implements I_RawJsonTransform {
                             deleteList.add(jsonbBlockDef);
                         }
                     }
-                    for (JsonbBlockDef deleteBlock: deleteList){
+                    for (JsonbBlockDef deleteBlock : deleteList) {
                         queryStep.getJsonColumns().remove(deleteBlock);
                     }
-                }
+                });
             }
         }
     }
@@ -93,9 +96,7 @@ public class RawJsonTransform implements I_RawJsonTransform {
 
     public static Result<Record> deleteNamedColumn(Result<Record> result, String columnName) {
 
-        List<Field> fields = new ArrayList<>();
-
-        fields.addAll(Arrays.asList(result.fields()));
+        List<Field> fields = new ArrayList<>(Arrays.asList(result.fields()));
         int ndx = columnIndex(fields, columnName);
         if (ndx >= 0) {
             fields.remove(ndx);

--- a/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
@@ -161,7 +161,7 @@ MF-007 Execute Ad-Hoc Query - Get Compositions From All EHRs
     B/200_query.tmp.json    B/200.tmp.json
     B/300_get_compositions_with_archetype_from_all_ehrs.json    B/300.tmp.json
 
-    [Teardown]          TRACE GITHUB ISSUE  GITHUB 108  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  GITHUB NO-ID  not-ready  diff in AQL resp
 
 
 MF-009 Execute Ad-Hoc Query - Get Composition(s)


### PR DESCRIPTION
This fixes the issue in https://github.com/ehrbase/project_management/issues/85 as well as a fix for correctly passing archetype node ids in content children. Solve warnings in this code. Added @SuppressWarnings("unchecked") for casting on LinkedTreeMap with generics since this cannot be solved at compile time.