### PR TITLE
fixes origin querying as well as name canonical json representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added validation checking for other_details and ehr_status. (see: https://github.com/ehrbase/ehrbase/pull/207)
 - Supports archetype_node_id and name for EHR_STATUS (see: https://github.com/ehrbase/ehrbase/pull/207)
+- fixes bad canonical encoding for observation/data/origin (see: https://github.com/ehrbase/ehrbase/pull/213)
 
 ## [0.12.0] (alpha)
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/EntryAttributeMapper.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/EntryAttributeMapper.java
@@ -124,27 +124,19 @@ public class EntryAttributeMapper {
                 else if ((ndxInterval = intervalValueIndex(fields)) > 0) { //interval
                     fields.add(ndxInterval, INTERVAL);
                 } else if (match != 0) {
-                    fields.set(match, SLASH_VALUE);
-                    if (match == fields.size() - 1)
-                        fields.add(VALUE);
+                    //deals with name/value (name value is contained into a list conventionally
+                    if (match > 1 && fields.get(match - 1).equals("name"))
+                        fields.set(match, VALUE);
+                    else
+                        //usual /value
+                        fields.set(match, SLASH_VALUE);
+
                 } else if (match + 1 < fields.size() - 1) {
                     Integer first = firstOccurence(match + 1, fields, VALUE);
                     if (first != null && first == match + 1)
                         fields.set(match + 1, SLASH_VALUE);
                 }
             }
-//            match = firstOccurence(0, fields, "name");
-//            if (match != null) {
-//                if (match < fields.size() - 1) {
-//                    if (fields.get(match + 1).equals("name")) {
-//                        fields.set(match + 1, "/name");
-//                    }
-//                }
-//                else if (match+1 == fields.size()){
-//                    //set it with a "/"
-//                    fields.set(match, "/name");
-//                }
-//            }
         }
 
         //prefix the first element
@@ -152,7 +144,14 @@ public class EntryAttributeMapper {
 
         //deals with the remainder of the array
         for (int i = floor; i < fields.size(); i++) {
-            fields.set(i, toCamelCase(fields.get(i)));
+
+            if (fields.get(i).toUpperCase().equals("NAME")){
+                //whenever the canonical json for name is queried
+                fields.set(i, "/name,0");
+            }
+            else
+                fields.set(i, toCamelCase(fields.get(i)));
+
         }
 
         //elegant...

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -66,7 +66,8 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
 
     //CCH 191018 EHR-163 matches trailing '/value'
     // '/name,0' is to matches path relative to the name array
-    public final static String matchNodePredicate = "(/(content|events|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\])|(/value|/value,definingCode|/time|/name,0)";
+    public final static String matchNodePredicate = "(/(content|events|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\])|" +
+            "(/value|/value,definingCode|/time|/name,0|/origin|/origin,/name,0|/origin,/value)";
 
     //Generic stuff
     private final static String JSONBSelector_CLOSE = "}'";
@@ -199,12 +200,7 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
                 } else {
                     jqueryPath.add(nodeId);
                 }
-//            if (StringUtils.endsWithAny(jquery, new String[]{"/value"}))
-//                //append the value key
-//                jquery += ",value";
         }
-
-//        String jquery = StringUtils.join(jqueryPath.toArray(new String[] {}));
 
         useEntry = true;
         //CHC 191018 EHR-163 '/value' for an ELEMENT will return a structure


### PR DESCRIPTION
## Changes
fix bad canonical json formatting when querying and observation origin (f.e.```o/data[at0001]/origin`` where `o` is an OBSERVATION.

## Related issue
closes: https://github.com/ehrbase/project_management/issues/225


## Additional information and checks

- [x] Pull request linked in changelog
