### PR TITLE
Deals with an empty result for canonical item structure

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
@@ -57,10 +57,11 @@ public class RawJsonTransform implements I_RawJsonTransform {
                     List<JsonbBlockDef> deleteList = new ArrayList<>();
                     for (JsonbBlockDef jsonbBlockDef : queryStep.getJsonColumns()) {
 
+                        if (record.getValue(jsonbBlockDef.getField()) == null)
+                            continue;
+
                         String jsonbOrigin = record.getValue(jsonbBlockDef.getField()).toString();
 
-                        if (jsonbOrigin == null)
-                            continue;
                         //apply the transformation
                         try {
                             JsonElement jsonElement = new LightRawJsonEncoder(jsonbOrigin).encodeContentAsJson(jsonbBlockDef.getJsonPathRoot());


### PR DESCRIPTION
## Changes

This fixes a NPE whenever a canonical json result is null (e.g. non existent)

## Related issue

Closes: https://github.com/ehrbase/project_management/issues/186


## Additional information and checks

- [ ] Pull request linked in changelog
