### PR TITLE
enable datetime comparison by forcing SQL whenever datetime is detected

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/WhereTemporal.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/WhereTemporal.java
@@ -1,0 +1,31 @@
+package org.ehrbase.aql.sql;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+public class WhereTemporal {
+    List<Object> whereItems;
+
+    public WhereTemporal(List<Object> whereItems) {
+        this.whereItems = whereItems;
+    }
+
+    public boolean containsTemporalItem(){
+        for (Object item: whereItems){
+            if (item instanceof String){ //ignore variable definition
+                String testItem = (String)item;
+                try {
+                    if (testItem.startsWith("'") && testItem.endsWith("'"))
+                        testItem = testItem.substring(1, testItem.length() - 1);
+                    ZonedDateTime.parse(testItem);
+                    return true;
+                } catch (DateTimeParseException e){
+
+                }
+
+            }
+        }
+        return false;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
@@ -91,14 +91,16 @@ class ExpressionField {
                                         throw new InternalServerException("Couldn't handle variable:" + variableDefinition.toString() + "Code error:" + e);
                                     }
                                 }
-                                else if (jsonbEntryQuery.getItemCategory().equals("ELEMENT")){
+                                else if (jsonbEntryQuery.getItemCategory().equals("ELEMENT") || jsonbEntryQuery.getItemCategory().equals("CLUSTER")){
                                     int cut = jsonbItemPath.lastIndexOf(",/value");
-                                    //we keep the path that select the json element value block, and call the formatting function
-                                    //to pass the actual value datatype into the json block
+                                    if (cut != -1)
+                                        //we keep the path that select the json element value block, and call the formatting function
+                                        //to pass the actual value datatype into the json block
+                                        field = DSL.field("(ehr.js_typed_element_value(" + jsonbItemPath.substring(0, cut) + "}')::jsonb))");
+
                                     String alias = variableDefinition.getAlias();
                                     if (alias == null)
                                         alias = new DefaultColumnId().value(variableDefinition);
-                                    field = DSL.field("(ehr.js_typed_element_value("+jsonbItemPath.substring(0, cut)+"}')::jsonb))");
                                     field = field.as(alias);
                                 }
                             }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -24,6 +24,7 @@ package org.ehrbase.aql.sql.binding;
 import org.ehrbase.aql.containment.IdentifierMapper;
 import org.ehrbase.aql.definition.I_VariableDefinition;
 import org.ehrbase.aql.definition.VariableDefinition;
+import org.ehrbase.aql.sql.WhereTemporal;
 import org.ehrbase.aql.sql.queryImpl.CompositionAttributeQuery;
 import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
 import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
@@ -194,7 +195,11 @@ public class WhereBinder {
                         if (new VariablePath(((I_VariableDefinition) item).getPath()).hasPredicate()) {
                             taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null)));
                         } else {
-                            taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, false, null)));
+                            //check if a comparison item is a date, then force SQL if any
+                            if (new WhereTemporal(whereItems).containsTemporalItem())
+                                taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, true, null)));
+                            else
+                                taggedStringBuilder.append(expandForCondition(encodeWhereVariable(templateId, comp_id, (I_VariableDefinition) item, false, null)));
                         }
                     }
                 }


### PR DESCRIPTION
fixed OutOfBound exception for specific aql encoding

## Changes

This allows using datetime comparison in AQL where clause.

The issue is that whenever using jsquery, comparison is allowed for numerical values only (https://github.com/postgrespro/jsquery). This fix address simple datetime formats a more general solution would be more complex to implement due to the great (!) variety of date encoding... It is therefore recommended and assumed the format of stored datetime (partial in particular is known in advance). That said, comparisons such as:

```
m/data[at0001]/items[at0004]/value/value>='2020-04-02T11:00Z' and
m/data[at0001]/items[at0005]/value/value<='2020-04-04T13:00Z')
```
are now supported.

## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/258

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
