### PR TITLE
AQL test updates and fixes

### DIFF
--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -33,11 +33,11 @@ tasks:
           - task: stopdb
 
     starteb:
-        desc: START EHRBASE SERVER W/O CACHING (CACHE DISABLED!)
+        desc: START EHRBASE SERVER W/O CACHING (CACHE DISABLED!) and allow temple-override
         cmds:
           - echo ... starting EHRbase server ...
           # - java -jar ../application/target/application-0.12.0.jar --cache.enabled=false --server.nodename=manual.execution.org > log &
-          - java -jar ../application/target/application-0.12.0.jar --cache.enabled=false > log &
+          - java -jar ../application/target/application-0.12.0.jar --cache.enabled=false --system.allow-template-overwrite=true > log &
           - sleep 20
           - echo ... EHRbase server started.
           #- grep -m 1 "Started EhrBase in" <(tail -f log)   # FAIL!

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -72,12 +72,22 @@ tasks:
           - docker container rm -f ehrdb
           - echo ... DB server stopped.
 
+    package:
+        desc: mvn package -Dmaven.javadoc.skip=true
+        cmds:
+          - cd .. && mvn package -Dmaven.javadoc.skip=true
+
+    cpackage:
+        desc: mvn clean package -Dmaven.javadoc.skip=true
+        cmds:
+          - cd .. && mvn clean package -Dmaven.javadoc.skip=true
+
     test:
         desc: RUN SPECIFIED TESTS
         cmds:
-          # adjust this part to the needs of your current test session
+          ## adjust this part to the needs of your current test session
           - robot -v nodocker -i empty_db -e future -e circleci -e TODO -e obsolete -d results -L TRACE --noncritical not-ready robot/QUERY_SERVICE_TESTS
-          # example of "execute single test by it's test-case name" (wildcards accepted):
+          ## example of "execute single test by it's test-case name" (wildcards accepted):
           # - robot -t "MF-030 - Create new EHR*" -d results -L TRACE robot/EHR_SERVICE_TESTS
           # - spd-say "Robot is ready! Check the results!"
 
@@ -93,6 +103,6 @@ tasks:
           - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output aqledb.xml --name "QUERY empty_db"  -i empty_db  robot/QUERY_SERVICE_TESTS
           - robot -e future -e circleci -e TODO -e obsolete -e libtest -d results/xml -L TRACE --noncritical not-ready --log None --report None --output aqlldb.xml --name "QUERY loaded_db" -i loaded_db robot/QUERY_SERVICE_TESTS
 
-          # consolidate results
+          ## consolidate results
           - rebot -e future -e circleci -e TODO -e obsolete -e libtest -d results -L TRACE --noncritical not-ready --name EHRbase results/xml/*.xml
           # - spd-say "Robot is ready! Check the results!"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ robotframework-databaselibrary == 1.2.4
 RESTinstance == 1.0.0
 
 docker == 4.0.2
-deepdiff == 4.0.6
+deepdiff == 4.3.2
 psycopg2-binary == 2.8.4
 
 # pyjwt

--- a/tests/robot/QUERY_SERVICE_TESTS/00_AQL_SMOKE_TEST.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/00_AQL_SMOKE_TEST.robot
@@ -195,22 +195,30 @@ A-101 Execute Ad-Hoc Query - Get EHRs
 
 B-100 Execute Ad-Hoc Query - Get Compositions From All EHRs
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              235
     B/100_get_compositions_from_all_ehrs.json    B/100.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  235  not-ready
+
+
+B-102 Execute Ad-Hoc Query - Get Compositions (ordered by: name)
+    [Template]          execute ad-hoc query and check result (loaded DB)
+    [Tags]              TODO
+    B/102_get_compositions_orderby_name.json    B/102.tmp.json
+    # execute ad-hoc query    B/102_get_compositions_orderby_name.json
+    # check response (LOADED DB): returns correct ordered content    B/102.tmp.json
+    [Teardown]          TRACE GITHUB ISSUE  TODO  not-ready
 
 
 B-400 Execute Ad-Hoc Query - Get Composition(s)
-    [Documentation]     NOTE: activate commit of "all_types.composition.json"
-    ...                       in PRECONDITIONS step to make this test work!
+    [Documentation]     Test w/ "all_types.composition.json" commit
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              227
+    [Tags]              234
     B/400_get_compositions_contains_section_with_archetype_from_all_ehrs.json    B/400.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  227  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  234  not-ready
 
 
 B-800 Execute Ad-Hoc Query - Get Compositions By UID
-    [Documentation]     B/800: SELECT c FROM COMPOSITION c [uid/value='123::local.ehrbase.org::1']
+    [Documentation]     B/800: SELECT c FROM COMPOSITION c [uid/value='123::node.name.com::1']
     ...                 B/801: SELECT c FROM COMPOSITION c [uid/value=$uid]
     [Template]          execute ad-hoc query and check result (loaded DB)
     [Tags]              109    future
@@ -224,7 +232,7 @@ D-306 Execute Ad-HOc Query - Get Data
     [Template]          execute ad-hoc query and check result (loaded DB)
     [Tags]              206
     D/306_select_data_values_from_all_ehrs_contains_composition_with_archetype.json    D/306.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  191  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  206  not-ready
 
 
 D-309 Execute Ad-HOc Query - Get Data
@@ -242,14 +250,6 @@ D-312 Execute Ad-HOc Query - Get Data
     D/312_select_data_values_from_all_ehrs_contains_composition_with_archetype_top_5.json    D/312.tmp.json
 
 
-D-400 Execute Ad-HOc Query - Get Data
-    [Documentation]     Get Data related query.
-    [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              207
-    D/400_query.tmp.json    D/400.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  207  not-ready
-
-
 D-500 Execute Ad-HOc Query - Get Data
     [Documentation]     Get Data related query.
     [Template]          execute ad-hoc query and check result (loaded DB)
@@ -261,9 +261,9 @@ D-500 Execute Ad-HOc Query - Get Data
 D-501 Execute Ad-HOc Query - Get Data
     [Documentation]     Get Data related query.
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              225
+    [Tags]              236
     D/501_query.tmp.json    D/501.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  225  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  236  not-ready
 
 
 CLEAN UP SUT

--- a/tests/robot/QUERY_SERVICE_TESTS/00_AQL_SMOKE_TEST.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/00_AQL_SMOKE_TEST.robot
@@ -115,7 +115,7 @@ AQL LOADED DB SMOKE TEST
         # execute ad-hoc query and check result (loaded DB)  B/101_get_compositions_top_5.json    B/101.tmp.json
         # execute ad-hoc query and check result (loaded DB)  B/102_get_compositions_orderby_name.json    B/102.tmp.json
         # execute ad-hoc query and check result (loaded DB)  B/103_get_compositions_within_timewindow.json    B/103.tmp.json
-        # execute ad-hoc query and check result (loaded DB)  B/200_query.tmp.json    B/200.tmp.json
+        # execute ad-hoc query and check result (loaded DB)  B/200_get_compositions_from_ehr_by_id.json    B/200.tmp.json
         # execute ad-hoc query and check result (loaded DB)  B/300_get_compositions_with_archetype_from_all_ehrs.json    B/300.tmp.json
         # execute ad-hoc query and check result (loaded DB)  B/400_get_compositions_contains_section_with_archetype_from_all_ehrs.json    B/400.tmp.json
         # execute ad-hoc query and check result (loaded DB)  B/500_get_compositions_by_contains_entry_of_type_from_all_ehrs.json    B/500.tmp.json

--- a/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
@@ -176,9 +176,9 @@ A-600 Execute Ad-Hoc Query - Get EHRs Which Have Compositions
 
 B-100 Execute Ad-Hoc Query - Get Compositions From All EHRs
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/100_get_compositions_from_all_ehrs.json    B/100.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-101 Execute Ad-Hoc Query - Get Compositions (filtered: top 5)
@@ -191,6 +191,7 @@ B-102 Execute Ad-Hoc Query - Get Compositions (ordered by: name)
     [Template]          execute ad-hoc query and check result (loaded DB)
     [Tags]              TODO    not-ready
     B/102_get_compositions_orderby_name.json    B/102.tmp.json
+    ## comment: check SMOKE test suite
 
 
 B-103 Execute Ad-Hoc Query - Get Compositions (filtered: timewindow)
@@ -213,71 +214,70 @@ B-105 Get Compositions (filtered: top 5, ordered by: start_time DESC)
 
 B-200 Execute Ad-Hoc Query - Get Compositions From All EHRs
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/200_query.tmp.json    B/200.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-300 Execute Ad-Hoc Query - Get Compositions From All EHRs
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/300_get_compositions_with_archetype_from_all_ehrs.json    B/300.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-400 Execute Ad-Hoc Query - Get Composition(s)
-    [Documentation]     NOTE: activate commit of "all_types.composition.json"
-    ...                       in PRECONDITIONS step to make this test work!
+    [Documentation]     Test w/ "all_types.composition.json" commit
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              227
+    [Tags]              234
     B/400_get_compositions_contains_section_with_archetype_from_all_ehrs.json    B/400.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  227  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  234  not-ready
 
 
 B-500 Execute Ad-Hoc Query - Get Composition(s)
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/500_get_compositions_by_contains_entry_of_type_from_all_ehrs.json    B/500.tmp.json
     B/501_get_compositions_by_contains_entry_of_type_from_all_ehrs.json    B/501.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-502 Execute Ad-Hoc Query - Get Composition(s)
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/502_get_compositions_by_contains_entry_of_type_from_all_ehrs.json    B/502.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-503 Execute Ad-Hoc Query - Get Composition(s)
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/503_get_compositions_by_contains_entry_of_type_from_all_ehrs.json    B/503.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-600 Execute Ad-Hoc Query - Get Composition(s)
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/600_get_compositions_by_contains_entry_with_archetype_from_all_ehrs.json    B/600.tmp.json
     B/601_get_compositions_by_contains_entry_with_archetype_from_all_ehrs.json    B/601.tmp.json
     B/602_get_compositions_by_contains_entry_with_archetype_from_all_ehrs.json    B/602.tmp.json
     B/603_get_compositions_by_contains_entry_with_archetype_from_all_ehrs.json    B/603.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 
 B-700 Execute Ad-Hoc Query - Get Composition(s)
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/700_get_compositions_by_contains_entry_with_archetype_and_condition_from_all_ehrs.json    B/700.tmp.json
     B/701_get_compositions_by_contains_entry_with_archetype_and_condition_from_all_ehrs.json    B/701.tmp.json
     B/702_get_compositions_by_contains_entry_with_archetype_and_condition_from_all_ehrs.json    B/702.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 B-800 Execute Ad-Hoc Query - Get Compositions By UID
-    [Documentation]     B/800: SELECT c FROM COMPOSITION c [uid/value='123::local.ehrbase.org::1']
+    [Documentation]     B/800: SELECT c FROM COMPOSITION c [uid/value='123::node.name.com::1']
     ...                 B/801: SELECT c FROM COMPOSITION c [uid/value=$uid]
     [Template]          execute ad-hoc query and check result (loaded DB)
     [Tags]              109    future
@@ -287,13 +287,13 @@ B-800 Execute Ad-Hoc Query - Get Compositions By UID
 
 
 B-802 Execute Ad-Hoc Query - Get Compositions By UID
-    [Documentation]     B/802: SELECT c FROM COMPOSITION c WHERE c/uid/value='123::local.ehrbase.org::1'
+    [Documentation]     B/802: SELECT c FROM COMPOSITION c WHERE c/uid/value='123::node.name.com::1'
     ...                 B/803: SELECT c FROM COMPOSITION c WHERE c/uid/value=$uid
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              199
+    [Tags]              TBD
     B/802_query.tmp.json    B/802.tmp.json
     B/803_query.tmp.json    B/803.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  199  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  TBD  not-ready
 
 
 D-200 Execute Ad-HOc Query - Get Data
@@ -466,9 +466,9 @@ D-500 Execute Ad-HOc Query - Get Data
 D-501 Execute Ad-HOc Query - Get Data
     [Documentation]     Get Data related query.
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              225
+    [Tags]              236
     D/501_query.tmp.json    D/501.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  225  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  236  not-ready
 
 
 D-502 Execute Ad-HOc Query - Get Data

--- a/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__z_Empty_DB.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__z_Empty_DB.robot
@@ -316,14 +316,14 @@ D-306 Execute Ad-Hoc Query - Get Data
     [Template]          execute ad-hoc query and check result (empty DB)
     [Tags]              data    206
     D/306_select_data_values_from_all_ehrs_contains_composition_with_archetype.json
-    [Teardown]          TRACE GITHUB ISSUE  191  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  206  not-ready
 
 
 D-307 Execute Ad-Hoc Query - Get Data
     [Template]          execute ad-hoc query and check result (empty DB)
     [Tags]              data    206
     D/307_select_data_values_from_all_ehrs_contains_composition_with_archetype.json
-    [Teardown]          TRACE GITHUB ISSUE  191  not-ready
+    [Teardown]          TRACE GITHUB ISSUE  206  not-ready
 
 
 D-311 Execute Ad-Hoc Query - Get Data

--- a/tests/robot/_resources/keywords/aql_query_keywords.robot
+++ b/tests/robot/_resources/keywords/aql_query_keywords.robot
@@ -270,11 +270,6 @@ check response (LOADED DB): returns correct content
                         Log To Console  \n/////////// EXPECTED //////////////////////////////
                         Output    ${expected result}
 
-    ## comment: RESTORE THIS IF LAST CHANGE BREAKS TO MUCH!
-    # &{diff}=            compare json-strings  ${response body}  ${expected result}
-    # ...                 report_repetition=True
-    # ...                 exclude_paths=root['meta']
-
     &{diff}             compare_jsons_ignoring_properties    ${response body}    ${expected result}
     # ...                 meta    path    foo        # comment: example of how to add additional
                                                      #          properties to be ignored
@@ -298,17 +293,6 @@ check response (LOADED DB): returns correct ordered content
                         Log To Console  \n/////////// EXPECTED //////////////////////////////
                         Output    ${expected result}
     
-    ## comment: working example
-    # ${exclude_paths}    Create List    root\\['meta'\\]    \\['columns'\\]\\[\\d+\\]\\['path'\\]
-    #                     ...            \\['_type'\\]
-    # &{diff}             compare json-strings    ${response body}    ${expected result}
-    #                     ...                     exclude_regex_paths=${exclude_paths}
-    #                     ...                     ignore_order=False
-
-    ## comment: working example
-    # &{diff}             compare_ignoring_path_and_type_properties    ${response body}    ${expected result}
-    #                     ...    ignore_order=${FALSE}
-
     # TODO: probably need to sort the expected result before comparison
     
     &{diff}             compare_jsons_ignoring_properties    ${response body}    ${expected result}
@@ -1658,3 +1642,11 @@ D/503
 #                         ...                 auth=${${SUT}.CREDENTIALS}    debug=2    verify=True
 
 #                         Set Test Variable   ${headers}    ${headers}
+
+
+# Example of how to properly escape regex expressions to use with DeepDiff lib
+#    ${exclude_paths}    Create List    root\\['meta'\\]    \\['columns'\\]\\[\\d+\\]\\['path'\\]
+#                        ...            \\['_type'\\]
+#    &{diff}             compare json-strings    ${response body}    ${expected result}
+#                        ...                     exclude_regex_paths=${exclude_paths}
+#                        ...                     ignore_order=False

--- a/tests/robot/_resources/keywords/aql_query_keywords.robot
+++ b/tests/robot/_resources/keywords/aql_query_keywords.robot
@@ -270,9 +270,16 @@ check response (LOADED DB): returns correct content
                         Log To Console  \n/////////// EXPECTED //////////////////////////////
                         Output    ${expected result}
 
-    &{diff}=            compare json-strings  ${response body}  ${expected result}
-    ...                 report_repetition=True
-    ...                 exclude_paths=root['meta']
+    ## comment: RESTORE THIS IF LAST CHANGE BREAKS TO MUCH!
+    # &{diff}=            compare json-strings  ${response body}  ${expected result}
+    # ...                 report_repetition=True
+    # ...                 exclude_paths=root['meta']
+
+    &{diff}             compare_jsons_ignoring_properties    ${response body}    ${expected result}
+    # ...                 meta    path    foo        # comment: example of how to add additional
+                                                     #          properties to be ignored
+    ...                 report_repetition=${TRUE}
+
                         Should Be Empty  ${diff}  msg=DIFF DETECTED!
 
 
@@ -282,10 +289,34 @@ check response (LOADED DB): returns correct content
 #     &{diff}=            compare json-strings  ${response body}  ${expected result}  exclude_paths=root['meta']
 
 
-# check response (LOADED DB): returns correct ordered content for
-#     [Arguments]         ${aql_payload}
-#                         load expected results-data-set (LOADED DB)    ${aql_payload}
-#     &{diff}=            compare json-strings  ${response body}  ${expected result}  exclude_paths=root['meta']
+check response (LOADED DB): returns correct ordered content
+    [Documentation]     expected result is generated at runtime and saved as .tmp.json
+    ...                 in the same folder as the related blueprint
+    [Arguments]         ${path_to_expected_result}
+                        load expected results-data-set (LOADED DB)    ${path_to_expected_result}
+
+                        Log To Console  \n/////////// EXPECTED //////////////////////////////
+                        Output    ${expected result}
+    
+    ## comment: working example
+    # ${exclude_paths}    Create List    root\\['meta'\\]    \\['columns'\\]\\[\\d+\\]\\['path'\\]
+    #                     ...            \\['_type'\\]
+    # &{diff}             compare json-strings    ${response body}    ${expected result}
+    #                     ...                     exclude_regex_paths=${exclude_paths}
+    #                     ...                     ignore_order=False
+
+    ## comment: working example
+    # &{diff}             compare_ignoring_path_and_type_properties    ${response body}    ${expected result}
+    #                     ...    ignore_order=${FALSE}
+
+    # TODO: probably need to sort the expected result before comparison
+    
+    &{diff}             compare_jsons_ignoring_properties    ${response body}    ${expected result}
+    ...                 meta    path
+    ...                 ignore_order=${FALSE}
+    ...                 report_repetition=${TRUE}
+
+                        Should Be Empty    ${diff}    msg=DIFF DETECTED!
 
 
 check response (EMPTY DB): returns correct content for
@@ -591,9 +622,13 @@ Commit Compo
     &{resp}=            REST.POST    ${baseurl}/ehr/${ehr_id}/composition    ${compo_file}
                         Output Debug Info To Console
                         Integer    response status    201
-    &{body}=            Output     response body
                         Set Suite Variable    ${response}    ${resp}
-   
+
+    # comment: This returns the object from response body wrapped in a list []
+    #          That's exactly what we need to inject into expected-result blueprint most of the time.
+    #          In cases where you need the oject itself use index 0 on that list: ${compo_in_list}[0]
+    @{body}=            Object     response body
+                        Set Suite Variable    ${compo_in_list}    ${body}
                         Set Suite Variable    ${compo_uid_value}    ${response.body.uid.value}
                         Set Suite Variable    ${compo_uid}    ${response.body.uid}    
                         Set Suite Variable    ${compo_name_value}    ${response.body.name.value}
@@ -626,6 +661,7 @@ Commit Compo
     ###########################################################################################
 
     B/100
+    B/102
     B/200
     B/300
     B/400
@@ -695,11 +731,6 @@ Commit Compo
     # ${B/101}=           Load JSON From File    ${QUERY RESULTS LOADED DB}/B/101.tmp.json
     # ${B/101}=           Add Object To Json     ${B/101}    $.rows    ${response.body}
     #                     Output    ${B/101}     ${QUERY RESULTS LOADED DB}/B/101.tmp.json
-
-    # # NOT READY - order Composisions by name (GITHUB #105)
-    # ${B/102}=           Load JSON From File    ${QUERY RESULTS LOADED DB}/B/102.tmp.json
-    # ${B/102}=           Add Object To Json     ${B/102}    $.rows    ${response.body}
-    #                     Output    ${B/102}     ${QUERY RESULTS LOADED DB}/B/102.tmp.json
 
     # # NOT READY - "TIMEWINDOW" not implemented (GITHUB #106)
     # ${B/103}=           Load JSON From File    ${QUERY RESULTS LOADED DB}/B/103.tmp.json
@@ -1029,8 +1060,14 @@ A/603
 
 B/100
     ${B/100}=           Load JSON From File    ${QUERY RESULTS LOADED DB}/B/100.tmp.json
-    ${B/100}=           Add Object To Json     ${B/100}    $.rows    ${response.body}
+    ${B/100}=           Add Object To Json     ${B/100}    $.rows    ${compo_in_list}
                         Output    ${B/100}     ${QUERY RESULTS LOADED DB}/B/100.tmp.json
+
+B/102
+    Return From Keyword If    (${ehr_index}>=5)    nothing to do here!
+    ${B/102}=           Load JSON From File    ${QUERY RESULTS LOADED DB}/B/102.tmp.json
+    ${B/102}=           Add Object To Json     ${B/102}    $.rows    ${compo_in_list}
+                        Output    ${B/102}     ${QUERY RESULTS LOADED DB}/B/102.tmp.json
 
 B/200
     Return From Keyword If    not (${ehr_index}==1)    nothing to do here!
@@ -1043,67 +1080,67 @@ B/200
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/200.tmp.json
                         Update Value To Json   ${expected}    $.q    SELECT c FROM EHR e [ehr_id/value='${ehr_id}'] CONTAINS COMPOSITION c
                         Update Value To Json   ${expected}    $.meta._executed_aql    SELECT c FROM EHR e [ehr_id/value='${ehr_id}'] CONTAINS COMPOSITION c
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/200.tmp.json
 
 B/300
     Return From Keyword If    not ("${compo_archetype_id_value}"=="openEHR-EHR-COMPOSITION.minimal.v1")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/300.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/300.tmp.json
 
 B/400
     Return From Keyword If    not ("${compo_archetype_id_value}"=="openEHR-EHR-COMPOSITION.test_all_types.v1")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/400.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/400.tmp.json
 
 B/500
     Return From Keyword If    not ("${compo_content_type}"=="OBSERVATION")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/500.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/500.tmp.json
 
 B/501
     Return From Keyword If    not ("${compo_content_type}"=="EVALUATION")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/501.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/501.tmp.json
 
 B/502
     Return From Keyword If    not ("${compo_content_type}"=="INSTRUCTION")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/502.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/502.tmp.json
 
 B/503
     Return From Keyword If    not ("${compo_content_type}"=="ACTION")    nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/503.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/503.tmp.json
 
 B/600
     Return From Keyword If    not ("${compo_content_archetype_node_id}"=="openEHR-EHR-OBSERVATION.minimal.v1")   nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/600.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/600.tmp.json
 
 B/601
     Return From Keyword If    not ("${compo_content_archetype_node_id}"=="openEHR-EHR-EVALUATION.minimal.v1")   nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/601.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/601.tmp.json
 
 B/602
     Return From Keyword If    not ("${compo_content_archetype_node_id}"=="openEHR-EHR-INSTRUCTION.minimal.v1")   nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/602.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/602.tmp.json
 
 B/603
     Return From Keyword If    not ("${compo_content_archetype_node_id}"=="openEHR-EHR-ACTION.minimal_2.v1")   nothing to do here!
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/603.tmp.json
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/603.tmp.json
 
 B/700 701 702
@@ -1112,7 +1149,7 @@ B/700 701 702
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/${dataset}.tmp.json
     ${items}            Set Variable    ${response.body.content[0].data.events[0].data["items"]}
     ${obs_value}        Set Variable    ${items[0].value.value}
-                        Run Keyword If    "${obs_value}"=="first value"    Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Run Keyword If    "${obs_value}"=="first value"    Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Run Keyword Unless    "${obs_value}"=="first value"    Return From Keyword
                         Output    ${expected}    ${QUERY RESULTS LOADED DB}/${dataset}.tmp.json
 
@@ -1127,7 +1164,7 @@ B/800
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/800.tmp.json
                         Update Value To Json   ${expected}    $.q    SELECT c FROM COMPOSITION c [uid/value='${compo_uid_value}']
                         Update Value To Json   ${expected}    $.meta._executed_aql    SELECT c FROM COMPOSITION c [uid/value='${compo_uid_value}']
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/800.tmp.json
 
 B/801
@@ -1139,7 +1176,7 @@ B/801
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/801.tmp.json
                         Update Value To Json   ${expected}    $.q    SELECT c FROM COMPOSITION c [uid/value='${compo_uid_value}']
                         Update Value To Json   ${expected}    $.meta._executed_aql    SELECT c FROM COMPOSITION c [uid/value='${compo_uid_value}']
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/801.tmp.json
 
 B/802
@@ -1151,7 +1188,7 @@ B/802
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/802.tmp.json
                         Update Value To Json   ${expected}    $.q    SELECT c FROM COMPOSITION c WHERE c/uid/value='${compo_uid_value}'
                         Update Value To Json   ${expected}    $.meta._executed_aql    SELECT c FROM COMPOSITION c WHERE c/uid/value='${compo_uid_value}'
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/802.tmp.json
 
 B/803
@@ -1163,7 +1200,7 @@ B/803
     ${expected}=        Load JSON From File    ${QUERY RESULTS LOADED DB}/B/803.tmp.json
                         Update Value To Json   ${expected}    $.q    SELECT c FROM COMPOSITION c WHERE c/uid/value='${compo_uid_value}'
                         Update Value To Json   ${expected}    $.meta._executed_aql    SELECT c FROM COMPOSITION c WHERE c/uid/value='${compo_uid_value}'
-                        Add Object To Json     ${expected}    $.rows    ${response.body}
+                        Add Object To Json     ${expected}    $.rows    ${compo_in_list}
                         Output    ${expected}     ${QUERY RESULTS LOADED DB}/B/803.tmp.json
 
 

--- a/tests/robot/_resources/keywords/aql_query_keywords.robot
+++ b/tests/robot/_resources/keywords/aql_query_keywords.robot
@@ -311,7 +311,7 @@ check response (EMPTY DB): returns correct content for
                         Log To Console  \n/////////// EXPECTED //////////////////////////////
                         Output    ${expected result}
 
-    &{diff}=            compare json-strings  ${response body}  ${expected result}  exclude_paths=root['meta']
+    &{diff}=            compare_jsons_ignoring_properties  ${response body}  ${expected result}
                         Should Be Empty  ${diff}  msg=DIFF DETECTED!
 
 

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -434,7 +434,6 @@ startup SUT
                ...      Set Global Variable    ${CONTROL_MODE}    ${DEV.CONTROL}
 
                         Log    \n\t SUT CONFIG (EHRbase v${VERSION})\n    console=true
-                        # Log    \t EHRbase VERSION: ${VERSION}    console=true
                         Log    \t BASEURL: ${BASEURL}    console=true
                         Log    \t HEARTBEAT: ${HEARTBEAT_URL}    console=true
                         Log    \t AUTH: ${AUTHORIZATION}    console=true

--- a/tests/robot/_resources/keywords/generic_keywords.robot
+++ b/tests/robot/_resources/keywords/generic_keywords.robot
@@ -375,6 +375,7 @@ do quick sanity check
 
 
 warn about manual test environment start up
+    [Tags]              robot:flatten
     Log    ${EMPTY}                                                                             level=WARN
     Log    /////////////////////////////////////////////////////////////////////                level=WARN
     Log    //${SPACE * 64}///                                                                   level=WARN
@@ -421,6 +422,8 @@ abort tests due to issues with manually controlled test environment
     abort test execution if this test fails
 
 startup SUT
+    get application version
+
     # comment: switch to manual test environment control when "-v nodocker" cli option is used
     Run Keyword If      $NODOCKER.upper() in ["TRUE", ""]    Run Keywords
                ...      Set Global Variable    ${NODOCKER}    TRUE    AND
@@ -430,7 +433,8 @@ startup SUT
                ...      Set Global Variable    ${CREATING_SYSTEM_ID}    ${DEV.NODENAME}    AND
                ...      Set Global Variable    ${CONTROL_MODE}    ${DEV.CONTROL}
 
-                        Log    \n\t SUT CONFIG\n    console=true
+                        Log    \n\t SUT CONFIG (EHRbase v${VERSION})\n    console=true
+                        # Log    \t EHRbase VERSION: ${VERSION}    console=true
                         Log    \t BASEURL: ${BASEURL}    console=true
                         Log    \t HEARTBEAT: ${HEARTBEAT_URL}    console=true
                         Log    \t AUTH: ${AUTHORIZATION}    console=true

--- a/tests/robot/_resources/libraries/jsonlib.py
+++ b/tests/robot/_resources/libraries/jsonlib.py
@@ -137,15 +137,31 @@ def ignore_type_properties(obj, path):
     `path` refers to the location of obj in the dict.
     """
     ignorable_types = [
-        # "ACTIVITY",
-        "ARCHETYPED",
         "ARCHETYPE_ID",
+        "ARCHETYPED",
         "CODE_PHRASE",
+        "DV_BOOLEAN",
         "DV_CODED_TEXT",
         "DV_COUNT",
+        "DV_DATE",
         "DV_DATE_TIME",
+        "DV_DATE_TIME",
+        "DV_DURATION",
+        "DV_EHR_URI",
+        "DV_IDENTIFIER",
+        "DV_MULTIMEDIA",
+        "DV_ORDINAL",
+        "DV_PARSABLE",
+        "DV_PROPORTION",
+        "DV_QUANTITY",
+        "DV_SCALE",
+        "DV_STATE",
         "DV_TEXT",
+        "DV_TIME",
+        "DV_URI",
+        "REFERENCE_RANGE",
         "TEMPLATE_ID",
+        "TERM_MAPPING",
         "TERMINOLOGY_ID",
     ]
     return True if "_type" in path and obj in ignorable_types else False

--- a/tests/robot/_resources/libraries/jsonlib.py
+++ b/tests/robot/_resources/libraries/jsonlib.py
@@ -34,7 +34,7 @@ def compare_jsons(
     ignore_string_case=False,
     ignore_type_subclasses=False,
     verbose_level=2,
-    **kwargs
+    **kwargs,
 ):
     """
     :json_1: valid JSON string \n
@@ -73,35 +73,27 @@ def compare_jsons(
         try:
             actual = json.loads(json_1)
         except (JSONDecodeError, TypeError) as error:
-            raise JsonCompareError(
-                f"Only VALID JSON strings accepted! ERROR: {error}"
-            )
+            raise JsonCompareError(f"Only VALID JSON strings accepted! ERROR: {error}")
     if isinstance(json_2, dict):
         expected = json_2
     else:
         try:
             expected = json.loads(json_2)
         except (JSONDecodeError, TypeError) as error:
-            raise JsonCompareError(
-                f"Only VALID JSON strings accepted! ERROR: {error}"
-            )
+            raise JsonCompareError(f"Only VALID JSON strings accepted! ERROR: {error}")
 
     logger.debug("AFTER TRY BLOCK")
     logger.debug(f"ACTUAL: {type(actual)}")
     logger.debug(f"EXPECTED: {type(expected)}")
 
+    logger.debug(f"EXCLUDED PATHS: {exclude_paths} - (type: {type(exclude_paths)})")
+    logger.debug(f"IGNORE ORDER: {ignore_order} - (type: {type(ignore_order)})")
     logger.debug(
-        "EXCLUDED PATHS: {}, type: {}".format(exclude_paths, type(exclude_paths))
+        f"IGNORE_STRING_CASE: {ignore_string_case} - (type: {type(ignore_string_case)})"
     )
-    logger.debug("IGNORE ORDER: {}, type: {}".format(ignore_order, type(ignore_order)))
-    logger.debug(
-        "IGNORE_STRING_CASE: {}, type: {}".format(
-            ignore_string_case, type(ignore_string_case)
-        )
-    )
-    logger.debug("IGNORE_TYPE_SUBCLASSES: {}".format(ignore_type_subclasses))
-    logger.debug("VERBOSE_LEVEL: {}".format(verbose_level))
-    logger.debug("KWARGS: {}".format(kwargs))
+    logger.debug(f"IGNORE_TYPE_SUBCLASSES: {ignore_type_subclasses}")
+    logger.debug(f"VERBOSE_LEVEL: {verbose_level}")
+    logger.debug(f"KWARGS: {kwargs}")
 
     diff = DeepDiff(
         actual,
@@ -112,10 +104,10 @@ def compare_jsons(
         ignore_string_case=ignore_string_case,
         ignore_type_subclasses=ignore_type_subclasses,
         verbose_level=verbose_level,
-        **kwargs
+        **kwargs,
     )
 
-    logger.debug("DIFF: {}".format(diff))
+    # logger.debug(f"DIFF: {diff}")
 
     changes = [
         "type_changes",
@@ -131,11 +123,60 @@ def compare_jsons(
     for change in changes:
         if change in diff:
             change_counter += 1
-            logger.debug(
-                "{}. CHANGE ({}): {}".format(change_counter, change, diff[change])
-            )
+            logger.debug(f"{change_counter}. CHANGE ({change}): \n{diff[change]}\n\n")
 
     return diff.to_dict()
+
+
+def ignore_type_properties(obj, path):
+    """
+    This is a callback function. It is used inside of `compare_jsons_ignoring_properties()`.
+    It takes the object and its path and returns a Boolean. If True is returned,
+    the object is excluded from the results, otherwise it is included.
+    `obj` refers to the value part of a key:value pair.
+    `path` refers to the location of obj in the dict.
+    """
+    ignorable_types = [
+        # "ACTIVITY",
+        "ARCHETYPED",
+        "ARCHETYPE_ID",
+        "CODE_PHRASE",
+        "DV_CODED_TEXT",
+        "DV_COUNT",
+        "DV_DATE_TIME",
+        "DV_TEXT",
+        "TEMPLATE_ID",
+        "TERMINOLOGY_ID",
+    ]
+    return True if "_type" in path and obj in ignorable_types else False
+
+
+def compare_jsons_ignoring_properties(
+    json_1, json_2, *properties, meta=True, path=True, **kwargs
+):
+    """
+    Compares JSON and ignores meta and path properties by default.
+    More properties can be added by their name and will be added
+    to ignore_regex_path as r"\['name'\] where name is the property
+    that is passed as argument.
+    """
+    ignore_properties = []
+
+    for prop in properties:
+        property = f"\['{prop}'\]"
+        ignore_properties.append(r"{}".format(property))
+    if meta:
+        ignore_properties.append(r"root\['meta'\]")
+    if path:
+        ignore_properties.append(r"\['columns'\]\[\d+\]\['path'\]")
+
+    return compare_jsons(
+        json_1,
+        json_2,
+        exclude_regex_paths=ignore_properties,
+        exclude_obj_callback=ignore_type_properties,
+        **kwargs,
+    )
 
 
 def payloads_match_exactly(json_1, json_2, ignore_order=False, **kwargs):
@@ -165,13 +206,13 @@ def payloads_match_exactly(json_1, json_2, ignore_order=False, **kwargs):
 
     diff = compare_jsons(json_1, json_2, ignore_order=ignore_order, **kwargs)
 
-    logger.debug("type(json_1): {}".format(type(json_1)))
-    logger.debug("type(json_2): {}".format(type(json_2)))
-    logger.debug("type(diff): {}".format(type(diff)))
+    logger.debug(f"type(json_1): {type(json_1)}")
+    logger.debug(f"type(json_2): {type(json_2)}")
+    logger.debug(f"type(diff): {type(diff)}")
 
     if diff != {}:
         logger.error("Payloads don't match!")
-        raise JsonCompareError("Payloads do NOT match! Differences: {}".format(diff))
+        raise JsonCompareError(f"Payloads do NOT match! Differences: {diff}")
     else:
         return True
 
@@ -216,8 +257,8 @@ def payload_is_superset_of_expected(payload, expected, **kwargs):
     #   unprocessed                ? if occurs should be handled extra
     """
 
-    logger.debug("type(payload): {}".format(type(payload)))
-    logger.debug("type(expected): {}".format(type(expected)))
+    logger.debug(f"type(payload): {type(payload)}")
+    logger.debug(f"type(expected): {type(expected)}")
 
     diff = compare_jsons(payload, expected, **kwargs)
 
@@ -246,7 +287,6 @@ def payload_is_superset_of_expected(payload, expected, **kwargs):
         "iterable_item_added",
     ]
 
-
     if diff != {}:
         for change in changes:
             # check if change are relevant or can be ignored
@@ -269,9 +309,7 @@ def search_in(obj, item, **kwargs):
         try:
             obj = json.loads(obj)
         except (JSONDecodeError, TypeError) as error:
-            raise JsonCompareError(
-                f"Only VALID JSON strings accepted! ERROR: {error}"
-            )
+            raise JsonCompareError(f"Only VALID JSON strings accepted! ERROR: {error}")
     logger.debug(f"OBJ: {obj}")
     logger.debug(f"ITEM: {item}")
     logger.debug(f"KWARGS: {kwargs}")
@@ -322,3 +360,14 @@ class JsonCompareError(Exception):
 
 # dict_ = dict(b=1, a=2, z=3, f=4, e=dict(F=1, C=2))
 # dump = json.dumps(dict_, sort_keys=True, indent=2)
+
+
+# def compare_ignoring_path_and_type_properties(json_1, json_2, **kwargs):
+#     ignore_properties = [
+#         r"root\['meta'\]",
+#         r"\['columns'\]\[\d+\]\['path'\]",
+#         r"\['_type'\]",
+#     ]
+#     return compare_jsons(
+#         json_1, json_2, exclude_regex_paths=ignore_properties, **kwargs
+#     )

--- a/tests/robot/_resources/libraries/jsonlib.py
+++ b/tests/robot/_resources/libraries/jsonlib.py
@@ -164,7 +164,16 @@ def ignore_type_properties(obj, path):
         "TERM_MAPPING",
         "TERMINOLOGY_ID",
     ]
-    return True if "_type" in path and obj in ignorable_types else False
+    # BACKUP# return True if "_type" in path and obj in ignorable_types else False
+    # Data Value (DV) is inside ELEMENT.value - those are NOT ignored
+    if "_type" in path and "value" in path and obj in ignorable_types:
+        return False
+    # DV is NOT inside ELEMENT.value - those ARE ignored
+    if "_type" in path and ("value" not in path) and obj in ignorable_types:
+        logger.debug(f"path: {path}, object: {obj}")
+        return True
+    else:
+        False
 
 
 def compare_jsons_ignoring_properties(

--- a/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/800_get_composition_by_uid_empty_db.json
+++ b/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/800_get_composition_by_uid_empty_db.json
@@ -1,3 +1,3 @@
 {
-  "q": "SELECT c FROM COMPOSITION c [uid/value='73ed44af-778a-4b8c-aa0d-5b46342d84ec::local.ehrbase.org::1']"
+  "q": "SELECT c FROM COMPOSITION c [uid/value='73ed44af-778a-4b8c-aa0d-5b46342d84ec::node.name.com::1']"
 }

--- a/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/801_get_composition_by_uid_empty_db.json
+++ b/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/801_get_composition_by_uid_empty_db.json
@@ -1,6 +1,6 @@
 {
   "q": "SELECT c FROM COMPOSITION c [uid/value=$uid]",
   "query_parameters": {
-    "uid": "73ed44af-778a-4b8c-aa0d-5b46342d84ec::local.ehrbase.org::1"
+    "uid": "73ed44af-778a-4b8c-aa0d-5b46342d84ec::node.name.com::1"
   }
 }

--- a/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/802_get_composition_by_uid_empty_db.json
+++ b/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/802_get_composition_by_uid_empty_db.json
@@ -1,3 +1,3 @@
 {
-  "q": "SELECT c FROM COMPOSITION c WHERE c/uid/value='73ed44af-778a-4b8c-aa0d-5b46342d84ec::local.ehrbase.org::1'"
+  "q": "SELECT c FROM COMPOSITION c WHERE c/uid/value='73ed44af-778a-4b8c-aa0d-5b46342d84ec::node.name.com::1'"
 }

--- a/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/803_get_composition_by_uid_empty_db.json
+++ b/tests/robot/_resources/test_data_sets/query/aql_queries_valid/B/803_get_composition_by_uid_empty_db.json
@@ -1,6 +1,6 @@
 {
   "q": "SELECT c FROM COMPOSITION c WHERE c/uid/value=$uid",
   "query_parameters": {
-    "uid": "73ed44af-778a-4b8c-aa0d-5b46342d84ec::local.ehrbase.org::1"
+    "uid": "73ed44af-778a-4b8c-aa0d-5b46342d84ec::node.name.com::1"
   }
 }

--- a/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
+++ b/tests/robot/_resources/test_data_sets/valid_templates/minimal/minimal_observation.composition.participations.extdatetimes.ehrbase.json
@@ -8,12 +8,12 @@
 	"archetype_node_id": "openEHR-EHR-COMPOSITION.report-result.v1",
 	"uid": {
 		"@type": "OBJECT_VERSION_ID",
-		"value": "a9d09e4e-9bdd-4d23-a549-80201d685db9::local.ehrbase.org::1",
+		"value": "a9d09e4e-9bdd-4d23-a549-80201d685db9::node.name.com::1",
 		"root": {
 			"@type": "INTERNET_ID",
-			"value": "::local.ehrbase.org::1"
+			"value": "::node.name.com::1"
 		},
-		"extension": "local.ehrbase.org::1"
+		"extension": "node.name.com::1"
 	},
 	"archetype_details": {
 		"@type": "ARCHETYPED",

--- a/tests/run_local_tests.sh
+++ b/tests/run_local_tests.sh
@@ -95,7 +95,7 @@ robot -i KNOWLEDGE -e circleci -e EHRSCAPE -e obsolete -e libtest \
 
 # RUN QUERY SERVICE TESTS - PART I (empty DB)
 robot -i aqlANDempty_db -e circleci -e EHRSCAPE -e obsolete -e libtest \
-      --outputdir results/test-suites/QUERY_SERVICE \
+      --outputdir results/test-suites/QUERY_SERVICE_I \
       --noncritical not-ready \
       --flattenkeywords for \
       --flattenkeywords foritem \
@@ -106,7 +106,7 @@ robot -i aqlANDempty_db -e circleci -e EHRSCAPE -e obsolete -e libtest \
 
 # RUN QUERY SERVICE TESTS - PART II (loaded DB)
 robot -i aqlANDloaded_db -e circleci -e EHRSCAPE -e obsolete -e libtest \
-      --outputdir results/test-suites/QUERY_SERVICE \
+      --outputdir results/test-suites/QUERY_SERVICE_II \
       --noncritical not-ready \
       --flattenkeywords for \
       --flattenkeywords foritem \

--- a/tests/run_local_tests.sh
+++ b/tests/run_local_tests.sh
@@ -93,17 +93,27 @@ robot -i KNOWLEDGE -e circleci -e EHRSCAPE -e obsolete -e libtest \
       --name KNOWLEDGE \
       robot/KNOWLEDGE_TESTS/
 
-# RUN QUERY SERVICE TESTS
-robot -i AQL -e circleci -e EHRSCAPE -e obsolete -e libtest \
+# RUN QUERY SERVICE TESTS - PART I (empty DB)
+robot -i aqlANDempty_db -e circleci -e EHRSCAPE -e obsolete -e libtest \
       --outputdir results/test-suites/QUERY_SERVICE \
       --noncritical not-ready \
       --flattenkeywords for \
       --flattenkeywords foritem \
       --flattenkeywords name:_resources.* \
       --loglevel $LOG_LEVEL \
-      --name AQL \
+      --name AQL1 \
       robot/QUERY_SERVICE_TESTS/
 
+# RUN QUERY SERVICE TESTS - PART II (loaded DB)
+robot -i aqlANDloaded_db -e circleci -e EHRSCAPE -e obsolete -e libtest \
+      --outputdir results/test-suites/QUERY_SERVICE \
+      --noncritical not-ready \
+      --flattenkeywords for \
+      --flattenkeywords foritem \
+      --flattenkeywords name:_resources.* \
+      --loglevel $LOG_LEVEL \
+      --name AQL2 \
+      robot/QUERY_SERVICE_TESTS/
 
 
 # POST PROCESS & MERGE OUTPUTS


### PR DESCRIPTION
## Changes

- mainly related to # 176 and  227 but also other issues
- changes in jsonlib.py
  - implemented a solution to ignore some _type properties
  - compare kw can now take optional arguments
    to ignore properties w/ exclude_reqex_paths
  - meta and columns.path properties are now ignored by default
  - replaced format-strings with the new f-strings
  - reformated code w/ autoformater "black"
- **Updates deepdiff to v. 4.3.2 (requires update of your local test dependencies w/** `pip install -r requirements.txt`**)**
- some clean ups in empty_db test suite
- some fixes in aql_keywords resource


## traceability
added traces to new issues:
  - ehrbase/project_management#234
  - ehrbase/project_management#235
  - ehrbase/project_management#236

removed traces to
  - ehrbase/project_management/issues/199
  - ehrbase/project_management/issues/207
  - ehrbase/project_management/issues/225
  - ehrbase/project_management/issues/227


## Related issues

- closes ehrbase/project_management#176
- closes ehrbase/project_management#227
- closes ehrbase/project_management#199
- fixes ehrbase/project_management/issues/233
