### PR TITLE
Feature/134 bug ehr parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Response code when composition is logically deleted (see: https://github.com/ehrbase/ehrbase/pull/144)
+- Deserialization of EhrStatus attributes is_modifiable and is_queryable are defaulting to `true` now (see: https://github.com/ehrbase/ehrbase/pull/158)
 
 ## [0.10.0] (alpha)
 

--- a/api/src/main/java/org/ehrbase/api/mapper/JacksonConfiguration.java
+++ b/api/src/main/java/org/ehrbase/api/mapper/JacksonConfiguration.java
@@ -39,9 +39,9 @@ public class JacksonConfiguration {
     public Jackson2ObjectMapperBuilderCustomizer addCustomSerialization() {
         return jacksonObjectMapperBuilder -> jacksonObjectMapperBuilder
                 .serializerByType(StructuredString.class, new StructuredStringJSonSerializer())
-                .serializerByType(RMObject.class, new RmObjektJsonSerializer())
-                .deserializerByType(EhrStatus.class, new RmObjektJsonDeSerializer())
-                .deserializerByType(Folder.class, new RmObjektJsonDeSerializer())
+                .serializerByType(RMObject.class, new RmObjectJsonSerializer())
+                .deserializerByType(EhrStatus.class, new RmObjectJsonDeSerializer())
+                .deserializerByType(Folder.class, new RmObjectJsonDeSerializer())
                 .modules(new JavaTimeModule());
     }
 

--- a/api/src/main/java/org/ehrbase/api/mapper/RmObjectJsonDeSerializer.java
+++ b/api/src/main/java/org/ehrbase/api/mapper/RmObjectJsonDeSerializer.java
@@ -29,13 +29,13 @@ import org.ehrbase.serialisation.CanonicalXML;
 
 import java.io.IOException;
 
-public class RmObjektJsonDeSerializer extends StdDeserializer {
+public class RmObjectJsonDeSerializer extends StdDeserializer {
 
-    public RmObjektJsonDeSerializer() {
+    public RmObjectJsonDeSerializer() {
         this(null);
     }
 
-    public RmObjektJsonDeSerializer(Class<?> vc) {
+    public RmObjectJsonDeSerializer(Class<?> vc) {
         super(vc);
     }
 

--- a/api/src/main/java/org/ehrbase/api/mapper/RmObjectJsonSerializer.java
+++ b/api/src/main/java/org/ehrbase/api/mapper/RmObjectJsonSerializer.java
@@ -29,7 +29,7 @@ import org.ehrbase.serialisation.CanonicalXML;
 import javax.xml.namespace.QName;
 import java.io.IOException;
 
-public class RmObjektJsonSerializer extends JsonSerializer<RMObject> {
+public class RmObjectJsonSerializer extends JsonSerializer<RMObject> {
     @Override
     public void serialize(RMObject value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         if (gen instanceof ToXmlGenerator) {

--- a/tests/robot/EHR_SERVICE_TESTS/B.1_CREATE_EHR/B.1__a)_New_EHR.robot
+++ b/tests/robot/EHR_SERVICE_TESTS/B.1_CREATE_EHR/B.1__a)_New_EHR.robot
@@ -331,8 +331,6 @@ MF-023 - Create new EHR (POST /ehr variants)
     given      1               1              201
     given      0               0              201
 
-    [Teardown]          TRACE GITHUB ISSUE  134  not-ready
-
 
 MF-024 - Create new EHR w/ empty subject (POST /ehr variants)
     [Documentation]     Covers edge case where subject is provided but is just empty JSON.
@@ -396,8 +394,6 @@ MF-030 - Create new EHR w/ given ehr_id (PUT /ehr/ehr_id variants)
     given   given      "false"         "false"        201
     given   given      1               1              201
     given   given      0               0              201
-
-    [Teardown]          TRACE GITHUB ISSUE  134  not-ready
 
 
 MF-031 - Create new EHR w/ given ehr_id (PUT /ehr/ehr_id variants)


### PR DESCRIPTION
fixes https://github.com/ehrbase/project_management/issues/134

Technical problem: Our deserialization was defaulting the boolean values to `false` (Java spec) without any information left for the controller to see if this value was `false` on purpose or not.

Solution: Custom deserializer for EhrStatus, which

- checks for `is_modifiable` and sets it to the default `true` value if necessary (vs. the Java default `false` for booleans)
- checks for `is_queryable` and sets it to the default `true` value if necessary

followed by invoking the standard deserializer with the result input. So if the parameters were set to something valid in the request, everything is deserialized as before. But if not, the input is modified and routed into the normal deserialization.