### PR TITLE
fix element/value json and issue when querying down the tree partial …

### DIFF
--- a/base/src/main/resources/db/migration/V24_typed_element_value.sql
+++ b/base/src/main/resources/db/migration/V24_typed_element_value.sql
@@ -1,0 +1,53 @@
+-- convert to lower snake case
+CREATE OR REPLACE FUNCTION ehr.camel_to_snake(literal TEXT)
+  RETURNS TEXT AS
+$$
+DECLARE
+  out_literal TEXT := '';
+  literal_size INT;
+  char_at TEXT;
+  ndx INT;
+BEGIN
+  literal_size := length(literal);
+  if (literal_size = 0) then
+    return literal;
+  end if;
+  ndx = 1;
+  while ndx <= literal_size loop
+    char_at := substr(literal, ndx , 1);
+    if (char_at ~ '[A-Z]') then
+      if (ndx > 1 AND substr(literal, ndx - 1, 1) <> '<') then
+        out_literal = out_literal || '_';
+      end if;
+      out_literal = out_literal || lower(char_at);
+    else
+      out_literal = out_literal || char_at;
+    end if;
+    ndx := ndx + 1;
+  end loop;
+  out_literal := replace(replace(replace(out_literal, 'u_r_i', 'uri'), 'i_d', 'id'), 'i_s_m', 'ism');
+  return out_literal;
+END
+$$
+  LANGUAGE plpgsql;
+
+-- add the _type into an element value block
+CREATE OR REPLACE FUNCTION ehr.js_typed_element_value(JSONB)
+  RETURNS JSONB AS
+$$
+DECLARE
+  element_value ALIAS FOR $1;
+BEGIN
+  RETURN (
+    SELECT
+      jsonb_strip_nulls(
+            (element_value #>>'{/value}')::jsonb ||
+            jsonb_build_object(
+                '_type',
+                upper(ehr.camel_to_snake(element_value #>>'{/$CLASS$}'))
+              )
+        )
+  );
+END
+$$
+  LANGUAGE plpgsql;

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
@@ -21,12 +21,10 @@ import com.nedap.archie.rm.datavalues.DataValue;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.aql.definition.I_VariableDefinition;
-import org.ehrbase.aql.sql.queryImpl.CompositionAttributeQuery;
-import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
-import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
-import org.ehrbase.aql.sql.queryImpl.VariableAqlPath;
+import org.ehrbase.aql.sql.queryImpl.*;
 import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrResolver;
 import org.jooq.Field;
+import org.jooq.impl.DSL;
 
 import java.util.UUID;
 
@@ -81,17 +79,30 @@ class ExpressionField {
                         Class itemClass = ArchieRMInfoLookup.getInstance().getClass(jsonbEntryQuery.getItemType());
                         if (DataValue.class.isAssignableFrom(itemClass)) {
                             VariableAqlPath variableAqlPath = new VariableAqlPath(variableDefinition.getPath());
-                            if (variableAqlPath.getSuffix().equals("value")) { //assumes this is a data value within an ELEMENT
-                                try {
-                                    I_VariableDefinition variableDefinition1 = variableDefinition.clone();
-                                    variableDefinition1.setPath(variableAqlPath.getInfix());
-                                    field = jsonbEntryQuery.makeField(template_id, comp_id, identifier, variableDefinition1, I_QueryImpl.Clause.SELECT);
-                                    jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
-                                    rootJsonKey = variableAqlPath.getSuffix();
-                                } catch (CloneNotSupportedException e){
-                                    throw new InternalServerException("Couldn't handle variable:"+variableDefinition.toString()+"Code error:"+e);
+                            if (variableAqlPath.getSuffix().equals("value")){
+                                if (className.equals("COMPOSITION")) { //assumes this is a data value within an ELEMENT
+                                    try {
+                                        I_VariableDefinition variableDefinition1 = variableDefinition.clone();
+                                        variableDefinition1.setPath(variableAqlPath.getInfix());
+                                        field = jsonbEntryQuery.makeField(template_id, comp_id, identifier, variableDefinition1, I_QueryImpl.Clause.SELECT);
+                                        jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
+                                        rootJsonKey = variableAqlPath.getSuffix();
+                                    } catch (CloneNotSupportedException e) {
+                                        throw new InternalServerException("Couldn't handle variable:" + variableDefinition.toString() + "Code error:" + e);
+                                    }
+                                }
+                                else if (jsonbEntryQuery.getItemCategory().equals("ELEMENT")){
+                                    int cut = jsonbItemPath.lastIndexOf(",/value");
+                                    //we keep the path that select the json element value block, and call the formatting function
+                                    //to pass the actual value datatype into the json block
+                                    String alias = variableDefinition.getAlias();
+                                    if (alias == null)
+                                        alias = new DefaultColumnId().value(variableDefinition);
+                                    field = DSL.field("(ehr.js_typed_element_value("+jsonbItemPath.substring(0, cut)+"}')::jsonb))");
+                                    field = field.as(alias);
                                 }
                             }
+
                         }
                     }
                 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -31,6 +31,7 @@ import org.ehrbase.aql.sql.PathResolver;
 import org.ehrbase.aql.sql.binding.I_JoinBinder;
 import org.ehrbase.aql.sql.queryImpl.value_field.NodePredicate;
 import org.ehrbase.ehr.util.LocatableHelper;
+import org.ehrbase.opt.query.I_QueryOptMetaData;
 import org.ehrbase.serialisation.CompositionSerializer;
 import org.ehrbase.service.IntrospectService;
 import org.jooq.DSLContext;
@@ -337,7 +338,9 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
                 throw new IllegalArgumentException("MetaDataCache is not initialized");
             String reducedItemPathArray = new SegmentedPath(referenceItemPathArray).reduce();
             if (reducedItemPathArray != null && !reducedItemPathArray.isEmpty()) {
-                itemType = introspectCache.getQueryOptMetaData(templateId).type(reducedItemPathArray);
+                I_QueryOptMetaData queryOptMetaData = introspectCache.getQueryOptMetaData(templateId);
+                itemCategory = queryOptMetaData.category(reducedItemPathArray);
+                itemType = queryOptMetaData.type(reducedItemPathArray);
                 if (itemType != null) {
                     String pgType = new PGType(itemPathArray).forRmType(itemType);
                     if (pgType != null)

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/ObjectQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/ObjectQuery.java
@@ -34,6 +34,12 @@ public abstract class ObjectQuery {
     protected boolean jsonDataBlock = false;
     protected String itemType = null;
 
+    public String getItemCategory() {
+        return itemCategory;
+    }
+
+    protected String itemCategory = null;
+
     protected static int serial = 0; //used to alias fields for now.
 
     protected ObjectQuery(DSLContext context, PathResolver pathResolver) {

--- a/service/src/main/java/org/ehrbase/opt/query/I_QueryOptMetaData.java
+++ b/service/src/main/java/org/ehrbase/opt/query/I_QueryOptMetaData.java
@@ -29,6 +29,8 @@ public interface I_QueryOptMetaData extends Serializable {
 
     String type(String path);
 
+    String category(String path);
+
     List nodeByFieldValue(String field, String value);
 
     List nodeFieldRegexp(String field, String regexp);

--- a/service/src/main/java/org/ehrbase/opt/query/QueryOptMetaData.java
+++ b/service/src/main/java/org/ehrbase/opt/query/QueryOptMetaData.java
@@ -84,12 +84,21 @@ public class QueryOptMetaData implements I_QueryOptMetaData {
      */
     @Override
     public String type(String path) {
+        return attributeChildValue(path, "type");
+    }
+
+    @Override
+    public String category(String path) {
+        return attributeChildValue(path, "category");
+    }
+
+    private String attributeChildValue(String path, String attribute){
         Object child = JsonPath.read(document, "$..children[?(@.aql_path == '" + path + "')]");
 
         if (child != null && child instanceof JSONArray && ((JSONArray) child).size() > 0) {
             Object childDef = ((JSONArray) child).get(0);
             if (childDef != null && childDef instanceof Map) {
-                return (String) ((Map) childDef).get("type");
+                return (String) ((Map) childDef).get(attribute);
             }
         }
 

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/SelectBinderTest.java
@@ -74,7 +74,7 @@ public class SelectBinderTest {
             SelectQuery<?> selectQuery = cut.bind("IDCR - Immunisation summary.v0", UUID.randomUUID());
 
             //CCH 191016: EHR-163 removed trailing ',value' as now the query allows canonical json return
-            assertThat(selectQuery.getSQL()).isEqualTo("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value}') as \"/description[at0001]/items[at0002]/value\"");
+            assertThat(selectQuery.getSQL()).isEqualTo("select (ehr.js_typed_element_value((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0}')::jsonb)) as \"/description[at0001]/items[at0002]/value\"");
         }
 
         // select from EHR


### PR DESCRIPTION
## Changes

This fix a formatting issue when querying an element value json block.

For example, before this change, the json block was:

```
            {
                "units": "kg",
                "magnitude": 87.43,
                "other_reference_ranges": []
            }
```
With this fix it now contains the missing '_type':

```
            {
                "_type": "DV_QUANTITY",
                "units": "kg",
                "magnitude": 87.43,
                "other_reference_ranges": []
            }
```

## Related issue

Closes: https://github.com/ehrbase/project_management/issues/183


## Additional information and checks


- [ ] Pull request linked in changelog
