### PR TITLE
Provider name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ cd tests
  2. Browse to Swagger UI --> http://localhost:8080/ehrbase/swagger-ui.html
 
 
+## Docker
+
+To create a Docker image
+
+`docker build -f application/Dockerfile --build-arg JAR_FILE=application-*.jar -t my-org/ehrbase:latest .`
+
 ## Built With
 
 * [Maven](https://maven.apache.org/) - Dependency Management

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-alpine
 ARG JAR_FILE
-COPY /target/${JAR_FILE} app.jar
+COPY application/target/${JAR_FILE} app.jar
 RUN mkdir -p file_repo/knowledge/archetypes &&  mkdir -p file_repo/knowledge/operational_templates && mkdir -p file_repo/knowledge/templates
 EXPOSE 8080
 ENTRYPOINT ["java","-Dspring.profiles.active=docker","-jar","/app.jar"]

--- a/serialisation/src/main/java/org/ehrbase/serialisation/CompositionSerializer.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/CompositionSerializer.java
@@ -368,8 +368,14 @@ public class CompositionSerializer {
 
     private Map<String, Object> objectAttributes(RMObject object, String name) throws Exception {
         Map<String, Object> valuemap = newPathMap();
-        putObject(className(object), object, valuemap, TAG_NAME, mapName(name));
+
+        if (object instanceof PartyIdentified) {
+            // The PartyIdentified name field is a string and should not be treated like other name fields and changed to DV_TEXT
+            valuemap.put("name", name);
+        } else {
+            putObject(className(object), object, valuemap, TAG_NAME, mapName(name));
 //        putObject(object, valuemap, TAG_CLASS, object).getSimpleName());
+        }
 
         //assign the actual object to the value (instead of its field equivalent...)
         if (object instanceof Participation) {

--- a/service/src/main/java/org/ehrbase/dao/access/support/DataAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/support/DataAccess.java
@@ -72,6 +72,11 @@ public abstract class DataAccess implements I_DomainAccess {
     }
 
     @Override
+    public void releaseConnection(Connection connection) {
+        context.configuration().connectionProvider().release(connection);
+    }
+
+    @Override
     public DSLContext getContext() {
         return context;
     }

--- a/test-data/src/main/resources/composition/canonical_xml/diadem.xml
+++ b/test-data/src/main/resources/composition/canonical_xml/diadem.xml
@@ -155,6 +155,9 @@
             </terminology_id>
             <code_string>en</code_string>
         </language>
+        <provider  xsi:type="PARTY_IDENTIFIED">
+            <name>TestName</name>
+        </provider>
         <encoding>
             <terminology_id>
                 <value>IANA_character-sets</value>


### PR DESCRIPTION
I've added a PR to fix an issue I have seen when saving a composition that contains a provider

* Updating CompositionSerializer to handle the PartyIdentified name field as a string rather than DvText
* Updating diadem.xml to include provider on an evaluation so the RawJsonTest unmarshall test confirms there is no errors deserialising the provider details