### PR TITLE
AQL support of ehr_status/other_details

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPath.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+//TODO: add a clause allowing to get the RmType FROM the DB (f.e. ELEMENT/value doesn't get the type)
 public class GenericJsonPath {
 
     final String path;
@@ -33,13 +34,22 @@ public class GenericJsonPath {
                 actualPaths.add("content,/"+ segment);
                 actualPaths.add("0"); //as above
             }
-            else if (segment.equals("value") && (i < jqueryPaths.size() - 1) && jqueryPaths.get(i + 1).equals("value")){
+            else if (segment.matches("value|name") && !isTerminalValue(jqueryPaths, i)){
                 actualPaths.add("/"+ segment);
+                if (segment.matches("name"))
+                    actualPaths.add("0");
             }
             else
                 actualPaths.add(segment);
         }
 
         return "'{"+String.join(",", actualPaths)+"}'";
+    }
+
+    private boolean isTerminalValue(List paths, int index){
+        if (index == paths.size() - 1 && paths.get(index - 1).toString().matches("value|name")){
+            return true;
+        }
+        return false;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/ehrstatus/EhrStatusOtherDetails.java
@@ -34,11 +34,11 @@ public class EhrStatusOtherDetails extends EhrStatusAttribute {
 
     @Override
     public Field<?> sqlField(){
-        fieldContext.setJsonDatablock(true);
-        String variablePath = fieldContext.getVariableDefinition().getPath().substring("ehr_status/other_details".length() + 1);
-        Field<?> field = new JsonbEntryQuery(fieldContext.getContext(), fieldContext.getIntrospectCache(), fieldContext.getPathResolver(), fieldContext.getEntry_root())
-                .makeField(JsonbEntryQuery.OTHER_ITEM.OTHER_DETAILS, null, fieldContext.getVariableDefinition().getAlias(), variablePath, fieldContext.isWithAlias());
-        return field;
+        String variablePath = fieldContext.getVariableDefinition().getPath().substring("ehr_status/other_details".length());
+        if (variablePath.startsWith("/"))
+            variablePath = variablePath.substring(1);
+
+        return new EhrStatusJson(fieldContext, joinSetup).forJsonPath("other_details/"+variablePath).sqlField();
     }
 
     @Override

--- a/service/src/test/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPathTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryImpl/attribute/GenericJsonPathTest.java
@@ -13,7 +13,16 @@ public class GenericJsonPathTest {
         assertEquals("'{setting,defining_code}'", new GenericJsonPath("setting/defining_code").jqueryPath());
         assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]").jqueryPath());
         assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0,/items[at0001],0}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]/items[at0001]").jqueryPath());
-        assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0,/items[at0001],0,/value,value}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]/items[at0001]/value,value").jqueryPath());
+        assertEquals("'{other_context,/items[openEHR-EHR-CLUSTER.composition_context_detail.v1],0,/items[at0001],0,/value,value}'", new GenericJsonPath("other_context/items[openEHR-EHR-CLUSTER.composition_context_detail.v1]/items[at0001]/value/value").jqueryPath());
+    }
+
+    @Test
+    public void jqueryPathOtherDetails() {
+
+        assertEquals("'{other_details,/items[at0111],0,/value}'", new GenericJsonPath("other_details/items[at0111]/value").jqueryPath());
+        assertEquals("'{other_details,/items[at0111],0,/name,0}'", new GenericJsonPath("other_details/items[at0111]/name").jqueryPath());
+        assertEquals("'{other_details,/items[at0111],0,/value,value}'", new GenericJsonPath("other_details/items[at0111]/value/value").jqueryPath());
+        assertEquals("'{other_details,/items[at0111],0,/name,0,value}'", new GenericJsonPath("other_details/items[at0111]/name/value").jqueryPath());
 
     }
 }


### PR DESCRIPTION
AQL Querying other_details `SELECT  e/ehr_status/other_details` for an EHR defined as follows is now supported
```
{
  "_type": "EHR_STATUS",
  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
  "name": {
    "value": "EHR Status"
  },
  "subject": {
    "external_ref": {
      "id": {
        "_type": "GENERIC_ID",
        "value": "ins03",
        "scheme": "id_scheme"
      },
      "namespace": "examples",
      "type": "PERSON"
    }
  },
   "other_details": {
    "_type": "ITEM_TREE",
    "archetype_node_id": "at0001",
    "name": {
      "value": "Details"
    },
    "items": [
                {
		          "_type": "ELEMENT",
		          "name": {
		            "_type": "DV_TEXT",
		            "value": "Field 1"
		          },
		          "archetype_node_id": "at0111",
		          "value": {
		            "_type": "DV_DATE_TIME",
		            "value": "2014-02-05T12:54:54"
		          }
        		},
        		{
		          "_type": "ELEMENT",
		          "name": {
		            "_type": "DV_TEXT",
		            "value": "Field 2"
		          },
		          "archetype_node_id": "at0222",
		          "value": {
		            "_type": "DV_TEXT",
		            "value": "Value field 2"
		          }
        		}
    	]
  },
  "is_modifiable": true,
  "is_queryable": true
}
```
NB. Whenever querying on ELEMENT/value, the attribute `_type` is missing, a CR has been created to address this issue (https://github.com/ehrbase/project_management/issues/183)