### PR TITLE
SUT switch - https://github.com/ehrbase/project_management/issues/117

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,60 +1,76 @@
-# EHRbase Integration Tests with Robot Framework
+# EHRbase Integration Tests with Robot Framework <!-- omit in toc -->
 
-## How to run test locally
+- [Prerequisites](#prerequisites)
+- [Test Environment & SUT](#test-environment--sut)
+- [Local Execution (under Linux, Mac & Windows)](#local-execution-under-linux-mac--windows)
+    - [With Robot Command](#with-robot-command)
+    - [With Shell Script](#with-shell-script)
+    - [Example Content Of Shell Script (run_local_tests.sh)](#example-content-of-shell-script-runlocaltestssh)
+    - [Manually Controlled SUT](#manually-controlled-sut)
+- [Execution Control - Test Suites & Tags](#execution-control---test-suites--tags)
+- [Remote Execution](#remote-execution)
+- [Execution In CI/CD Pipeline](#execution-in-cicd-pipeline)
+- [Errors And Warnings](#errors-and-warnings)
+- [Auto-Generated Test Report Summary And Detailed Log](#auto-generated-test-report-summary-and-detailed-log)
 
-> PREREQUISITES
->
-> - Docker, Python 3 with Pip are installed
-> - RF dependencies are installed (`cd tests/`, `pip install -r requirements.txt`)
-> - **No DB / no server running!**
-> - ports `8080` and `5432` not used by any other application! (`netstat -tulpn`)
+---
+
+## Prerequisites
+xcvzxcvz
+
+1) Docker, Java 11 & Maven, Python 3 & Pip are installed
+2) Robot Framework & dependencies are installed (`pip install -r requirements.txt`)
+3) Build artefacts created (`mvn package` --> application/target/application-x.xx.x.jar)
+3) ⚠️ **No DB / no server running!**
+4) ⚠️ ports `8080` and `5432` not used by any other application! (`netstat -tulpn`)
 
 
-## Execution of tests under Linux, Mac and Windows
-In general tests are executed by calling the **`robot`** command pointing it to the folder wich contains the tests, i.e.:
+
+## Test Environment & SUT
+
+The test environment of this project consists of three main parts
+1) EHRbase openehr server (application-*.jar)
+2) PostgreSQL database
+3) OS with Docker, Java runtime, Python runtime, Robot Framework
+
+Let's refer to the first two parts as the SUT (system under test). By default Robot Framework (RF) takes control of the SUT. That means to execute the tests locally all you have to do is to ensure your host machine meets required [prerequisites](#prerequisites). RF will take care of properly starting up, restarting and shutting down SUT as it is required for test execution. There is an option to hand over control of SUT to you, though - described in section [Manually Controlled SUT](#manually-controlled-sut).
+
+
+
+## Local Execution (under Linux, Mac & Windows)
+In general tests are executed by 1) cd into tests/ folder and 2) call the **`robot`** command with the folder wich contains the test suites as argument. Alternatively you can use prepared shell script inside this folder.
+
+
+#### With Robot Command
+The following examples will run all test-cases inside robot/ folder
+
 ```
-# this will run all test-cases from robot/ folder 
-# when you call it from inside project_root/tests/
+# 1) from project's root
+cd tests/
 
-# Linux & Mac OS
-robot robot/
-robot ./robot/
+# 2) call robot command
+robot robot/     # Linux
+robot ./robot/   # Mac OS
+robot .\robot\   # Windoofs
+```
 
-# Windows
-robot .\robot\
+Everything between `robot` command and the last argument are commandline option to fine control test execution and the processing of test results. Examples:
 
-
+```
 # QUICK COPY/PASTE EXAMPLES TO RUN ONLY A SPECIFIC TEST-SUITE
 
 robot -i composition    -d results --noncritical not-ready -L TRACE robot/COMPOSITION_TESTS/
 robot -i contribution   -d results --noncritical not-ready -L TRACE robot/CONTRIBUTION_TESTS/
 robot -i directory      -d results --noncritical not-ready -L TRACE robot/DIRECTORY_TESTS/
 robot -i ehr_service    -d results --noncritical not-ready -L TRACE robot/EHR_SERVICE_TESTS/
+robot -i ehr_status     -d results --noncritical not-ready -L TRACE robot/EHR_STATUS_TESTS/
 robot -i knowledge      -d results --noncritical not-ready -L TRACE robot/KNOWLEDGE_TESTS/
 robot -i aql            -d results --noncritical not-ready -L TRACE robot/QUERY_SERVICE_TESTS/
 ```
 
-Execution of **all** integration tests takes **about 30 minutes** (on a fast dev machine). To avoid waiting for all results you can specify exactly which test-suite or even which subset of it you want to execute. There are six test-suites to choose from by passing proper TAG to `robot` command via the `--include` (or short `-i`) option: 
 
-
-TEST SUITE | SUPER TAG | SUB TAG(s) | EXAMPLE(s)
-:----------|:----------|:-----------|:----------
-COMPOSITION_TESTS   | composition   | json, json1, json2, <br> xml, xml1, xml2 | `robot --include composition` <br> `robot -i composition` <br> `robot -i compositionANDjson`
-CONTRIBUTION_TESTS  | contribution  | commit_contribution, <br> list_contributions, <br> has_contribution, <br> get_contribution | `robot -i contribution`
-DIRECTORY_TESTS     | directory     | create_directory, <br> update_directory, <br> get_directory, <br> delete_directory, <br> get_directory_@time, <br> ...   | `robot -i composition` <br> `robot -i create_directoryORupdate_directory`
-EHR_SERVICE_TESTS   | ehr_service   | create_ehr, update_ehr, <br> has_ehr, get_ehr, <br>  ehr_status | `robot -i ehr_service`
-KNOWLEDGE_TESTS     | knowledge     | opt14 | `robot -i knowledge`
-QUERY_SERVICE_TESTS | aql           | adhoc-query, <br> stored-query, <br> register-query, <br> list-query   | `robot -i adhoc-query`
-
-
-
-The **SUPER TAG** is meant to reference *all* tests from related test-suite. The **SUB TAGs** can be used (in combination with a SUPER TAG) to further narrow down which tests to include into execution. As you can see from the examples in the table above it is possible to combine TAGs with `AND` and `OR` operators. Tags themself are case insensitive but the operators have to be upper case. In addition to `--include` or `-i` option there is also an `--exclude` / `-e` option. It is possible to combine `-i` and `-e` in one call, i.e.
-```bash
-robot -i ehr_serviceANDget_ehr -e future robot/EHR_SERVICE_TESTS/
-```
-[Using TAGs to include/exclude tests] from execution is very well documented in [Robot Framework's User Guide].
-
-There is also a prepared [shell script] which you can use to run **all** available tests at once. You can also use it as a reference to see which [command line options] are available to the `robot` command. Check examples below to see how to execute that script on your OS: 
+#### With Shell Script
+Use [shell script] to run **all** available tests at once or use it as a reference to see which [command line options] are available to the `robot` command. Examples below demonstrate it's usage: 
 
 ```bash
 # Linux
@@ -70,7 +86,8 @@ robot -d results --noncritical not-ready -L TRACE robot/
 
 ```
 
-## Example content of run_local_tests.sh
+
+#### Example Content Of Shell Script (run_local_tests.sh)
 ```bash
 robot --include get_contribution \
       --exclude TODO -e future -e obsolete -e libtest \
@@ -85,15 +102,94 @@ robot --include get_contribution \
 ```
 
 
+#### Manually Controlled SUT
 
-## Manually Controlled Test Environment
-   TODO: @WLAD
+In case you don't want Robot to start up and shut down server and database for you - i.e. during local development iterations - there is a command line option (`-v nodocker`) to turn this off. **This option should be used with some precaution, though!**
+
+> ⚠️ 
+>
+> Test Suite Setups and Teardowns will NOT be orchestrated by Robot any more making it impossible to run ALL tests at once (i.e. with `robot robot/`) - test will simply impact each other. You will have to pass at least a test suite folder as argument or limit test selection by using tags to avoid this (see section below). More over
+> - start the server with cache DISABLED (`--cache.enabled=false`)
+> - ensure server applies to Robot's DEV configuration
+> - restart server and rollback/reset database properly
+> - when in doubt compare with results in CI pipeline
+> - YOU HAVE BEEN WARNED!
+>
+> ⚠️
+
+Usage examples:
+```
+robot --variable nodocker:true robot/TEST_SUITE_FOLDER
+
+# short variant
+robot -v nodocker robot/TEST_SUITE_FOLDER
+robot -v nodocker -i get_ehr robot/EHR_SERVICE_TESTS
+```
+
+Robot will print proper warning in console if it can't connect to server or database:
+```
+[ WARN ] //////////////////////////////////////////////////////////
+[ WARN ] //                                                     ///
+[ WARN ] // YOU HAVE CHOSEN TO START YOUR OWN TEST ENVIRONMENT! ///
+[ WARN ] // BUT IT IS NOT AVAILABLE OR IS NOT SET UP PROPERLY!  ///
+[ WARN ] //                                                     ///
+[ WARN ] //////////////////////////////////////////////////////////
+[ WARN ] 
+[ WARN ] [ check "Manually Controlled SUT" in test README ]
+[ WARN ] [ https://github.com/ehrbase/ehrbase/blob/develop/tests/README.md#manually-sut ]
+[ WARN ] 
+[ ERROR ] ABORTING EXECUTION DUE TO TEST ENVIRONMENT ISSUES:
+[ ERROR ] Could not connect to server!
+[ ERROR ] Could not connect to database!
+```
 
 
 
-## ERRORS and WARNINGS
+## Execution Control - Test Suites & Tags
+Execution of **all** integration tests takes **about 30 minutes** (on a fast dev machine). To avoid waiting for all results you can specify exactly which test-suite or even which subset of it you want to execute. There are seven test-suites to choose from by passing proper TAG to `robot` command via the `--include` (or short `-i`) option: 
 
-You will see `[WARN]` and `[ERROR]` in console output and in log.html
+
+TEST SUITE | SUPER TAG | SUB TAG(s) | EXAMPLE(s)
+:----------|:----------|:-----------|:----------
+COMPOSITION_TESTS   | composition   | json, json1, json2, <br> xml, xml1, xml2 | `robot --include composition` <br> `robot -i composition` <br> `robot -i compositionANDjson`
+CONTRIBUTION_TESTS  | contribution  | commit_contribution, <br> list_contributions, <br> has_contribution, <br> get_contribution | `robot -i contribution`
+DIRECTORY_TESTS     | directory     | create_directory, <br> update_directory, <br> get_directory, <br> delete_directory, <br> get_directory_@time, <br> ...   | `robot -i composition` <br> `robot -i create_directoryORupdate_directory`
+EHR_SERVICE_TESTS   | ehr_service   | create_ehr, update_ehr, <br> has_ehr, get_ehr, <br>  ehr_status | `robot -i ehr_service`
+EHR_STATUS_TESTS   | ehr_status   | get_ehr_status, <br> set_ehr_status, <br>  set_queryable, <br> clear_queryable, <br> set_modifiable, <br> clear_modifiable | `robot -i ehr_status`
+KNOWLEDGE_TESTS     | knowledge     | opt14 | `robot -i knowledge`
+QUERY_SERVICE_TESTS | aql           | adhoc-query, <br> stored-query, <br> register-query, <br> list-query   | `robot -i adhoc-query`
+
+
+
+The **SUPER TAG** is meant to reference *all* tests from related test-suite. The **SUB TAGs** can be used (in combination with a SUPER TAG) to further narrow down which tests to include into execution. As you can see from the examples in the table above it is possible to combine TAGs with `AND` and `OR` operators. Tags themself are case insensitive but **the operators have to be upper case**. In addition to `--include` or `-i` option there is also an `--exclude` / `-e` option. It is possible to combine `-i` and `-e` in one call. Example below would include all test from EHR_SERVICE_TESTS folder which have the `ehr_service` **and** `get_ehr` tags and would irgnore all test which have the `future` tag.
+```bash
+robot -i ehr_serviceANDget_ehr -e future robot/EHR_SERVICE_TESTS/
+```
+[Using TAGs to include/exclude tests] from execution is very well documented in [Robot Framework's User Guide].
+
+
+
+## Remote Execution
+> ⚠️: NOT READY - because controlling remote database via this settings is not implemented yet! 
+> 
+Add a configuration to a remote server in suite_settings.robot and point robot to it via command line switch:
+```
+robot --variable SUT:TARGET -d results robot/TEST_SUITE
+
+# short
+robot -v sut:target -d results robot/TEST_SUITE
+```
+
+
+
+## Execution In CI/CD Pipeline
+Check out .circleci/config.yml in project root for an CircleCI example pipline whiche run Robot tests in parallel.
+
+
+
+## Errors And Warnings
+
+⚠️ You will see `[WARN]` and `[ERROR]` in console output and in log.html
 
 `[ERROR]` --> take a closer look, probably important
 
@@ -106,7 +202,7 @@ You will see `[WARN]` and `[ERROR]` in console output and in log.html
 
 
 
-## Auto-generated test report summary and detailed log
+## Auto-Generated Test Report Summary And Detailed Log
 
 After each test run Robot creates a report.html (summary) and a log.html
 (details) in results folder. The files are overwritten after each run by default.

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,11 @@ robot --include get_contribution \
 
 
 
+## Manually Controlled Test Environment
+   TODO: @WLAD
+
+
+
 ## ERRORS and WARNINGS
 
 You will see `[WARN]` and `[ERROR]` in console output and in log.html

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,6 @@
 ---
 
 ## Prerequisites
-xcvzxcvz
 
 1) Docker, Java 11 & Maven, Python 3 & Pip are installed
 2) Robot Framework & dependencies are installed (`pip install -r requirements.txt`)

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -36,7 +36,8 @@ tasks:
         desc: START EHRBASE SERVER W/O CACHING (CACHE DISABLED!)
         cmds:
           - echo ... staring EHRbase server ...
-          - java -jar ../application/target/application-0.10.0.jar --cache.enabled=false --server.nodename=manual.execution.org > log &
+          # - java -jar ../application/target/application-0.10.0.jar --cache.enabled=false --server.nodename=manual.execution.org > log &
+          - java -jar ../application/target/application-0.10.0.jar --cache.enabled=false > log &
           - sleep 20
           - echo ... EHRbase server started.
           #- grep -m 1 "Started EhrBase in" <(tail -f log)   # FAIL!

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -4,6 +4,8 @@ version: '2'
 #   - usage:        https://taskfile.dev/#/usage
 #   - code:         https://github.com/go-task/task
 
+# silent: true
+
 tasks:
     default:
         desc: RESTART SUT
@@ -22,7 +24,7 @@ tasks:
         desc: START SUT (NO CACHE)
         cmds:
           - task: startdb
-          - task: starteb-nocache
+          - task: starteb
 
     stop:
         desc: STOP SUT
@@ -31,20 +33,20 @@ tasks:
           - task: stopdb
 
     starteb:
-        desc: START EHRBASE SERVER
+        desc: START EHRBASE SERVER W/O CACHING (CACHE DISABLED!)
         cmds:
           - echo ... staring EHRbase server ...
-          - java -jar ../application/target/application-0.10.0.jar > log &
+          - java -jar ../application/target/application-0.10.0.jar --cache.enabled=false --server.nodename=manual.execution.org > log &
           - sleep 20
           - echo ... EHRbase server started.
           #- grep -m 1 "Started EhrBase in" <(tail -f log)   # FAIL!
           # https://github.com/go-task/task/issues/270
 
-    starteb-nocache:
-        desc: START EHRBASE SERVER WITHOUT CACHE
+    starteb-cache:
+        desc: START EHRBASE SERVER WITH CACHE ENABLED
         cmds:
           - echo ... staring EHRbase server ...
-          - java -jar ../application/target/application-0.10.0.jar --cache.enabled=false > log &
+          - java -jar ../application/target/application-0.10.0.jar > log &
           - sleep 20
           - echo ... EHRbase server started.
 
@@ -57,7 +59,9 @@ tasks:
     startdb:
         desc: START POSTGRES DB DOCKER CONTAINER
         cmds:
+          - echo ... starting DB server ...
           - docker run --name ehrdb -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
+          - echo ... DB server started.
 
     stopdb:
         desc: KILL POSTGRES DB DOCKER CONTAINER
@@ -69,22 +73,23 @@ tasks:
         desc: RUN SPECIFIED TESTS
         cmds:
           # adjust this part to the needs of your current test session
-          - robot -i xxx -e future -e circleci -e TODO -e obsolete -d results -L TRACE --noncritical not-ready robot/EHR_SERVICE_TESTS
+          - robot -v nodocker -i empty_db -e future -e circleci -e TODO -e obsolete -d results -L TRACE --noncritical not-ready robot/QUERY_SERVICE_TESTS
           # example of "execute single test by it's test-case name" (wildcards accepted):
           # - robot -t "MF-030 - Create new EHR*" -d results -L TRACE robot/EHR_SERVICE_TESTS
           # - spd-say "Robot is ready! Check the results!"
 
-    test_all:
+    test-all:
         desc: RUN ALL ROBOT TESTS
         cmds:
-          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output compo.xml --name COMPO robot/COMPOSITION_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output compop.xml --name COMPO robot/COMPOSITION_TESTS
           - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output contri.xml --name CONTRI robot/CONTRIBUTION_TESTS
           - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output folder.xml --name FOLDER robot/DIRECTORY_TESTS
-          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output ehr.xml --name EHR robot/EHR_SERVICE_TESTS
-          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output knowledge.xml --name KNOWLEDGE robot/KNOWLEDGE_TESTS
-          - robot -i empty_db -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output query.xml --name "QUERY empty_db" robot/QUERY_SERVICE_TESTS
-          - robot -i loaded_db -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output query.xml --name QUERY "loaded_db" robot/QUERY_SERVICE_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output ehrser.xml --name EHRSERVICE robot/EHR_SERVICE_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output ehrsta.xml --name EHRSTATUS robot/EHR_STATUS_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output knowld.xml --name KNOWLEDGE robot/KNOWLEDGE_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output aqledb.xml --name "QUERY empty_db"  -i empty_db  robot/QUERY_SERVICE_TESTS
+          - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output aqlldb.xml --name "QUERY loaded_db" -i loaded_db robot/QUERY_SERVICE_TESTS
 
           # consolidate results
           - rebot -e future -e circleci -e TODO -e obsolete -e libtest -d results -L TRACE --noncritical not-ready --name EHRbase results/xml/*.xml
-          - spd-say "Robot is ready! Check the results!"
+          # - spd-say "Robot is ready! Check the results!"

--- a/tests/robot/DIRECTORY_TESTS/A.4_GET_DIRECTORY/A.4__c._EHR_with_complex_directory_structure_and_item.robot
+++ b/tests/robot/DIRECTORY_TESTS/A.4_GET_DIRECTORY/A.4__c._EHR_with_complex_directory_structure_and_item.robot
@@ -34,11 +34,11 @@ Force Tags
 Alternative flow 2: get directory on EHR with complex directory structure and items
 
     create EHR
-        
+
         TRACE GITHUB ISSUE  171  not-ready
 
     create DIRECTORY (JSON)    subfolders_in_directory_with_details_items.json
 
     get DIRECTORY at time (JSON)  time
 
-    validate GET version@time response - 200 retrieved
+    validate GET-version@time response - 200 retrieved

--- a/tests/robot/_resources/keywords/composition_keywords.robot
+++ b/tests/robot/_resources/keywords/composition_keywords.robot
@@ -59,7 +59,7 @@ generate random composition_uid
     ${uid}=             Evaluate    str(uuid.uuid4())    uuid
                         Set Test Variable   ${composition_uid}    ${uid}    # TODO: remove
                         Set Test Variable   ${versioned_object_uid}    ${uid}
-                        Set Test Variable   ${version_uid}    ${uid}::local.ehrbase.org::1    # TODO: get `local.ehrbase.org` from a variable
+                        Set Test Variable   ${version_uid}    ${uid}::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${preceding_version_uid}    ${version_uid}
 
 
@@ -68,7 +68,7 @@ generate random version_uid
     ...                 also as `preceding_version_uid` to test level scope
 
     ${uid}=             Evaluate    str(uuid.uuid4())    uuid
-                        Set Test Variable   ${version_uid}    ${uid}::local.ehrbase.org::1
+                        Set Test Variable   ${version_uid}    ${uid}::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${preceding_version_uid}    ${version_uid}
 
 
@@ -159,7 +159,7 @@ commit composition (JSON)
                         Set Test Variable   ${version_uid_v1}    ${version_uid}                  # different namesfor full uid
                         Set Test Variable   ${preceding_version_uid}    ${version_uid}          # for usage in other steps
 
-    ${short_uid}=       Remove String       ${version_uid}    ::local.ehrbase.org::1
+    ${short_uid}=       Remove String       ${version_uid}    ::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${compo_uid_v1}    ${short_uid}                      # TODO: rmv
                         Set Test Variable   ${versioned_object_uid}    ${short_uid}
 
@@ -197,7 +197,7 @@ commit composition (XML)
                         Set Test Variable   ${version_uid_v1}    ${version_uid}                  # different namesfor full uid
                         Set Test Variable   ${preceding_version_uid}    ${version_uid}          # for usage in other steps
 
-    ${short_uid}=       Remove String       ${version_uid}    ::local.ehrbase.org::1
+    ${short_uid}=       Remove String       ${version_uid}    ::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${compo_uid_v1}    ${short_uid}                 # TODO; rmv
                         Set Test Variable   ${versioned_object_uid}    ${short_uid}
 
@@ -249,7 +249,7 @@ update composition (JSON)
                         Set Test Variable   ${composition_uid_v2}    ${resp.json()['uid']['value']}    # TODO: remove
                         Set Test Variable   ${version_uid_v2}    ${resp.json()['uid']['value']}
 
-    ${short_uid}=       Remove String       ${version_uid_v2}    ::local.ehrbase.org::1
+    ${short_uid}=       Remove String       ${version_uid_v2}    ::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${versioned_object_uid_v2}    ${short_uid}
 
                         Set Test Variable   ${response}    ${resp}
@@ -300,7 +300,7 @@ update composition (XML)
                         Set Test Variable   ${composition_uid_v2}     ${long_uid.text}    # TODO: remove
                         Set Test Variable   ${version_uid_v2}     ${long_uid.text}
 
-    ${short_uid}=       Remove String       ${version_uid_v2}    ::local.ehrbase.org::1
+    ${short_uid}=       Remove String       ${version_uid_v2}    ::${CREATING_SYSTEM_ID}::1
                         Set Test Variable   ${versioned_object_uid_v2}    ${short_uid}
 
                         Set Test Variable   ${response}    ${resp}

--- a/tests/robot/_resources/keywords/directory_keywords.robot
+++ b/tests/robot/_resources/keywords/directory_keywords.robot
@@ -1040,7 +1040,7 @@ generate fake version_uid
 
     ${uid}=             Evaluate    str(uuid.uuid4())    uuid
                         Set Test Variable    ${folder_uid}    ${uid}
-                        Set Test Variable    ${version_uid}    ${uid}::local.ehrbase.org::1
+                        Set Test Variable    ${version_uid}    ${uid}::${CREATING_SYSTEM_ID}::1
                         Set Test Variable    ${preceding_version_uid}    ${version_uid}
 
 

--- a/tests/robot/_resources/keywords/ehr_keywords.robot
+++ b/tests/robot/_resources/keywords/ehr_keywords.robot
@@ -458,10 +458,6 @@ extract ehrstatus_uid (JSON)
     ${ehrstatus_uid}=   String       response body ehr_status uid value
 
                         Log To Console    \n\tDEBUG OUTPUT - EHR_STATUS UUID: \n\t${ehrstatus_uid}[0]
-                        # Set Test Variable    ${ehrstatus_uid}   ${ehrstatus_uid}[0]::local.ehrbase.org::1
-                        #                                         # NOTE: ::local.ehrbase.org::1 has to be provided
-                        #                                         # as part of ehr_status.uid.value by the repsonse
-                        #                                         # and must not be hard coded here
                         Set Test Variable    ${ehrstatus_uid}   ${ehrstatus_uid}[0]
 
 
@@ -480,8 +476,6 @@ extract ehrstatus_uid (XML)
 
     ${xml}=             Parse Xml    ${response.body}
     ${ehrstatus_uid}=   Get Element Text    ${xml}    xpath=ehr_status/uid/value
-                        # Set Test Variable   ${ehrstatus_uid}    ${ehrstatus_uid}::local.ehrbase.org::1
-                        #                                         # TODO this should probaply not be hard coded!!!
                         Set Test Variable   ${ehrstatus_uid}    ${ehrstatus_uid}
 
 extract system_id from response (XML)

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -26,7 +26,7 @@ Library    OperatingSystem
 
 *** Variables ***
 ${README_LINK}    https://github.com/ehrbase/ehrbase/blob/develop/tests/README.md
-${MANUAL_TEST_ENV}    \#manually-controlled-test-environment
+${MANUAL_TEST_ENV}    \#manually-controlled-sut
 
 
 
@@ -317,7 +317,7 @@ warn about manual test environment start up
     Log    //${SPACE * 54}///                                                   level=WARN
     Log    ///////////////////////////////////////////////////////////          level=WARN
     Log    ${EMPTY}                                                             level=WARN
-    Log    [ check "Manually Controlled Test Environment" in test README ]      level=WARN
+    Log    [ check "Manually Controlled SUT" in test README ]      level=WARN
     Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
     Log    ${EMPTY}                                                             level=WARN
     Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${FALSE}
@@ -344,7 +344,7 @@ abort tests due to issues with manually controlled test environment
     Log    //${SPACE * 53}///                                                   level=WARN
     Log    //////////////////////////////////////////////////////////           level=WARN
     Log    ${EMPTY}                                                             level=WARN
-    Log    [ check "Manually Controlled Test Environment" in test README ]      level=WARN
+    Log    [ check "Manually Controlled SUT" in test README ]      level=WARN
     Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
     Log    ${EMPTY}    level=WARN
     Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${TRUE}

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -294,13 +294,36 @@ set request headers
                         Set Suite Variable   ${headers}    ${headers}
 
 
-do quick sanity check
+server sanity check
+    [Documentation]     Sends a GET request to ${HEARTBEAT_URL} to check whether
+    ...                 the server is up and running.
+    
     ${server_status}    Run Keyword And Return Status    openehr server is online
+    [RETURN]            ${server_status}
+
+
+database sanity check
+    [Documentation]     Connects to local PostgreSQL DB regardless whether it was 
+    ...                 installed natively or dockerized. Disconnects immediately
+    ...                 on success.
+    ...                 Is skipped when CONTROL_MODE is not manual - e.g. when SUT
+    ...                 is on a remote host.
+
+    Return From Keyword If    "${CONTROL_MODE}"=="docker"    NO DB CHECK ON REMOTE SUT
+
     ${db_status}        Run Keyword And Return Status    Connect With DB
                         Run Keyword If    $db_status    Disconnect From Database
+    [RETURN]            ${db_status}
+
+
+do quick sanity check
+
+    ${server_status}    server sanity check
+    ${db_status}        database sanity check
 
     ${env_status}       Set Variable If   $server_status==False or $db_status==False
                         ...    ${FALSE}    ${TRUE}
+
 
                         Set Global Variable    @{TEST_ENVIRONMENT_STATUS}
                         ...                    ${env_status}    ${server_status}    ${db_status}

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -220,8 +220,9 @@ wait until openehr server is online
 
 
 openehr server is online
-    REST.GET    ${SWAGGER_URL}
-    Integer  response status  200
+    prepare new request session  JSON
+    REST.GET    ${HEARTBEAT_URL}
+    Integer  response status  404
 
 
 abort test execution
@@ -308,45 +309,45 @@ do quick sanity check
 
 
 warn about manual test environment start up
-    Log    ${EMPTY}    level=WARN
-    Log    ///////////////////////////////////////////////////////////          level=WARN
-    Log    //${SPACE * 54}///                                                   level=WARN
-    Log    // YOU HAVE CHOSEN TO START YOUR OWN TEST ENVIRONMENT!\ \ ///        level=WARN
-    Log    // MAKE SURE IT MEETS PREREQUISITES FOR TEST EXECUTION!\ ///         level=WARN
-    Log    // MAKE SURE TO RESET IT PROPERLY AFTER EACH TEST RUN!\ \ ///        level=WARN
-    Log    //${SPACE * 54}///                                                   level=WARN
-    Log    ///////////////////////////////////////////////////////////          level=WARN
-    Log    ${EMPTY}                                                             level=WARN
-    Log    [ check "Manually Controlled SUT" in test README ]      level=WARN
-    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
-    Log    ${EMPTY}                                                             level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    //${SPACE * 10} YOU HAVE CHOSEN TO START YOUR SUT MANUALLY! ${SPACE * 9}///          level=WARN
+    Log    //${SPACE * 5} MAKE SURE IT MEETS PREREQUISITES FOR TEST EXECUTION! ${SPACE * 5}///  level=WARN
+    Log    //${SPACE * 6} MAKE SURE TO RESET IT PROPERLY AFTER EACH TEST RUN! ${SPACE * 5}///   level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
+    Log    [ check "Manually Controlled SUT" in test README ]                                   level=WARN
+    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                                 level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
     Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${FALSE}
 
 
 warn about manual test environment shut down
     Run Keyword And Return If    ${SKIP_SHUTDOWN_WARNING}==${TRUE}    Log
                           ...    skipping manual test env control warning due to test abortion
-    Log    ${EMPTY}    level=WARN
-    Log    ////////////////////////////////////////////////////////             level=WARN
-    Log    //${SPACE * 51}///                                                   level=WARN
-    Log    // REMBER TO PROPERLY RESTART YOUR TEST ENVIRONMENT! ///             level=WARN
-    Log    //${SPACE * 51}///                                                   level=WARN
-    Log    ////////////////////////////////////////////////////////             level=WARN
-    Log    ${EMPTY}                                                             level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    //${SPACE * 13}REMBER TO PROPERLY RESTART YOUR SUT! ${SPACE * 13} ///                level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
 
 
 abort tests due to issues with manually controlled test environment
-    Log    ${EMPTY}    level=WARN
-    Log    //////////////////////////////////////////////////////////           level=WARN
-    Log    //${SPACE * 53}///                                                   level=WARN
-    Log    // YOU HAVE CHOSEN TO START YOUR OWN TEST ENVIRONMENT!\ ///          level=WARN
-    Log    // BUT IT IS NOT AVAILABLE OR IS NOT SET UP PROPERLY!\ \ ///         level=WARN
-    Log    //${SPACE * 53}///                                                   level=WARN
-    Log    //////////////////////////////////////////////////////////           level=WARN
-    Log    ${EMPTY}                                                             level=WARN
-    Log    [ check "Manually Controlled SUT" in test README ]      level=WARN
-    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
-    Log    ${EMPTY}    level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    //${SPACE * 10} YOU HAVE CHOSEN TO START YOUR SUT MANUALLY ${SPACE * 10}///          level=WARN
+    Log    //${SPACE * 6} BUT IT IS NOT AVAILABLE OR IS NOT SET UP PROPERLY! ${SPACE * 6}///    level=WARN
+    Log    //${SPACE * 64}///                                                                   level=WARN
+    Log    /////////////////////////////////////////////////////////////////////                level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
+    Log    [ check "Manually Controlled SUT" in test README ]                                   level=WARN
+    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                                 level=WARN
+    Log    ${EMPTY}                                                                             level=WARN
     Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${TRUE}
     abort test execution    @{TEST_ENVIRONMENT_STATUS}
 
@@ -357,16 +358,16 @@ startup SUT
     # comment: switch to manual test environment control when "-v nodocker" cli option is used
     Run Keyword If      $NODOCKER.upper() in ["TRUE", ""]    Run Keywords
                ...      Set Global Variable    ${NODOCKER}    TRUE    AND
-               ...      Set Global Variable    ${baseurl}    ${DEV.URL}    AND
-               ...      Set Global Variable    ${SWAGGER_URL}    ${DEV.SWAGGER}    AND
-               ...      Set Global Variable    ${authorization}    ${DEV.AUTH}    AND
+               ...      Set Global Variable    ${BASEURL}    ${DEV.URL}    AND
+               ...      Set Global Variable    ${HEARTBEAT_URL}    ${DEV.HEARTBEAT}    AND
+               ...      Set Global Variable    ${AUTHORIZATION}    ${DEV.AUTH}    AND
                ...      Set Global Variable    ${CREATING_SYSTEM_ID}    ${DEV.NODENAME}    AND
                ...      Set Global Variable    ${CONTROL_MODE}    ${DEV.CONTROL}
 
-                        Log    \n\t TEST ENVIRONMENT CONFIG\n    console=true
-                        Log    \t BASEURL: ${baseurl}    console=true
-                        Log    \t SWAGGER: ${SWAGGER_URL}    console=true
-                        Log    \t AUTH: ${authorization}    console=true
+                        Log    \n\t SUT CONFIG\n    console=true
+                        Log    \t BASEURL: ${BASEURL}    console=true
+                        Log    \t HEARTBEAT: ${HEARTBEAT_URL}    console=true
+                        Log    \t AUTH: ${AUTHORIZATION}    console=true
                         Log    \t CREATING SYSTEM ID: ${CREATING_SYSTEM_ID}    console=true
                         Log    \t CONTROL MODE: ${CONTROL_MODE}\n    console=true
 

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -24,6 +24,12 @@ Library    OperatingSystem
 
 
 
+*** Variables ***
+${README_LINK}    https://github.com/ehrbase/ehrbase/blob/develop/tests/README.md
+${MANUAL_TEST_ENV}    \#manually-controlled-test-environment
+
+
+
 *** Keywords ***
 # oooo    oooo oooooooooooo oooooo   oooo oooooo   oooooo     oooo   .oooooo.   ooooooooo.   oooooooooo.    .oooooo..o
 # `888   .8P'  `888'     `8  `888.   .8'   `888.    `888.     .8'   d8P'  `Y8b  `888   `Y88. `888'   `Y8b  d8P'    `Y8
@@ -138,7 +144,7 @@ restart SUT
 get application version
     ${root}=  Parse Xml    ${POM_FILE}
     ${version}=  Get Element Text   ${root}  version
-    Set Suite Variable    ${VERSION}    ${version}
+    Set Global Variable    ${VERSION}    ${version}
 
 
 unzip file_repo_content.zip
@@ -173,29 +179,32 @@ start openehr server
     get application version
     run keyword if  '${CODE_COVERAGE}' == 'True'   start server process with coverage
     run keyword if  '${CODE_COVERAGE}' == 'False'  start server process without coverage
-    Wait For Process  ehrserver  timeout=10  on_timeout=continue
+    Wait For Process  ehrserver  timeout=25  on_timeout=continue
     Is Process Running  ehrserver
-    Process Should Be Running  ehrserver
+    ${status}=      Run Keyword And Return Status    Process Should Be Running    ehrserver
+                    Run Keyword If    ${status}==${FALSE}    Fatal Error    Server failed to start!
     wait until openehr server is ready
     wait until openehr server is online
 
 
 start server process without coverage
     ${result}=          Start Process  java  -jar  ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
-                        ...                  --cache.enabled\=false    alias=ehrserver
+                        ...                  --cache.enabled\=false
+                        ...                  --server.nodename\=${CREATING_SYSTEM_ID}    alias=ehrserver
                         ...                    cwd=${PROJECT_ROOT}    stdout=stdout.txt    stderr=stderr.txt
 
 
 start server process with coverage
     ${result}=          Start Process  java  -javaagent:${JACOCO_LIB_PATH}/jacocoagent.jar\=output\=tcpserver,address\=127.0.0.1
                         ...                  -jar    ${PROJECT_ROOT}${/}application/target/application-${VERSION}.jar
-                        ...                  --cache.enabled\=false    alias=ehrserver
+                        ...                  --cache.enabled\=false
+                        ...                  --server.nodename\=${CREATING_SYSTEM_ID}    alias=ehrserver
                         ...                    cwd=${PROJECT_ROOT}    stdout=stdout.txt    stderr=stderr.txt
 
 
 wait until openehr server is ready
     Wait Until Keyword Succeeds  120 sec  3 sec  text "Started EhrBase ..." is in log
-    [Teardown]  Run keyword if  "${KEYWORD STATUS}"=="FAIL"  abort test execution if server not ready
+    [Teardown]  Run keyword if  "${KEYWORD STATUS}"=="FAIL"  abort test execution    Server is NOT running!
 
 
 text "Started EhrBase ..." is in log
@@ -207,17 +216,25 @@ text "Started EhrBase ..." is in log
 
 wait until openehr server is online
     Wait Until Keyword Succeeds  33 sec  3 sec  openehr server is online
-    [Teardown]  Run keyword if  "${KEYWORD STATUS}"=="FAIL"  abort test execution if server not ready
+    [Teardown]  Run keyword if  "${KEYWORD STATUS}"=="FAIL"  abort test execution    Server is NOT running!
 
 
 openehr server is online
-    REST.GET    http://localhost:8080/ehrbase/swagger-ui.html
+    REST.GET    ${SWAGGER_URL}
     Integer  response status  200
 
 
-abort test execution if server not ready
-    Log    THE SERVER IS NOT RUNNING    ERROR
-    Fatal Error  Aborted Tests Execution - Server is NOT running!
+abort test execution
+    [Arguments]         @{TEST_ENVIRONMENT_STATUS}
+
+    ${overall_status}    ${server_status}    ${db_status}=    Set Variable    ${TEST_ENVIRONMENT_STATUS}
+                        Log    ABORTING EXECUTION DUE TO TEST ENVIRONMENT ISSUES:    level=ERROR
+                        Run Keyword if    ${server_status}==${FALSE}    Log
+                        ...               Could not connect to server!    level=ERROR
+                        Run Keyword if    ${db_status}==${FALSE}    Log
+                        ...               Could not connect to database!    level=ERROR
+
+                        Fatal Error  ABORTED TEST EXECUTION!
 
 
 abort test execution if this test fails
@@ -268,7 +285,7 @@ set request headers
     # library: RESTinstance
     &{headers}=         Set Headers         ${headers}
                         Set Headers         ${authorization}
-    
+
     # library: RequestLibrary
                         Create Session      ${SUT}    ${${SUT}.URL}    debug=2
                         ...                 auth=${${SUT}.CREDENTIALS}    verify=True
@@ -276,14 +293,101 @@ set request headers
                         Set Suite Variable   ${headers}    ${headers}
 
 
+do quick sanity check
+    ${server_status}    Run Keyword And Return Status    openehr server is online
+    ${db_status}        Run Keyword And Return Status    Connect With DB
+                        Run Keyword If    $db_status    Disconnect From Database
+
+    ${env_status}       Set Variable If   $server_status==False or $db_status==False
+                        ...    ${FALSE}    ${TRUE}
+
+                        Set Global Variable    @{TEST_ENVIRONMENT_STATUS}
+                        ...                    ${env_status}    ${server_status}    ${db_status}
+
+    [RETURN]            ${env_status}    ${server_status}    ${db_status}
+
+
+warn about manual test environment start up
+    Log    ${EMPTY}    level=WARN
+    Log    ///////////////////////////////////////////////////////////          level=WARN
+    Log    //${SPACE * 54}///                                                   level=WARN
+    Log    // YOU HAVE CHOSEN TO START YOUR OWN TEST ENVIRONMENT!\ \ ///        level=WARN
+    Log    // MAKE SURE IT MEETS PREREQUISITES FOR TEST EXECUTION!\ ///         level=WARN
+    Log    // MAKE SURE TO RESET IT PROPERLY AFTER EACH TEST RUN!\ \ ///        level=WARN
+    Log    //${SPACE * 54}///                                                   level=WARN
+    Log    ///////////////////////////////////////////////////////////          level=WARN
+    Log    ${EMPTY}                                                             level=WARN
+    Log    [ check "Manually Controlled Test Environment" in test README ]      level=WARN
+    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
+    Log    ${EMPTY}                                                             level=WARN
+    Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${FALSE}
+
+
+warn about manual test environment shut down
+    Run Keyword And Return If    ${SKIP_SHUTDOWN_WARNING}==${TRUE}    Log
+                          ...    skipping manual test env control warning due to test abortion
+    Log    ${EMPTY}    level=WARN
+    Log    ////////////////////////////////////////////////////////             level=WARN
+    Log    //${SPACE * 51}///                                                   level=WARN
+    Log    // REMBER TO PROPERLY RESTART YOUR TEST ENVIRONMENT! ///             level=WARN
+    Log    //${SPACE * 51}///                                                   level=WARN
+    Log    ////////////////////////////////////////////////////////             level=WARN
+    Log    ${EMPTY}                                                             level=WARN
+
+
+abort tests due to issues with manually controlled test environment
+    Log    ${EMPTY}    level=WARN
+    Log    //////////////////////////////////////////////////////////           level=WARN
+    Log    //${SPACE * 53}///                                                   level=WARN
+    Log    // YOU HAVE CHOSEN TO START YOUR OWN TEST ENVIRONMENT!\ ///          level=WARN
+    Log    // BUT IT IS NOT AVAILABLE OR IS NOT SET UP PROPERLY!\ \ ///         level=WARN
+    Log    //${SPACE * 53}///                                                   level=WARN
+    Log    //////////////////////////////////////////////////////////           level=WARN
+    Log    ${EMPTY}                                                             level=WARN
+    Log    [ check "Manually Controlled Test Environment" in test README ]      level=WARN
+    Log    [ ${README_LINK}${MANUAL_TEST_ENV} ]                                 level=WARN
+    Log    ${EMPTY}    level=WARN
+    Set Global Variable    ${SKIP_SHUTDOWN_WARNING}    ${TRUE}
+    abort test execution    @{TEST_ENVIRONMENT_STATUS}
+
+    abort test execution  TEST_ENVIRONMENT_STATUS
+    abort test execution if this test fails
+
 startup SUT
+    # comment: switch to manual test environment control when "-v nodocker" cli option is used
+    Run Keyword If      $NODOCKER.upper() in ["TRUE", ""]    Run Keywords
+               ...      Set Global Variable    ${NODOCKER}    TRUE    AND
+               ...      Set Global Variable    ${baseurl}    ${DEV.URL}    AND
+               ...      Set Global Variable    ${SWAGGER_URL}    ${DEV.SWAGGER}    AND
+               ...      Set Global Variable    ${authorization}    ${DEV.AUTH}    AND
+               ...      Set Global Variable    ${CREATING_SYSTEM_ID}    ${DEV.NODENAME}    AND
+               ...      Set Global Variable    ${CONTROL_MODE}    ${DEV.CONTROL}
+
+                        Log    \n\t TEST ENVIRONMENT CONFIG\n    console=true
+                        Log    \t BASEURL: ${baseurl}    console=true
+                        Log    \t SWAGGER: ${SWAGGER_URL}    console=true
+                        Log    \t AUTH: ${authorization}    console=true
+                        Log    \t CREATING SYSTEM ID: ${CREATING_SYSTEM_ID}    console=true
+                        Log    \t CONTROL MODE: ${CONTROL_MODE}\n    console=true
+
+    ${sanity_check_passed}  ${server_status}  ${db_status}=    do quick sanity check
+
+    Run Keyword And Return If   "${CONTROL_MODE}"=="manual" and ${sanity_check_passed}
+                          ...    warn about manual test environment start up
+
+    Run Keyword And Return If   "${CONTROL_MODE}"=="manual" and not ${sanity_check_passed}
+                          ...   abort tests due to issues with manually controlled test environment
+
+    # comment: test environment controlled by Robot
     get application version
-    unzip file_repo_content.zip
     start ehrdb
     start openehr server
 
 
 shutdown SUT
+    Run Keyword And Return If   "${CONTROL_MODE}"=="manual"
+                          ...    warn about manual test environment shut down
+
     stop openehr server
     stop and remove ehrdb
     empty operational_templates folder
@@ -304,8 +408,10 @@ dump test coverage
 
 
 start ehrdb
-    run postgresql container
-    wait until ehrdb is ready
+    ${status}           Run Keyword And Return Status    run postgresql container
+                        Run Keyword If    ${status}==${FALSE}    Fatal Error   Could not start DB!
+
+                        wait until ehrdb is ready
 
 
 stop and remove ehrdb
@@ -388,20 +494,6 @@ log an ERROR and set tag(s)
 THIS IS JUST A PLACEHOLDER!
     Fail    Placeholder - no impact on CI!
     [Teardown]  Set Tags    not-ready    TODO
-
-
-TRACE JIRA BUG
-    [Arguments]     ${JIRA_BUG_ID}
-    ...             ${not-ready}=
-    ...             ${message}=Next step fails due to a bug!
-    ...             ${loglevel}=ERROR
-
-    Log  DEPRECATION WARNING - @WLAD replace/update this keyword!
-    ...  level=WARN
-
-                    Log    ${message} | JIRA: ${JIRA_BUG_ID}   level=${loglevel}
-                    Set Tags    bug    ${JIRA_BUG_ID}
-                    Run Keyword If    '${not-ready}'=='not-ready'    Set Tags    not-ready
 
 
 TRACE GITHUB ISSUE

--- a/tests/robot/_resources/suite_settings.robot
+++ b/tests/robot/_resources/suite_settings.robot
@@ -68,7 +68,7 @@ ${SUT}                  TEST    # DEFAULT
 
 # local test environment: for development
 &{DEV}                  URL=http://localhost:8080/ehrbase/rest/openehr/v1
-...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     HEARTBEAT=http://localhost:8080/ehrbase/
 ...                     CREDENTIALS=${devcreds}
 ...                     AUTH={"Authorization": null}
                         # comment: nodename is actually "CREATING_SYSTEM_ID" and can be set from cli
@@ -81,7 +81,7 @@ ${devcreds}             None
 
 # testing environment: used on CI pipeline
 &{TEST}                 URL=http://localhost:8080/ehrbase/rest/openehr/v1
-...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     HEARTBEAT=http://localhost:8080/ehrbase/
 ...                     CREDENTIALS=${testcreds}
 ...                     AUTH={"Authorization": null}
 ...                     NODENAME=local.ehrbase.org
@@ -90,7 +90,7 @@ ${testcreds}            None
 
 # staging environment
 &{STAGE}                URL=http://localhost:8080/ehrbase/rest/openehr/v1
-...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     HEARTBEAT=http://localhost:8080/ehrbase/
 ...                     CREDENTIALS=${stagecreds}
 ...                     AUTH={"Authorization": null}
 ...                     NODENAME=stage.ehrbase.org
@@ -99,7 +99,7 @@ ${stagecreds}           None
 
 # pre production environment
 &{PREPROD}              URL=http://localhost:8080/ehrbase/rest/openehr/v1
-...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     HEARTBEAT=http://localhost:8080/ehrbase/
 ...                     CREDENTIALS=${preprodcreds}
 ...                     AUTH={"Authorization": null}
 ...                     NODENAME=preprod.ehrbase.org
@@ -113,9 +113,9 @@ ${preprodcreds}         None
 # ...                     AUTH={"Authorization": "Basic Auth-String"}
 # @{aircreds}             username    password
 
-${baseurl}              ${${SUT}.URL}
-${SWAGGER_URL}          ${${SUT}.SWAGGER}
-${authorization}        ${${SUT}.AUTH}
+${BASEURL}              ${${SUT}.URL}
+${HEARTBEAT_URL}        ${${SUT}.HEARTBEAT}
+${AUTHORIZATION}        ${${SUT}.AUTH}
 ${CREATING_SYSTEM_ID}   ${${SUT}.NODENAME}
 ${CONTROL_MODE}         ${${SUT}.CONTROL}
 

--- a/tests/robot/_resources/suite_settings.robot
+++ b/tests/robot/_resources/suite_settings.robot
@@ -54,26 +54,70 @@ ${hip_baseurl_v1}     http://localhost:8080/ehrbase/rest/ecis/v1
 ${template_id}    IDCR%20-%20Immunisation%20summary.v0
 ${invalid_ehr_id}    123
 ${CODE_COVERAGE}    False
+${NODOCKER}         False
 
 ${PROJECT_ROOT}  ${EXECDIR}${/}..
 ${POM_FILE}    ${PROJECT_ROOT}${/}pom.xml
 ${FIXTURES}     ${PROJECT_ROOT}/tests/robot/_resources/fixtures
 
 
-${SUT}                 EHRBASE
 
-&{EHRSCAPE}            URL=https://rest.ehrscape.com/rest/openehr/v1
-...                    CREDENTIALS=@{scapecreds}
-...                    AUTH={"Authorization": "Basic YmlyZ2VyLmhhYXJicmFuZHRAcGxyaS5kZTplaHI0YmlyZ2VyLmhhYXJicmFuZHQ"}
-@{scapecreds}          birger.haarbrandt@plri.de    ehr4birger.haarbrandt
+# Your System Under Test (SUT) configuration goes here!
+# Check tests/README.md for details.
+${SUT}                  TEST    # DEFAULT
 
-&{EHRBASE}             URL=http://localhost:8080/ehrbase/rest/openehr/v1
-...                    CREDENTIALS=${basecreds}
-...                    AUTH={ "Authorization": null}
-${basecreds}           None
+# local test environment: for development
+&{DEV}                  URL=http://localhost:8080/ehrbase/rest/openehr/v1
+...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     CREDENTIALS=${devcreds}
+...                     AUTH={"Authorization": null}
+                        # comment: nodename is actually "CREATING_SYSTEM_ID" and can be set from cli
+                        #          when starting server .jar
+                        #          i.e. java -jar application.jar --server.nodename=some.foobar.baz
+                        #          EHRbase's default is local.ehrbase.org
+...                     NODENAME=local.ehrbase.org
+...                     CONTROL=manual
+${devcreds}             None
 
-${baseurl}             ${${SUT}.URL}
+# testing environment: used on CI pipeline
+&{TEST}                 URL=http://localhost:8080/ehrbase/rest/openehr/v1
+...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     CREDENTIALS=${testcreds}
+...                     AUTH={"Authorization": null}
+...                     NODENAME=local.ehrbase.org
+...                     CONTROL=docker
+${testcreds}            None
+
+# staging environment
+&{STAGE}                URL=http://localhost:8080/ehrbase/rest/openehr/v1
+...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     CREDENTIALS=${stagecreds}
+...                     AUTH={"Authorization": null}
+...                     NODENAME=stage.ehrbase.org
+...                     CONTROL=docker
+${stagecreds}           None
+
+# pre production environment
+&{PREPROD}              URL=http://localhost:8080/ehrbase/rest/openehr/v1
+...                     SWAGGER=http://localhost:8080/ehrbase/swagger-ui.html
+...                     CREDENTIALS=${preprodcreds}
+...                     AUTH={"Authorization": null}
+...                     NODENAME=preprod.ehrbase.org
+...                     CONTROL=docker
+${preprodcreds}         None
+
+
+# # Basic Auth example
+# &{AIRBASE}              URL=https://domain.com/rest/openehr/v1
+# ...                     CREDENTIALS=@{aircreds}
+# ...                     AUTH={"Authorization": "Basic Auth-String"}
+# @{aircreds}             username    password
+
+${baseurl}              ${${SUT}.URL}
+${SWAGGER_URL}          ${${SUT}.SWAGGER}
 ${authorization}        ${${SUT}.AUTH}
+${CREATING_SYSTEM_ID}   ${${SUT}.NODENAME}
+${CONTROL_MODE}         ${${SUT}.CONTROL}
 
 
 

--- a/tests/run_local_tests.sh
+++ b/tests/run_local_tests.sh
@@ -71,6 +71,17 @@ robot -i EHR_SERVICE -e circleci -e EHRSCAPE -e obsolete -e libtest \
       --name EHR \
       robot/EHR_SERVICE_TESTS/
 
+# RUN EHR STATUS TESTS
+robot -i EHR_STATUS -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/EHR_STATUS \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name EHR \
+      robot/EHR_STATUS_TESTS/
+
 # RUN KNOWLEDGE SERVICE TESTS
 robot -i KNOWLEDGE -e circleci -e EHRSCAPE -e obsolete -e libtest \
       --outputdir results/test-suites/KNOWLEDGE_SERVICE \


### PR DESCRIPTION
resolves https://github.com/ehrbase/project_management/issues/117

- added ~Test Environment~ SUT (system under test) configs to suite_settings
- target SUT can now be defined in suite_settings.robot and switching requires only to change `${SUT}` variable, which can be done in suite_settings or from command line
- added a command line option to allow manual control of the ~test environment~ SUT (`-v nodocker`)
- updated resource files:
  - composition_keywords
  - directory_keywords
  - ehr_keywords
  - generic_keywords
- fixed typo in a KW in DIRECTORY_TESTS
- updated/fixed my Taskfile.yml