### PR TITLE
fix order by identifiers and force double-quoted column ids

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/binding/OrderByBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/OrderByBinder.java
@@ -24,7 +24,6 @@ package org.ehrbase.aql.sql.binding;
 import org.ehrbase.aql.compiler.OrderAttribute;
 import org.apache.commons.collections4.CollectionUtils;
 import org.ehrbase.aql.definition.I_VariableDefinition;
-import org.ehrbase.aql.definition.VariableDefinition;
 import org.jooq.Record;
 import org.jooq.SelectQuery;
 import org.jooq.SortField;
@@ -32,6 +31,7 @@ import org.jooq.impl.DSL;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -42,10 +42,12 @@ public class OrderByBinder {
 
     private List<OrderAttribute> orderAttributes;
     private final SelectQuery<Record> select;
+    private final VariableDefinitions variableDefinitions;
 
-    OrderByBinder(List<OrderAttribute> orderAttributes, SelectQuery<Record> select) {
+    OrderByBinder(VariableDefinitions variableDefinitions, List<OrderAttribute> orderAttributes, SelectQuery<Record> select) {
         this.orderAttributes = orderAttributes;
         this.select = select;
+        this.variableDefinitions = variableDefinitions;
     }
 
     List<SortField<Object>> getOrderByFields() {
@@ -56,14 +58,41 @@ public class OrderByBinder {
 
         for (OrderAttribute orderAttribute : orderAttributes) {
             SortField<Object> field;
-                String fieldIdentifier = orderAttribute.getVariableDefinition().getAlias() == null ?
-                        "\"/"+orderAttribute.getVariableDefinition().getPath()+"\"" :
-                        orderAttribute.getVariableDefinition().getAlias();
+            String fieldIdentifier = null;
 
-                if (orderAttribute.getDirection() != null && orderAttribute.getDirection().equals(OrderAttribute.OrderDirection.DESC)) {
-                    field = DSL.field(fieldIdentifier).desc();
-                } else //default to ASCENDING
-                    field = DSL.field(fieldIdentifier).asc();
+            //get the corresponding variable definition
+            if (variableDefinitions != null) {
+                Iterator<I_VariableDefinition> localIterator = variableDefinitions.iterator();
+
+                while (localIterator.hasNext()) {
+                    I_VariableDefinition variableDefinition = localIterator.next();
+                    if (orderAttribute.getVariableDefinition().getPath() != null && orderAttribute.getVariableDefinition().getPath().equals(variableDefinition.getPath())) {
+                        if (variableDefinition.getAlias() != null)
+                            fieldIdentifier = variableDefinition.getAlias();
+                        else
+                            fieldIdentifier = "/" + orderAttribute.getVariableDefinition().getPath();
+                        break;
+                    }
+                    else if (orderAttribute.getVariableDefinition().getAlias() != null)
+                        fieldIdentifier = orderAttribute.getVariableDefinition().getAlias();
+                }
+
+            }
+
+            if (fieldIdentifier == null) { //hidden field
+                fieldIdentifier = orderAttribute.getVariableDefinition().getAlias() == null ?
+                    "/"+orderAttribute.getVariableDefinition().getPath() :
+                    orderAttribute.getVariableDefinition().getAlias();
+                orderAttribute.getVariableDefinition().setHidden(true);
+            }
+
+            if (!fieldIdentifier.startsWith("\""))
+                fieldIdentifier = "\""+fieldIdentifier+"\""; //by postgresql convention
+
+            if (orderAttribute.getDirection() != null && orderAttribute.getDirection().equals(OrderAttribute.OrderDirection.DESC)) {
+                field = DSL.field(fieldIdentifier).desc();
+            } else //default to ASCENDING
+                field = DSL.field(fieldIdentifier).asc();
 
             orderFields.add(field);
         }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/SuperQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/SuperQuery.java
@@ -149,7 +149,7 @@ public class SuperQuery {
 
     @SuppressWarnings("unchecked")
     public SelectQuery setOrderBy(List<OrderAttribute> orderAttributes, SelectQuery selectQuery){
-        return new OrderByBinder(orderAttributes, selectQuery).bind();
+        return new OrderByBinder(variableDefinitions, orderAttributes, selectQuery).bind();
     }
 
     public SelectQuery select() {

--- a/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/QueryProcessorTest.java
@@ -173,7 +173,7 @@ public class QueryProcessorTest {
                         "from (" +
                         "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1 and name/value=''Immunisation summary''],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') " +
                         "as \"description\" from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?" +
-                        ") as \"\" order by description asc",
+                        ") as \"\" order by \"description\" asc",
                 true));
 
         // where  clause json column  from entry

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/OrderByBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/OrderByBinderTest.java
@@ -41,12 +41,12 @@ public class OrderByBinderTest {
             OrderAttribute orderAttribute = new OrderAttribute(I_VariableDefinitionHelper.build(null, "date_created", null, false, false, false));
             orderAttribute.setDirection(OrderAttribute.OrderDirection.ASC);
 
-            OrderByBinder cut = new OrderByBinder(Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
+            OrderByBinder cut = new OrderByBinder(null, Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
             List<SortField<Object>> actual = cut.getOrderByFields();
 
             assertThat(actual).size().isEqualTo(1);
             SortField<?> sortField = actual.get(0);
-            assertThat(sortField.toString()).isEqualTo("date_created asc");
+            assertThat(sortField.toString()).isEqualTo("\"date_created\" asc");
         }
 
         //descending
@@ -55,12 +55,12 @@ public class OrderByBinderTest {
             OrderAttribute orderAttribute = new OrderAttribute(I_VariableDefinitionHelper.build(null, "date_created", null, false, false, false));
             orderAttribute.setDirection(OrderAttribute.OrderDirection.DESC);
 
-            OrderByBinder cut = new OrderByBinder(Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
+            OrderByBinder cut = new OrderByBinder(null, Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
             List<SortField<Object>> actual = cut.getOrderByFields();
 
             assertThat(actual).size().isEqualTo(1);
             SortField<?> sortField = actual.get(0);
-            assertThat(sortField.toString()).isEqualTo("date_created desc");
+            assertThat(sortField.toString()).isEqualTo("\"date_created\" desc");
         }
 
         //no direction
@@ -69,12 +69,12 @@ public class OrderByBinderTest {
             OrderAttribute orderAttribute = new OrderAttribute(I_VariableDefinitionHelper.build(null, "date_created", null, false, false, false));
 
 
-            OrderByBinder cut = new OrderByBinder(Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
+            OrderByBinder cut = new OrderByBinder(null, Collections.singletonList(orderAttribute), DSLContextHelper.buildContext().selectQuery());
             List<SortField<Object>> actual = cut.getOrderByFields();
 
             assertThat(actual).size().isEqualTo(1);
             SortField<?> sortField = actual.get(0);
-            assertThat(sortField.toString()).isEqualTo("date_created asc");
+            assertThat(sortField.toString()).isEqualTo("\"date_created\" asc");
         }
     }
 }


### PR DESCRIPTION
## Changes

Fixes handling of multiple columns in ORDER BY statement

## Related issue

fixes: https://github.com/ehrbase/ehrbase/issues/230


## Additional information and checks

- [ ] Pull request linked in changelog
