### PR TITLE
fix empty name, rows but display columns. Preserver order of variables

### DIFF
--- a/service/src/main/java/org/ehrbase/dao/access/jooq/AqlQueryHandler.java
+++ b/service/src/main/java/org/ehrbase/dao/access/jooq/AqlQueryHandler.java
@@ -32,6 +32,7 @@ import org.ehrbase.dao.access.interfaces.I_DomainAccess;
 import org.ehrbase.dao.access.support.DataAccess;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -67,7 +68,7 @@ public class AqlQueryHandler extends DataAccess {
         AqlResult aqlResult =  queryProcessor.execute();
 
         //add the variable from statements
-        Map<String, String> variables = new HashMap();
+        Map<String, String> variables = new LinkedHashMap<>();
         for (I_VariableDefinition variableDefinition: statements.getVariables()) {
             variables.put(variableDefinition.getAlias(), "/"+variableDefinition.getPath());
         }


### PR DESCRIPTION
Fixes several AQL issues as in https://github.com/ehrbase/project_management/issues/65

```
{
    "q": "SELECT e/ehr_id/value FROM EHR e",
    "name": null,
    "columns": [],
    "rows": []
}
```

Now, the list of columns is correctly set and in the order defined in the select statement. Further, if null, attribute 'name' is not in the json structure.