### PR TITLE
Raise jackson versions to 2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- FasterXML Jackson version raised to 2.10.2
+
+## [0.10.0] (alpha)
+
+
+## [0.9.0] (pre-alpha)
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <json.path.version>2.4.0</json.path.version>
         <log4j.version>2.7</log4j.version>
         <jooq.version>3.12.3</jooq.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
         <keycloak.version>4.0.0.Final</keycloak.version>
         <springfox.version>2.9.2</springfox.version>
         <springfox-snapshot.version>3.0.0-SNAPSHOT</springfox-snapshot.version>
@@ -336,7 +336,7 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.coren</groupId>
+                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>


### PR DESCRIPTION
Update of Dependency done. No breaking change inside Release Notes of Jackson and no issues identified during tests of new version.

Closes ehrbase/project_management#136

