### PR TITLE
Feature/fix npe validation for unsupported language

### DIFF
--- a/terminology/src/main/java/org/ehrbase/terminology/openehr/implementation/SimpleTerminologyAccess.java
+++ b/terminology/src/main/java/org/ehrbase/terminology/openehr/implementation/SimpleTerminologyAccess.java
@@ -128,7 +128,8 @@ public class SimpleTerminologyAccess implements TerminologyAccess {
 	public Set<CodePhrase> codesForGroupName(String name, String language) {
 		Map<String, String> map = groupLangNameToId.get(language);
 		if(map == null) {
-			return null;
+			//default to English
+			map = codeRubrics.get("en");
 		}
 		String groupId = map.get(name);
 		return groups.get(groupId);
@@ -137,7 +138,9 @@ public class SimpleTerminologyAccess implements TerminologyAccess {
 	public String rubricForCode(String code, String language) {
 		Map<String, String> map = codeRubrics.get(language);
 		if(map == null) {
-			return null;			
+			//default to English
+			map = codeRubrics.get("en");
+			return map.get(code);
 		}
 		return map.get(code);
 	}

--- a/terminology/src/main/java/org/ehrbase/terminology/openehr/implementation/SimpleTerminologyAccess.java
+++ b/terminology/src/main/java/org/ehrbase/terminology/openehr/implementation/SimpleTerminologyAccess.java
@@ -140,7 +140,6 @@ public class SimpleTerminologyAccess implements TerminologyAccess {
 		if(map == null) {
 			//default to English
 			map = codeRubrics.get("en");
-			return map.get(code);
 		}
 		return map.get(code);
 	}


### PR DESCRIPTION
Generic fix whenever a language is not found in the openehr terminology. Specifically, for example setting the composition language to 'de' resulted in NPE whenever attempting to get the codephrase 'rubric' (the string value) for a codestring. The language is defaulted to 'en'. 