### PR TITLE
support parenthesis in WHERE clause

### DIFF
--- a/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
+++ b/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
@@ -111,7 +111,7 @@ contains
 
 identifiedExpr
         : identifiedEquality ((OR|XOR|AND) identifiedEquality)*
-        | OPEN_PAR identifiedEquality ((OR|XOR|AND) identifiedEquality)* CLOSE_PAR
+        | OPEN_PAR identifiedEquality ((OR|XOR|AND)identifiedEquality)* CLOSE_PAR
         ;
 
 //identifiedExprAnd
@@ -119,16 +119,16 @@ identifiedExpr
 //      : identifiedEquality (AND identifiedExpr)*;
 
 identifiedEquality
-        : NOT? identifiedOperand COMPARABLEOPERATOR identifiedOperand
-        | NOT? identifiedOperand MATCHES OPEN_CURLY matchesOperand CLOSE_CURLY
-        | NOT? identifiedOperand MATCHES REGEXPATTERN
-        | NOT? identifiedOperand LIKE STRING
-        | NOT? identifiedOperand ILIKE STRING
-        | NOT? identifiedOperand SIMILARTO STRING
+        : OPEN_PAR? NOT? identifiedOperand COMPARABLEOPERATOR identifiedOperand CLOSE_PAR?
+        | OPEN_PAR? NOT? identifiedOperand MATCHES OPEN_CURLY matchesOperand CLOSE_CURLY CLOSE_PAR?
+        | OPEN_PAR? NOT? identifiedOperand MATCHES REGEXPATTERN CLOSE_PAR?
+        | OPEN_PAR? NOT? identifiedOperand LIKE STRING CLOSE_PAR?
+        | OPEN_PAR? NOT? identifiedOperand ILIKE STRING CLOSE_PAR?
+        | OPEN_PAR? NOT? identifiedOperand SIMILARTO STRING CLOSE_PAR?
 //        | NOT identifiedEquality
-        | NOT? IN OPEN_PAR queryExpr CLOSE_PAR
-        | NOT? EXISTS identifiedPath
-        | NOT? EXISTS identifiedExpr;
+        | OPEN_PAR? NOT? IN OPEN_PAR queryExpr CLOSE_PAR CLOSE_PAR?
+        | OPEN_PAR? NOT? EXISTS identifiedPath CLOSE_PAR?
+        | OPEN_PAR? NOT? EXISTS identifiedExpr CLOSE_PAR?;
 
 identifiedOperand
         : operand
@@ -423,7 +423,7 @@ RAW_COMPOSITION_ENCODE : '_' '_' R A W '_' C O M P O S I T I O N '_' E N C O D E
 
 fragment
 ESC_SEQ
-    :   '\\' ('b'|'t'|'n'|'f'|'r'|'\"'|'\''|'\\')
+    :   '\\' ('b'|'t'|'n'|'f'|'r'|'\\"'|'\''|'\\')
     |   UNICODE_ESC
     |   OCTAL_ESC
     ;

--- a/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
+++ b/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
@@ -119,16 +119,16 @@ identifiedExpr
 //      : identifiedEquality (AND identifiedExpr)*;
 
 identifiedEquality
-        : OPEN_PAR? NOT? identifiedOperand COMPARABLEOPERATOR identifiedOperand CLOSE_PAR?
-        | OPEN_PAR? NOT? identifiedOperand MATCHES OPEN_CURLY matchesOperand CLOSE_CURLY CLOSE_PAR?
-        | OPEN_PAR? NOT? identifiedOperand MATCHES REGEXPATTERN CLOSE_PAR?
-        | OPEN_PAR? NOT? identifiedOperand LIKE STRING CLOSE_PAR?
-        | OPEN_PAR? NOT? identifiedOperand ILIKE STRING CLOSE_PAR?
-        | OPEN_PAR? NOT? identifiedOperand SIMILARTO STRING CLOSE_PAR?
+        : OPEN_PAR* NOT? identifiedOperand COMPARABLEOPERATOR identifiedOperand CLOSE_PAR*
+        | OPEN_PAR* NOT? identifiedOperand MATCHES OPEN_CURLY matchesOperand CLOSE_CURLY CLOSE_PAR*
+        | OPEN_PAR* NOT? identifiedOperand MATCHES REGEXPATTERN CLOSE_PAR*
+        | OPEN_PAR* NOT? identifiedOperand LIKE STRING CLOSE_PAR*
+        | OPEN_PAR* NOT? identifiedOperand ILIKE STRING CLOSE_PAR*
+        | OPEN_PAR* NOT? identifiedOperand SIMILARTO STRING CLOSE_PAR*
 //        | NOT identifiedEquality
-        | OPEN_PAR? NOT? IN OPEN_PAR queryExpr CLOSE_PAR CLOSE_PAR?
-        | OPEN_PAR? NOT? EXISTS identifiedPath CLOSE_PAR?
-        | OPEN_PAR? NOT? EXISTS identifiedExpr CLOSE_PAR?;
+        | OPEN_PAR* NOT? IN OPEN_PAR queryExpr CLOSE_PAR CLOSE_PAR*
+        | OPEN_PAR* NOT? EXISTS identifiedPath CLOSE_PAR*
+        | OPEN_PAR* NOT? EXISTS identifiedExpr CLOSE_PAR*;
 
 identifiedOperand
         : operand

--- a/service/src/main/java/org/ehrbase/aql/compiler/WhereClauseUtil.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/WhereClauseUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.compiler;
+
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * utility class to check some validity factors of a WHERE expression (f.e. balanced parenthesis)
+ */
+class WhereClauseUtil {
+
+    private List<Object> expression;
+    private String unbalanced;
+
+    WhereClauseUtil(List<Object> expression) {
+        this.expression = expression;
+    }
+
+    /**
+     * check if an expression block is balanced
+     * A block is delimited by '[...]', '{...}' or '(...)'
+     * @return true if the block is balanced, false otherwise
+     */
+    boolean isBalancedBlocks(){
+
+        Stack<Object> stack = new Stack<>();
+
+        for (Object item: expression){
+            if (item.toString().length() == 1 && item.toString().matches("\\(|}|\\["))
+                stack.push(item);
+            else if (item.toString().length() == 1 && item.toString().matches("\\)|\\{|\\]")){
+                if (stack.empty())
+                    return false;
+                else if (!isBalanced(stack.pop(), item))
+                    return false;
+            }
+        }
+
+        return stack.empty();
+    }
+
+    private boolean isBalanced(Object fromStack, Object actual){
+        boolean result = false;
+        if (actual.toString().equals(")"))
+            result = fromStack.toString().equals("(");
+        else if (actual.toString().equals("]"))
+            result = fromStack.toString().equals("[");
+        if (actual.toString().equals("}"))
+            result = fromStack.toString().equals("{");
+
+        if (!result)
+            unbalanced = actual.toString();
+
+        return result;
+    }
+
+    /**
+     * return the balanced state of the last check
+     * @return boolean
+     */
+    String getUnbalanced() {
+        return unbalanced;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/compiler/WhereVisitor.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/WhereVisitor.java
@@ -196,6 +196,11 @@ public class WhereVisitor<T, ID> extends AqlBaseVisitor<List<Object>> {
     }
 
     List<Object> getWhereExpression() {
+        WhereClauseUtil whereClauseUtil = new WhereClauseUtil(whereExpression);
+
+        if (!whereClauseUtil.isBalancedBlocks())
+            throw new IllegalArgumentException("Unbalanced block in WHERE clause missing:'"+whereClauseUtil.getUnbalanced()+"'");
+
         return whereExpression;
     }
 

--- a/service/src/main/java/org/ehrbase/aql/containment/IdentifierMapper.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/IdentifierMapper.java
@@ -102,7 +102,7 @@ public class IdentifierMapper {
 
     public FromEhrDefinition.EhrPredicate getEhrContainer() {
         for (Map.Entry<String, Mapper> containment : mapper.entrySet()) {
-            if (containment.getValue().getContainer() instanceof FromEhrDefinition.EhrPredicate)
+            if (containment.getValue().getContainer() instanceof FromEhrDefinition.EhrPredicate && !((FromEhrDefinition.EhrPredicate) containment.getValue().getContainer()).isVoid())
                 return (FromEhrDefinition.EhrPredicate) containment.getValue().getContainer();
         }
         return null;

--- a/service/src/main/java/org/ehrbase/aql/definition/FromEhrDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/FromEhrDefinition.java
@@ -74,6 +74,10 @@ public class FromEhrDefinition implements I_FromEntityDefinition {
         public String toString() {
             return "EHR::" + getIdentifier() + "::" + getIdentifier() + "::" + getValue();
         }
+
+        public boolean isVoid(){
+            return field == null && value == null && operator == null;
+        }
     }
 
     private boolean isEHR = false;
@@ -121,4 +125,5 @@ public class FromEhrDefinition implements I_FromEntityDefinition {
     public List<EhrPredicate> getEhrPredicates() {
         return fromEhrPredicates;
     }
+
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/I_TaggedStringBuilder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/I_TaggedStringBuilder.java
@@ -40,6 +40,10 @@ public interface I_TaggedStringBuilder {
 
     void replace(String previous, String newString);
 
+    void replace(Integer start, Integer end, String replacement);
+
+    void insert(Integer offset, String toInsert);
+
     String toString();
 
     int length();

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/TaggedStringBuilder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/TaggedStringBuilder.java
@@ -18,6 +18,8 @@
 
 package org.ehrbase.aql.sql.binding;
 
+import java.util.Optional;
+
 public class TaggedStringBuilder implements I_TaggedStringBuilder {
 
     private StringBuilder stringBuffer;
@@ -69,6 +71,16 @@ public class TaggedStringBuilder implements I_TaggedStringBuilder {
             stringBuffer.delete(indexOf, indexOf + previous.length());
             stringBuffer.insert(indexOf, newString);
         }
+    }
+
+    @Override
+    public void replace(Integer start, Integer end, String replacement){
+        stringBuffer.replace(start, end, replacement);
+    }
+
+    @Override
+    public void insert(Integer offset, String toInsert){
+        stringBuffer.insert(offset,toInsert);
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -149,7 +149,7 @@ public class WhereBinder {
                     case "XOR":
                     case "AND":
                     case "NOT":
-                        taggedBuffer = jsqueryClosure(taggedBuffer);
+                        taggedBuffer = new WhereJsQueryExpression(taggedBuffer, requiresJSQueryClosure, isFollowedBySQLConditionalOperator).closure();
                         taggedBuffer.append(" " + item + " ");
                         break;
 
@@ -212,23 +212,23 @@ public class WhereBinder {
 
         }
 
-        taggedBuffer = jsqueryClosure(taggedBuffer); //termination
+        taggedBuffer = new WhereJsQueryExpression(taggedBuffer, requiresJSQueryClosure, isFollowedBySQLConditionalOperator).closure(); //termination
 
         return DSL.condition(taggedBuffer.toString());
     }
 
 
-    private TaggedStringBuilder jsqueryClosure(TaggedStringBuilder taggedStringBuilder){
-        if (requiresJSQueryClosure) {
-            if (taggedStringBuilder.toString().charAt(taggedStringBuilder.length()-1)==')' && !isFollowedBySQLConditionalOperator)
-                taggedStringBuilder.replaceLast(")", JsonbEntryQuery.Jsquery_CLOSE+")");
-            else
-                taggedStringBuilder.append(JsonbEntryQuery.Jsquery_CLOSE);
-            isFollowedBySQLConditionalOperator = false;
-            requiresJSQueryClosure = false;
-        }
-        return taggedStringBuilder;
-    }
+//    private TaggedStringBuilder jsqueryClosure(TaggedStringBuilder taggedStringBuilder){
+//        if (requiresJSQueryClosure) {
+//            if (taggedStringBuilder.toString().charAt(taggedStringBuilder.length()-1)==')' && !isFollowedBySQLConditionalOperator)
+//                taggedStringBuilder = new WhereJsQueryExpression(taggedStringBuilder, requiresJSQueryClosure).closeWithJsQueryTag();
+//            else
+//                taggedStringBuilder.append(JsonbEntryQuery.Jsquery_CLOSE);
+//            isFollowedBySQLConditionalOperator = false;
+//            requiresJSQueryClosure = false;
+//        }
+//        return taggedStringBuilder;
+//    }
 
     //look ahead for a SQL operator
     private boolean isFollowedBySQLConditionalOperator(int cursor) {

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -42,7 +42,7 @@ import java.util.*;
  */
 public class WhereBinder {
 
-    private static final String JSQUERY_EXPR_VALUE = "\"value\"";
+    private static final String VALUETYPE_EXPR_VALUE = "\"value\"";
     //from AQL grammar
     private static final Set<String> sqloperators = new HashSet<>(Arrays.asList("=", "!=", ">", ">=", "<", "<=", "MATCHES", "EXISTS", "NOT", "(", ")", "{", "}"));
 
@@ -53,7 +53,9 @@ public class WhereBinder {
     private Condition initialCondition;
     private boolean isWholeComposition = false;
     private String compositionName = null;
-    private String sqlSetStatementRegexp = "(?i)(like|ilike|in|not in)"; //list of subquery and operators
+    private String sqlConditionalFunctionalOperatorRegexp = "(?i)(like|ilike|in|not in)"; //list of subquery and operators
+    private boolean requiresJSQueryClosure = false;
+    private boolean isFollowedBySQLConditionalOperator = false;
 
     private enum Operator {OR, XOR, AND, NOT, EXISTS}
 
@@ -130,102 +132,34 @@ public class WhereBinder {
         return taggedBuffer;
     }
 
-    private Condition wrapInCondition(Condition condition, TaggedStringBuilder taggedStringBuilder, Deque<Operator> operators) {
-        //perform the condition query wrapping depending on the dialect jsquery or sql
-        String wrapped;
-
-        switch (taggedStringBuilder.getTagField()) {
-            case JSQUERY:
-                wrapped = JsonbEntryQuery.Jsquery_COMPOSITION_OPEN + taggedStringBuilder.toString() + JsonbEntryQuery.Jsquery_CLOSE;
-                break;
-            case SQLQUERY:
-                wrapped = taggedStringBuilder.toString();
-                break;
-
-            default:
-                throw new IllegalArgumentException("Uninitialized tag passed in query expression");
-        }
-
-        if (condition == null)
-            condition = DSL.condition(wrapped);
-        else {
-            if (operators.isEmpty()) //assumes AND
-                condition = condition.and(wrapped);
-            else {
-                Operator operator = operators.pop();
-                switch (operator) {
-                    case OR:
-                        condition = condition.or(wrapped);
-                        break;
-                    case XOR:
-                        throw new IllegalArgumentException("XOR is not supported yet...");
-
-                    case AND:
-                        condition = condition.and(wrapped);
-                        break;
-                    case NOT:
-                        Condition condition1 = DSL.condition(wrapped);
-                        if (!operators.isEmpty()) {
-                            operator = operators.pop();
-                            switch (operator) {
-                                case OR:
-                                    condition = condition.orNot(condition1);
-                                    break;
-                                case AND:
-                                    condition = condition.andNot(condition1);
-                                    break;
-                                default:
-                                    condition = condition.andNot(condition1);
-                            }
-                        } else
-                            condition = condition.andNot(condition1);
-                        break;
-                }
-            }
-        }
-
-        return condition;
-    }
-
     public Condition bind(String templateId, UUID comp_id) {
-        Deque<Operator> operators = new ArrayDeque<>();
-        TaggedStringBuilder taggedBuffer = new TaggedStringBuilder();
-        Condition condition = initialCondition;
 
-//        List whereItems = new WhereResolver(whereClause).resolveDateCondition();
+        if (whereClause.size() == 0)
+            return null;
+
+        TaggedStringBuilder taggedBuffer = new TaggedStringBuilder();
+
         List whereItems = whereClause;
 
         for (int cursor = 0; cursor < whereItems.size(); cursor++) {
             Object item = whereItems.get(cursor);
             if (item instanceof String) {
-                switch ((String) item) {
+                switch (((String) item).trim().toUpperCase()) {
                     case "OR":
-                    case "or":
-                        operators.push(Operator.OR);
-                        break;
-
                     case "XOR":
-                    case "xor":
-                        operators.push(Operator.XOR);
-                        break;
-
                     case "AND":
-                    case "and":
-                        operators.push(Operator.AND);
-                        break;
-
                     case "NOT":
-                    case "not":
-                        operators.push(Operator.NOT);
+                        taggedBuffer = jsqueryClosure(taggedBuffer);
+                        taggedBuffer.append(" " + item + " ");
                         break;
 
                     default:
                         ISODateTime isoDateTime = new ISODateTime(((String) item).replaceAll("'", ""));
                         if (isoDateTime.isValidDateTimeExpression()) {
                             Long timestamp = isoDateTime.toTimeStamp();
-                            int lastValuePos = taggedBuffer.lastIndexOf(JSQUERY_EXPR_VALUE);
+                            int lastValuePos = taggedBuffer.lastIndexOf(VALUETYPE_EXPR_VALUE);
                             if (lastValuePos > 0) {
-                                taggedBuffer.replaceLast(JSQUERY_EXPR_VALUE, "\"epoch_offset\"");
+                                taggedBuffer.replaceLast(VALUETYPE_EXPR_VALUE, "\"epoch_offset\"");
                             }
                             item = hackItem(taggedBuffer, timestamp.toString());
                             taggedBuffer.append((String) item);
@@ -240,14 +174,10 @@ public class WhereBinder {
                 item = hackItem(taggedBuffer, item.toString());
                 taggedBuffer.append(item.toString());
             } else if (item instanceof I_VariableDefinition) {
-                if (taggedBuffer.length() > 0) {
-                    condition = wrapInCondition(condition, taggedBuffer, operators);
-                    taggedBuffer = new TaggedStringBuilder();
-                }
                 //look ahead and check if followed by a sql operator
-                TaggedStringBuilder taggedStringBuilder = null;
-                if (isFollowedBySQLSetOperator(cursor))
-                    taggedStringBuilder = encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null);
+                TaggedStringBuilder taggedStringBuilder = new TaggedStringBuilder();
+                if (isFollowedBySQLConditionalOperator(cursor))
+                    taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null)));
                 else {
                     if (((I_VariableDefinition) item).getPath() != null && isWholeComposition) {
                         //assume a composition
@@ -262,9 +192,9 @@ public class WhereBinder {
                     } else {
                         //if the path contains node predicate expression uses a SQL syntax instead of jsquery
                         if (new VariablePath(((I_VariableDefinition) item).getPath()).hasPredicate()) {
-                            taggedStringBuilder = encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null);
+                            taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null)));
                         } else {
-                            taggedStringBuilder = encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, false, null);
+                            taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, false, null)));
                         }
                     }
                 }
@@ -273,33 +203,43 @@ public class WhereBinder {
                     taggedBuffer.append(taggedStringBuilder.toString());
                     taggedBuffer.setTagField(taggedStringBuilder.getTagField());
                 }
-                //check for a composition name if applicable
-//                if (((VariableDefinition) item).getAlias())
-//                condition = wrapInCondition(condition, stringBuffer, operators);
+
             } else if (item instanceof List) {
                 TaggedStringBuilder taggedStringBuilder = buildWhereCondition(templateId, comp_id, taggedBuffer, (List) item);
                 taggedBuffer.append(taggedStringBuilder.toString());
                 taggedBuffer.setTagField(taggedStringBuilder.getTagField());
-                condition = wrapInCondition(condition, taggedBuffer, operators);
             }
 
         }
 
-        if (taggedBuffer.length() != 0) {
-            condition = wrapInCondition(condition, taggedBuffer, operators);
-        }
+        taggedBuffer = jsqueryClosure(taggedBuffer); //termination
 
-        return condition;
+        return DSL.condition(taggedBuffer.toString());
     }
 
 
+    private TaggedStringBuilder jsqueryClosure(TaggedStringBuilder taggedStringBuilder){
+        if (requiresJSQueryClosure) {
+            if (taggedStringBuilder.toString().charAt(taggedStringBuilder.length()-1)==')' && !isFollowedBySQLConditionalOperator)
+                taggedStringBuilder.replaceLast(")", JsonbEntryQuery.Jsquery_CLOSE+")");
+            else
+                taggedStringBuilder.append(JsonbEntryQuery.Jsquery_CLOSE);
+            isFollowedBySQLConditionalOperator = false;
+            requiresJSQueryClosure = false;
+        }
+        return taggedStringBuilder;
+    }
+
     //look ahead for a SQL operator
-    private boolean isFollowedBySQLSetOperator(int cursor) {
+    private boolean isFollowedBySQLConditionalOperator(int cursor) {
         if (cursor < whereClause.size() - 1) {
             Object nextToken = whereClause.get(cursor + 1);
-            if (nextToken instanceof String && ((String) nextToken).matches(sqlSetStatementRegexp))
+            if (nextToken instanceof String && ((String) nextToken).trim().matches(sqlConditionalFunctionalOperatorRegexp)) {
+                isFollowedBySQLConditionalOperator = true;
                 return true;
+            }
         }
+        isFollowedBySQLConditionalOperator = false;
         return false;
     }
 
@@ -344,16 +284,30 @@ public class WhereBinder {
         return item;
     }
 
-    public void setInitialCondition(Condition initialCondition) {
-        this.initialCondition = initialCondition;
-    }
-
-    public void setIsWholeComposition() {
-        isWholeComposition = true;
-    }
 
     public WhereBinder setUsePgExtensions(boolean usePgExtensions) {
         this.usePgExtensions = usePgExtensions;
         return this;
     }
+
+    private String expandForCondition(TaggedStringBuilder taggedStringBuilder) {
+        //perform the condition query wrapping depending on the dialect jsquery or sql
+        String wrapped;
+
+        switch (taggedStringBuilder.getTagField()) {
+            case JSQUERY:
+                wrapped = JsonbEntryQuery.Jsquery_COMPOSITION_OPEN + taggedStringBuilder.toString();
+                requiresJSQueryClosure = true;
+                break;
+            case SQLQUERY:
+                wrapped = taggedStringBuilder.toString();
+                break;
+
+            default:
+                throw new IllegalArgumentException("Uninitialized tag passed in query expression");
+        }
+
+        return wrapped;
+    }
+
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereJsQueryExpression.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereJsQueryExpression.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 Christian Chevalley, Vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehrbase.aql.sql.binding;
+
+import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
+
+/**
+ * handles jsquery expression
+ */
+public class WhereJsQueryExpression {
+
+    TaggedStringBuilder expression;
+    Boolean requiresJSQueryClosure;
+    Boolean isFollowedBySQLConditionalOperator;
+
+    public WhereJsQueryExpression(TaggedStringBuilder expression, Boolean requiresJSQueryClosure, Boolean isFollowedBySQLConditionalOperator) {
+        this.expression = expression;
+        this.requiresJSQueryClosure = requiresJSQueryClosure;
+        this.isFollowedBySQLConditionalOperator = isFollowedBySQLConditionalOperator;
+    }
+
+    /**
+     * append the JsQuery tag closure at the right location (e.g. before the following parenthesis!)
+     * @return
+     */
+    private TaggedStringBuilder closeWithJsQueryTag(){
+        if (!requiresJSQueryClosure)
+            return expression;
+
+        if (expression.toString().lastIndexOf(')') == 0)
+            return expression;
+
+        for (int i = expression.toString().lastIndexOf(')') - 1; i >= 0; i--){
+            while (i >= 0 && expression.toString().charAt(i)==')'){
+                i--;
+            }
+            //replace the last parenthesis not preceded by another
+            expression.insert(i+1, JsonbEntryQuery.Jsquery_CLOSE);
+            break;
+        }
+
+        return expression;
+    }
+
+    public TaggedStringBuilder closure(){
+        if (requiresJSQueryClosure) {
+            if (expression.toString().charAt(expression.length()-1)==')' && !isFollowedBySQLConditionalOperator)
+                expression = closeWithJsQueryTag();
+            else
+                expression.append(JsonbEntryQuery.Jsquery_CLOSE);
+            isFollowedBySQLConditionalOperator = false;
+            requiresJSQueryClosure = false;
+        }
+        return expression;
+    }
+}

--- a/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
@@ -106,5 +106,30 @@ public class AqlExpressionTest {
         }
     }
 
+    @Test
+    public void testWhereExpressionWithParenthesis() {
+
+        String query = "select\n" +
+                "    e/ehr_id,\n" +
+                "    a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude,\n" +
+                "    a_a/data[at0002]/events[at0003]/time/value\n" +
+                "from EHR e\n" +
+                "contains COMPOSITION a\n" +
+                "contains OBSERVATION a_a[openEHR-EHR-OBSERVATION.body_temperature.v1]\n" +
+                "where a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude>38\n" +
+                "AND  a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C'\n" +
+                "AND e/ehr_id/value MATCHES {\n" +
+                "    '849bf097-bd16-44fc-a394-10676284a012',\n" +
+                "    '34b2e263-00eb-40b8-88f1-823c87096457'}\n" +
+                "    OR (a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C' AND a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C')";
+
+        AqlExpression cut = new AqlExpression().parse(query);
+
+        Statements statements = new Statements(cut.getParseTree(), new Contains(cut.getParseTree()).process().getIdentifierMapper()).process();
+
+        assertThat(statements.getWhereClause()).isNotNull();
+
+    }
+
 
 }

--- a/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass1Test.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass1Test.java
@@ -47,10 +47,7 @@ public class QueryCompilerPass1Test {
             IdentifierMapper identifierMapper = cut.getIdentifierMapper();
 
             assertThat(identifierMapper.getClassName("e")).isEqualTo("EHR");
-            assertThat(identifierMapper.getEhrContainer().getField()).isNull();
-            assertThat(identifierMapper.getEhrContainer().getIdentifier()).isEqualTo("e");
-            assertThat(identifierMapper.getEhrContainer().getOperator()).isNull();
-            assertThat(identifierMapper.getEhrContainer().getValue()).isNull();
+            assertThat(identifierMapper.getEhrContainer()).isNull();
         }
         // variable for ehr with predicate
         {

--- a/service/src/test/java/org/ehrbase/aql/compiler/WhereClauseUtilTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/WhereClauseUtilTest.java
@@ -1,0 +1,41 @@
+package org.ehrbase.aql.compiler;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class WhereClauseUtilTest {
+
+    @Test
+    public void testIsBalancedBlocks() {
+        List<Object> expression =
+                Arrays.asList(("a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude,>,38," +
+                        "AND,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                        "AND,e::ehr_id/value,IN,(,'849bf097-bd16-44fc-a394-10676284a012',,,'34b2e263-00eb-40b8-88f1-823c87096457',)," +
+                        "OR,(,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                            "AND, a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C',)").split(","));
+
+        assertTrue(new WhereClauseUtil(expression).isBalancedBlocks());
+
+        expression =
+                Arrays.asList(("a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude,>,38," +
+                        "AND,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                        "AND,e::ehr_id/value,IN,'849bf097-bd16-44fc-a394-10676284a012',,,'34b2e263-00eb-40b8-88f1-823c87096457',)," +
+                        "OR,(,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                        "AND, a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C',)").split(","));
+
+        assertFalse(new WhereClauseUtil(expression).isBalancedBlocks());
+
+        expression =
+                Arrays.asList(("a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude,>,38," +
+                        "AND,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                        "AND,e::ehr_id/value,IN,(,'849bf097-bd16-44fc-a394-10676284a012',,,'34b2e263-00eb-40b8-88f1-823c87096457'," +
+                        "OR,(,a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C'," +
+                        "AND, a_a::data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units,=,'°C',)").split(","));
+
+        assertFalse(new WhereClauseUtil(expression).isBalancedBlocks());
+    }
+}

--- a/service/src/test/java/org/ehrbase/aql/compiler/WhereVisitorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/WhereVisitorTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WhereVisitorTest {
@@ -163,5 +164,33 @@ public class WhereVisitorTest {
 
 
         }
+    }
+
+    @Test
+    public void testStructuredAST1()
+    {
+        WhereVisitor cut = new WhereVisitor();
+        String aql = "SELECT e " +
+                "FROM EHR e[ehr_id/value='1234'] " +
+                "WHERE ((e/ehr_id/value = '1111' AND e/ehr_id/value = '2222') OR (e/ehr_id/value = '333' OR e/ehr_id/value = '444')) ";
+        ParseTree tree = QueryHelper.setupParseTree(aql);
+        cut.visit(tree);
+
+        List<Object> whereExpression = cut.getWhereExpression();
+        assertThat(whereExpression).size().isEqualTo(21);
+
+        assertEquals(whereExpression.toString(), "[(, (, e::ehr_id/value, =, '1111', AND, e::ehr_id/value, =, '2222', ), OR, (, e::ehr_id/value, =, '333', OR, e::ehr_id/value, =, '444', ), )]");
+    }
+
+    @Test
+    public void testEmptyWhereStatement()
+    {
+        WhereVisitor cut = new WhereVisitor();
+        String aql = "select e/ehr_id/value from EHR e";
+        ParseTree tree = QueryHelper.setupParseTree(aql);
+        cut.visit(tree);
+
+        List<Object> whereExpression = cut.getWhereExpression();
+        assertThat(whereExpression).size().isEqualTo(0);
     }
 }

--- a/service/src/test/resources/samples/191_where_parenthesis.aql
+++ b/service/src/test/resources/samples/191_where_parenthesis.aql
@@ -1,0 +1,13 @@
+select
+    e/ehr_id,
+    a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude,
+    a_a/data[at0002]/events[at0003]/time/value
+from EHR e
+contains COMPOSITION a
+contains OBSERVATION a_a[openEHR-EHR-OBSERVATION.body_temperature.v1]
+where a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/magnitude>38
+AND  a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C'
+AND e/ehr_id/value MATCHES {
+    '849bf097-bd16-44fc-a394-10676284a012',
+    '34b2e263-00eb-40b8-88f1-823c87096457'}
+    OR (a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C' AND a_a/data[at0002]/events[at0003]/data[at0001]/items[at0004]/value/units = '°C')


### PR DESCRIPTION
## Changes

- Modified Aql.g4 grammar to enable parenthesis support in WHERE clause
- Refactored WhereBinder since it was not supporting multi-level parenthesis expression
- Added parenthesis and other delimiter balancing validation
- Added more unit test
- Fix unit test (case #12  of QueryProcessorTest was wrongly assuming the IN operator was supported by JsQuery) 

## Related issue

Closes: https://github.com/ehrbase/project_management/issues/191

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
