### PR TITLE
Error when reading a composition that has a provider name set - fix

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/serialisation/CompositionSerializer.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/CompositionSerializer.java
@@ -368,8 +368,14 @@ public class CompositionSerializer {
 
     private Map<String, Object> objectAttributes(RMObject object, String name) throws Exception {
         Map<String, Object> valuemap = newPathMap();
-        putObject(className(object), object, valuemap, TAG_NAME, mapName(name));
+
+        if (object instanceof PartyIdentified) {
+            // The PartyIdentified name field is a string and should not be treated like other name fields and changed to DvText
+            valuemap.put("name", name);
+        } else {
+            putObject(className(object), object, valuemap, TAG_NAME, mapName(name));
 //        putObject(object, valuemap, TAG_CLASS, object).getSimpleName());
+        }
 
         //assign the actual object to the value (instead of its field equivalent...)
         if (object instanceof Participation) {

--- a/test-data/src/main/resources/composition/canonical_xml/diadem.xml
+++ b/test-data/src/main/resources/composition/canonical_xml/diadem.xml
@@ -155,6 +155,9 @@
             </terminology_id>
             <code_string>en</code_string>
         </language>
+        <provider  xsi:type="PARTY_IDENTIFIED">
+            <name>TestName</name>
+        </provider>
         <encoding>
             <terminology_id>
                 <value>IANA_character-sets</value>


### PR DESCRIPTION
I've added a PR to fix an issue I have seen when saving a composition that contains a provider
* Updating CompositionSerializer to handle the PartyIdentified name field as a string rather than DvText
* Updating diadem.xml to include provider on an evaluation so the RawJsonTest unmarshall test confirms there is no errors deserialising the provider details
