### PR TITLE
lowercase event

### DIFF
--- a/base/src/main/resources/terminology.xml
+++ b/base/src/main/resources/terminology.xml
@@ -1217,7 +1217,7 @@
     <Concept Language="en" ConceptID="430" Rubric="URI - resource identifier"/>
     <Concept Language="en" ConceptID="431" Rubric="persistent"/>
     <Concept Language="en" ConceptID="432" Rubric="Composition category"/>
-    <Concept Language="en" ConceptID="433" Rubric="Event"/>
+    <Concept Language="en" ConceptID="433" Rubric="event"/>
     <Concept Language="en" ConceptID="434" Rubric="process"/>
     <Concept Language="en" ConceptID="435" Rubric="laboratory"/>
     <Concept Language="en" ConceptID="436" Rubric="imaging"/>

--- a/test-data/src/main/resources/composition/canonical_json/full_composition.json
+++ b/test-data/src/main/resources/composition/canonical_json/full_composition.json
@@ -1584,7 +1584,7 @@
   },
   "category": {
     "_type": "DV_CODED_TEXT",
-    "value": "Event",
+    "value": "event",
     "defining_code": {
       "_type": "CODE_PHRASE",
       "code_string": "433",

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_composition.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_composition.json
@@ -716,7 +716,7 @@
   },
   "category": {
     "_type": "DV_CODED_TEXT",
-    "value": "Event",
+    "value": "event",
     "defining_code": {
       "_type": "CODE_PHRASE",
       "code_string": "433",

--- a/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
+++ b/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
@@ -52,7 +52,7 @@
 	},
 	"category": {
 		"@type": "DV_CODED_TEXT",
-		"value": "Event",
+		"value": "event",
 		"mappings": [],
 		"defining_code": {
 			"@type": "CODE_PHRASE",


### PR DESCRIPTION
This is a partial fix for #114. It changes the term "Event" to lowercase, according to the specification.

Together with #113, this makes ehrBase generate valid representations from the raw JSON stored in the database.