### PR TITLE
use openehr instead of openEhr as terminology_id

### DIFF
--- a/service/src/main/java/org/ehrbase/dao/access/interfaces/I_ConceptAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/interfaces/I_ConceptAccess.java
@@ -64,7 +64,7 @@ public interface I_ConceptAccess {
 
     static DvCodedText fetchConceptText(I_DomainAccess domainAccess, UUID uuid) {
         ConceptRecord conceptRecord = domainAccess.getContext().fetchAny(CONCEPT, CONCEPT.ID.eq(uuid));
-        return new DvCodedText(conceptRecord.getDescription(), new CodePhrase(new TerminologyId("openEhr"), "" + conceptRecord.getConceptid()));
+        return new DvCodedText(conceptRecord.getDescription(), new CodePhrase(new TerminologyId("openehr"), "" + conceptRecord.getConceptid()));
     }
 
     static String fetchConceptLiteral(I_DomainAccess domainAccess, Integer conceptId, String language) {

--- a/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
+++ b/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
@@ -58,7 +58,7 @@
 			"@type": "CODE_PHRASE",
 			"terminology_id": {
 				"@type": "TERMINOLOGY_ID",
-				"value": "openEhr"
+				"value": "openehr"
 			},
 			"code_string": "433"
 		}


### PR DESCRIPTION
According to https://specifications.openehr.org/releases/TERM/latest/SupportTerminology.html the correct term for the support terminology is `openehr` and not `openEhr`.

Contributions were only accepted with the `openehr` term while the output always produced `openEhr`.