### PR TITLE
refactoring and fixes to support correct canonical json representation

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/EmbeddedValue.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/EmbeddedValue.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.ehr.encode.wrappers.json.writer.translator_db2raw;
+
+import com.google.gson.internal.LinkedTreeMap;
+import org.ehrbase.serialisation.CompositionSerializer;
+
+/**
+ * restructure special items containing a "value" key for canonical representation
+ */
+class EmbeddedValue {
+    private LinkedTreeMap<String, Object> valueMap;
+
+    private String[] embeddedTags = {CompositionSerializer.TAG_NARRATIVE,CompositionSerializer.TAG_MATH_FUNCTION,CompositionSerializer.TAG_WIDTH,CompositionSerializer.TAG_UID};
+
+    EmbeddedValue(LinkedTreeMap<String, Object> valueMap) {
+        this.valueMap = valueMap;
+    }
+
+    private LinkedTreeMap<String, Object> formatForTag(String tag){
+        if (valueMap.containsKey(tag)) {
+            LinkedTreeMap<String, Object> treeMap = (LinkedTreeMap<String, Object>) valueMap.get(tag);
+            //get the value
+            LinkedTreeMap treeMapValue = (LinkedTreeMap) treeMap.get(CompositionSerializer.TAG_VALUE);
+            if (treeMapValue != null)
+                treeMap.replace(CompositionSerializer.TAG_VALUE, treeMapValue.get("value"));
+        }
+
+        return valueMap;
+    }
+
+    LinkedTreeMap<String, Object> formatForEmbeddedTag(){
+        for (String tag: embeddedTags){
+            if (valueMap.containsKey(tag))
+                valueMap =  formatForTag(tag);
+        }
+        return valueMap;
+    }
+}

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/IterativeItemStructure.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/IterativeItemStructure.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.ehr.encode.wrappers.json.writer.translator_db2raw;
+
+import com.google.gson.internal.LinkedTreeMap;
+import org.ehrbase.serialisation.CompositionSerializer;
+
+import java.util.Map;
+
+/**
+ * deals with representation issues required to support AQL at DB level but causing wrong structuration when
+ * returning canonical json. For example
+ * <code>
+ *     /events: {
+ *         /events[at0002]: [
+ *         ...
+ *         ]
+ *     }
+ * </code>
+ *
+ * Should be return as:
+ *
+ * <code>
+ *     {"events":[...,"archetype_node_id":"at0002"}]}
+ * </code>
+ *
+ * The same logic applies to ACTIVITIES
+ */
+class IterativeItemStructure {
+
+    private LinkedTreeMap<String, Object> valueMap;
+
+    private String[] iterativeTags = {CompositionSerializer.TAG_ACTIVITIES,CompositionSerializer.TAG_EVENTS};
+
+
+    IterativeItemStructure(LinkedTreeMap<String, Object> valueMap) {
+        this.valueMap = valueMap;
+    }
+
+    LinkedTreeMap<String, Object> promoteIterations() {
+        for (String iterativeTag: iterativeTags) {
+            if (valueMap.containsKey(iterativeTag)) {
+                LinkedTreeMap<String, Object> activities = (LinkedTreeMap<String, Object>) valueMap.get(iterativeTag);
+                for (Map.Entry<String, Object> activityItem : activities.entrySet()) {
+                    if (activityItem.getKey().startsWith(iterativeTag)) {
+                        valueMap.put(activityItem.getKey(), activityItem.getValue());
+                    }
+                }
+                valueMap.remove(iterativeTag);
+            }
+        }
+        return valueMap;
+    }
+}

--- a/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/ehr/encode/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
@@ -159,47 +159,11 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private LinkedTreeMap reformatEmbeddedValue(LinkedTreeMap instructionMap, String tag) {
-
-        if (instructionMap.containsKey(tag)) {
-            LinkedTreeMap<String, Object> narrative = (LinkedTreeMap<String, Object>) instructionMap.get(tag);
-            //get the value
-            LinkedTreeMap narrativeValue = (LinkedTreeMap) narrative.get(CompositionSerializer.TAG_VALUE);
-            if (narrativeValue != null)
-                narrative.replace(CompositionSerializer.TAG_VALUE, narrativeValue.get("value"));
-        }
-
-        return instructionMap;
-    }
 
     @SuppressWarnings("unchecked")
-    private LinkedTreeMap promoteActivities(LinkedTreeMap<String, Object> instructionMap) {
-
-        if (instructionMap.containsKey(CompositionSerializer.TAG_ACTIVITIES)) {
-            LinkedTreeMap<String, Object> activities = (LinkedTreeMap<String, Object>) instructionMap.get(CompositionSerializer.TAG_ACTIVITIES);
-            for (Map.Entry<String, Object> activityItem : activities.entrySet()) {
-                if (activityItem.getKey().startsWith(CompositionSerializer.TAG_ACTIVITIES)) {
-                    instructionMap.put(activityItem.getKey(), activityItem.getValue());
-                }
-            }
-            instructionMap.remove(CompositionSerializer.TAG_ACTIVITIES);
-        }
-        return instructionMap;
-    }
-
-    @SuppressWarnings("unchecked")
-    private LinkedTreeMap reformatMapForCanonical(LinkedTreeMap map) {
-        if (map.containsKey(CompositionSerializer.TAG_ACTIVITIES))
-            promoteActivities(map);
-        if (map.containsKey(CompositionSerializer.TAG_NARRATIVE))
-            reformatEmbeddedValue(map, CompositionSerializer.TAG_NARRATIVE);
-        if (map.containsKey(CompositionSerializer.TAG_MATH_FUNCTION))
-            reformatEmbeddedValue(map, CompositionSerializer.TAG_MATH_FUNCTION);
-        if (map.containsKey(CompositionSerializer.TAG_WIDTH))
-            reformatEmbeddedValue(map, CompositionSerializer.TAG_WIDTH);
-        if (map.containsKey(CompositionSerializer.TAG_UID))
-            reformatEmbeddedValue(map, CompositionSerializer.TAG_UID);
+    private LinkedTreeMap<String, Object> reformatMapForCanonical(LinkedTreeMap<String, Object> map) {
+        map = new IterativeItemStructure(map).promoteIterations();
+        map = new EmbeddedValue(map).formatForEmbeddedTag();
         return map;
     }
 
@@ -374,6 +338,7 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap> implements 
                     LinkedTreeMap eventMap = (LinkedTreeMap) valueMap.get(CompositionSerializer.TAG_EVENTS);
                     valueMap.remove(CompositionSerializer.TAG_EVENTS);
                     valueMap.putAll(eventMap);
+                    valueMap.put(AT_TYPE, new SnakeCase(elementType).camelToUpperSnake());
                 } else if (archetypeNodeId.equals(CompositionSerializer.TAG_TIMING) && elementType.equals("DvParsable")) {
                     //promote value and formalism
                     Map timingValueMap = (LinkedTreeMap) valueMap.get(CompositionSerializer.TAG_VALUE);

--- a/serialisation/src/test/java/org/ehrbase/serialisation/DBEncodeTest.java
+++ b/serialisation/src/test/java/org/ehrbase/serialisation/DBEncodeTest.java
@@ -23,6 +23,8 @@ import com.nedap.archie.rm.composition.AdminEntry;
 import com.nedap.archie.rm.composition.ContentItem;
 import com.nedap.archie.rm.composition.Evaluation;
 import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datastructures.History;
+import com.nedap.archie.rm.datastructures.PointEvent;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.quantity.DvInterval;
@@ -83,7 +85,7 @@ public class DBEncodeTest {
             //see if this can be interpreted by Archie
             Composition object = new CanonicalJson().unmarshal(converted,Composition.class);
 
-            assertTrue(object != null);
+            assertNotNull(object);
 
             //check if encoded/decode carry the same name
             assertThat(composition.getName().getValue()).isEqualTo(object.getName().getValue());
@@ -105,7 +107,7 @@ public class DBEncodeTest {
         //see if this can be interpreted by Archie
         Composition object = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
 
-        assertTrue(object != null);
+        assertNotNull(object);
 
         String interpreted = new CanonicalXML().marshal(object);
 
@@ -118,7 +120,43 @@ public class DBEncodeTest {
         JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
         Object object = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
 
-        assertTrue(object != null);
+        assertNotNull(object);
+    }
+
+    @Test
+    public void unmarshal_from_js_composition_observation_events() throws IOException {
+        String marshal = IOUtils.resourceToString("/composition/canonical_json/rawdb_composition_observation_event.json", UTF_8);
+        JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
+        Object object = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
+
+        assertNotNull(object);
+    }
+
+    @Test
+    public void unmarshal_from_js_composition_observation_events_data() throws IOException {
+        String marshal = IOUtils.resourceToString("/composition/canonical_json/rawdb_composition_observation_event_item.json", UTF_8);
+        JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
+        Object object = new CanonicalJson().unmarshal(converted.toString(), PointEvent.class);
+
+        assertNotNull(object);
+    }
+
+    @Test
+    public void unmarshal_from_js_events_data_as_array() throws IOException {
+        String marshal = IOUtils.resourceToString("/composition/canonical_json/rawdb_returning_array.json", UTF_8);
+        JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
+        Object object = new CanonicalJson().unmarshal(converted.toString(), PointEvent.class);
+
+        assertNotNull(object);
+    }
+
+    @Test
+    public void unmarshal_from_js_history() throws IOException {
+        String marshal = IOUtils.resourceToString("/composition/canonical_json/rawdb_composition_history.json", UTF_8);
+        JsonElement converted = new LightRawJsonEncoder(marshal).encodeContentAsJson(null);
+        Object object = new CanonicalJson().unmarshal(converted.toString(), History.class);
+
+        assertNotNull(object);
     }
 
     @Test
@@ -139,7 +177,7 @@ public class DBEncodeTest {
         //see if this can be interpreted by Archie
         Composition object = new CanonicalJson().unmarshal(converted,Composition.class);
 
-        assertTrue(object != null);
+        assertNotNull(object);
 
         //check if encoded/decode carry the same name
         assertEquals(sectionOccurrences, object.getContent().size());
@@ -167,7 +205,7 @@ public class DBEncodeTest {
         //see if this can be interpreted by Archie
         Composition object = new CanonicalJson().unmarshal(converted,Composition.class);
 
-        assertTrue(object != null);
+        assertNotNull(object);
 
         String interpreted = new CanonicalXML().marshal(object);
 
@@ -194,7 +232,7 @@ public class DBEncodeTest {
         //see if this can be interpreted by Archie
         Composition object = new CanonicalJson().unmarshal(converted,Composition.class);
 
-        assertTrue(object != null);
+        assertNotNull(object);
 
         String interpreted = new CanonicalXML().marshal(object);
 
@@ -216,7 +254,7 @@ public class DBEncodeTest {
         ((DvInterval)((Element)((AdminEntry)composition.getContent().get(0)).getData().getItems().get(0)).getValue()).setLower(new DvDateTime("2019-11-22T00:00+01:00"));
         ((DvInterval)((Element)((AdminEntry)composition.getContent().get(0)).getData().getItems().get(0)).getValue()).setUpper(new DvDateTime("2019-12-22T00:00+01:00"));
 
-        assertTrue(composition != null);
+        assertNotNull(composition);
 
         String toJson  = new CanonicalJson().marshal(composition);
 
@@ -241,7 +279,7 @@ public class DBEncodeTest {
         //see if this can be interpreted by Archie
         Composition composition2 = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
 
-        assertTrue(composition2 != null);
+        assertNotNull(composition2);
     }
 
 }

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_composition_history.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_composition_history.json
@@ -1,0 +1,65 @@
+{
+  "/name": [
+    {
+      "value": "Event Series"
+    }
+  ],
+  "/events": {
+    "/events[at0002]": [
+      {
+        "/name": [
+          {
+            "value": "Cualquier evento"
+          }
+        ],
+        "/time": {
+          "/name": [
+            {
+              "value": "Cualquier evento"
+            }
+          ],
+          "/value": {
+            "value": "2019-06-27T11:48:03.602+02:00",
+            "epoch_offset": 1561628883
+          },
+          "/$PATH$": "/content[openEHR-EHR-OBSERVATION.minimal.v1 and name/value='Minimal']/data[at0001]/events[at0002 and name/value='Cualquier evento']/time",
+          "/$CLASS$": "DvDateTime"
+        },
+        "/$CLASS$": "PointEvent",
+        "/data[at0003]": {
+          "/$CLASS$": [
+            "ItemTree"
+          ],
+          "/items[at0004]": [
+            {
+              "/name": [
+                {
+                  "value": "text"
+                }
+              ],
+              "/value": {
+                "value": "first value"
+              },
+              "/$PATH$": "/content[openEHR-EHR-OBSERVATION.minimal.v1 and name/value='Minimal']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0004]",
+              "/$CLASS$": "DvText"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "/origin": {
+    "/name": [
+      {
+        "value": "Event Series"
+      }
+    ],
+    "/value": {
+      "value": "2019-06-27T11:48:03.602+02:00",
+      "epoch_offset": 1561628883
+    },
+    "/$PATH$": "/content[openEHR-EHR-OBSERVATION.minimal.v1 and name/value='Minimal']/data[at0001]/origin",
+    "/$CLASS$": "DvDateTime"
+  },
+  "/$CLASS$": "History"
+}

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_composition_observation_event.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_composition_observation_event.json
@@ -1,0 +1,47 @@
+{
+  "/events": {
+    "/events[at0002]": [
+      {
+        "/name": [
+          {
+            "value": "Cualquier evento"
+          }
+        ],
+        "/time": {
+          "/name": [
+            {
+              "value": "Cualquier evento"
+            }
+          ],
+          "/value": {
+            "value": "2019-01-28T21:22:49.332Z",
+            "epoch_offset": 1548710569
+          },
+          "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/time",
+          "/$CLASS$": "DvDateTime"
+        },
+        "/$CLASS$": "PointEvent",
+        "/data[at0003]": {
+          "/$CLASS$": [
+            "ItemTree"
+          ],
+          "/items[at0004]": [
+            {
+              "/name": [
+                {
+                  "value": "text"
+                }
+              ],
+              "/value": {
+                "value": "aValue"
+              },
+              "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0004]",
+              "/$CLASS$": "DvText"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "/$CLASS$": "History"
+}

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_composition_observation_event_item.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_composition_observation_event_item.json
@@ -1,0 +1,43 @@
+[
+  {
+    "/name": [
+      {
+        "value": "Cualquier evento"
+      }
+    ],
+    "/time": {
+      "/name": [
+        {
+          "value": "Cualquier evento"
+        }
+      ],
+      "/value": {
+        "value": "2019-01-28T21:22:49.332Z",
+        "epoch_offset": 1548710569
+      },
+      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/time",
+      "/$CLASS$": "DvDateTime"
+    },
+    "/$CLASS$": "PointEvent",
+    "/data[at0003]": {
+      "/$CLASS$": [
+        "ItemTree"
+      ],
+      "/items[at0004]": [
+        {
+          "/name": [
+            {
+              "value": "text"
+            }
+          ],
+          "/value": {
+            "value": "aValue"
+          },
+          "/$PATH$": "/content[openEHR-EHR-OBSERVATION.test_all_types.v1 and name/value='Test all types']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0004]",
+          "/$CLASS$": "DvText"
+        }
+      ]
+    }
+  }
+]
+

--- a/test-data/src/main/resources/composition/canonical_json/rawdb_returning_array.json
+++ b/test-data/src/main/resources/composition/canonical_json/rawdb_returning_array.json
@@ -1,0 +1,42 @@
+[
+  {
+    "/name": [
+      {
+        "value": "Cualquier evento"
+      }
+    ],
+    "/time": {
+      "/name": [
+        {
+          "value": "Cualquier evento"
+        }
+      ],
+      "/value": {
+        "value": "2019-06-27T11:48:03.602+02:00",
+        "epoch_offset": 1561628883
+      },
+      "/$PATH$": "/content[openEHR-EHR-OBSERVATION.minimal.v1 and name/value='Minimal']/data[at0001]/events[at0002 and name/value='Cualquier evento']/time",
+      "/$CLASS$": "DvDateTime"
+    },
+    "/$CLASS$": "PointEvent",
+    "/data[at0003]": {
+      "/$CLASS$": [
+        "ItemTree"
+      ],
+      "/items[at0004]": [
+        {
+          "/name": [
+            {
+              "value": "text"
+            }
+          ],
+          "/value": {
+            "value": "first value"
+          },
+          "/$PATH$": "/content[openEHR-EHR-OBSERVATION.minimal.v1 and name/value='Minimal']/data[at0001]/events[at0002 and name/value='Cualquier evento']/data[at0003]/items[at0004]",
+          "/$CLASS$": "DvText"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Changes

This is to fix several issues when returning canonical json in AQL:

### Events
```
{
  "q": "select o/data[at0001]
	from EHR e
	contains COMPOSITION c
	contains OBSERVATION o[openEHR-EHR-OBSERVATION.minimal.v1]
" 
}
```
Was:

```
    "rows": [
        [
            {
                "name": {
                    "value": "Event Series"
                },
                "events": {
                    "events": [
                        {
                            "name": {
                                "value": "Cualquier evento"
                            },
                            "time": {
                                "value": "2019-01-28T21:22:19.562Z",
                                "_type": "DV_DATE_TIME"
                            },
 ``` 
The expression
```
                "events": {
                    "events": [
```
is replaced with 
```
                 "events": [
```
### Similar issue when an AQL query return an array
```
{
  "q": "select o/data[at0001]/events[at0002]
	from EHR e
	contains COMPOSITION c
	contains OBSERVATION o[openEHR-EHR-OBSERVATION.minimal.v1]
" 
}
```
Was
```
    "rows": [
        [
            {
                "items": [
                    {
                        "name": {
                            "value": "Cualquier evento"
                        },
                        "time": {
                            "value": "2019-01-28T21:22:19.562Z",
                            "_type": "DV_DATE_TIME"
                        },
                        "_type": "POINT_EVENT",
                        "data": {
                            "archetype_node_id": "at0003",
                            "_type": "ITEM_TREE",
                            "items": [
                                {
                                    "name": {
                                        "value": "text"
                                    },
                                    "value": {
                                        "value": "modified value",
                                        "_type": "DV_TEXT"
                                    },
                                    "_type": "ELEMENT",
                                    "archetype_node_id": "at0004"
                                }
                            ]
                        }
                    }
                ]
            }
        ],
```
Now:
```
   "rows": [
        [
           
                    {
                        "name": {
                            "value": "Cualquier evento"
                        },
                        "time": {
                            "value": "2019-01-28T21:22:19.562Z",
                            "_type": "DV_DATE_TIME"
                        },
                        "_type": "POINT_EVENT",
                        "data": {
                            "archetype_node_id": "at0003",
                            "_type": "ITEM_TREE",
                            "items": [
                                {
                                    "name": {
                                        "value": "text"
                                    },
                                    "value": {
                                        "value": "modified value",
                                        "_type": "DV_TEXT"
                                    },
                                    "_type": "ELEMENT",
                                    "archetype_node_id": "at0004"
                                }
                            ]
                        }
                    }
        ],
````

Several jUnit tests illustrate this translation:
```
DBEncodeTest::unmarshal_from_js_composition_observation_events()
DBEncodeTest::unmarshal_from_js_composition_observation_events_data()
DBEncodeTest:unmarshal_from_js_events_data_as_array()
DBEncodeTest:unmarshal_from_js_history()
```

## Related issue

Closes: https://github.com/ehrbase/project_management/issues/185

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
