### PR TITLE
Feature/256 contains clause

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/containment/ContainOperator.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/ContainOperator.java
@@ -1,0 +1,20 @@
+package org.ehrbase.aql.containment;
+
+public class ContainOperator {
+
+    private enum OPERATOR {AND, OR, XOR}
+
+    private OPERATOR operator;
+
+    public ContainOperator(String operator) {
+        this.operator = OPERATOR.valueOf(operator);
+    }
+
+    public String getOperator() {
+        return operator.name();
+    }
+
+    public boolean isEqualTo(ContainOperator another){
+        return this.getOperator().equals(another.getOperator());
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/containment/ContainmentSet.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/ContainmentSet.java
@@ -41,8 +41,6 @@ public class ContainmentSet {
     private int operatorSlot = -1; //the last position where to insert an operator, -1 initially
 
 
-    public enum OPERATOR {AND, OR, XOR}
-
     public ContainmentSet(int serial, Containment enclosing) {
         this.serial = serial;
         this.enclosing = enclosing;
@@ -53,7 +51,7 @@ public class ContainmentSet {
     }
 
     public void add(String operator) {
-        containmentList.add(OPERATOR.valueOf(operator));
+        containmentList.add(new ContainOperator(operator));
     }
 
 
@@ -68,7 +66,7 @@ public class ContainmentSet {
     }
 
     public void setOperator(String operator) {
-        OPERATOR op = OPERATOR.valueOf(operator.trim());
+        ContainOperator op = new ContainOperator(operator.trim());
 
         if (op == null)
             throw new IllegalArgumentException("Invalid operator value:" + operator);
@@ -123,7 +121,7 @@ public class ContainmentSet {
 
                 if (item instanceof Containment)
                     sb.append(item);
-                else if (item instanceof OPERATOR) {
+                else if (item instanceof ContainOperator) {
                     sb.append(item);
                 } else if (item instanceof String) {
                     sb.append(item);

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/PredicatesBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/PredicatesBinder.java
@@ -18,6 +18,7 @@
 
 package org.ehrbase.aql.sql.binding;
 
+import org.ehrbase.aql.containment.ContainOperator;
 import org.ehrbase.aql.containment.Containment;
 import org.ehrbase.aql.containment.ContainmentSet;
 import org.ehrbase.aql.containment.Predicates;
@@ -44,7 +45,7 @@ class PredicatesBinder {
     }
 
     private boolean isOperator(Object object) {
-        return object instanceof ContainmentSet.OPERATOR;
+        return object instanceof ContainOperator;
     }
 
     private boolean isContainment(Object object) {
@@ -55,26 +56,26 @@ class PredicatesBinder {
         return cursor + 1 >= containmentList.size();
     }
 
-    private int resolveUnallocated(Deque<ContainmentSet.OPERATOR> operatorStack) {
+    private int resolveUnallocated(Deque<ContainOperator> operatorStack) {
 
         //check what's in stack
         if (!predicates.getAtomicPredicates().isEmpty() && !operatorStack.isEmpty()) {
-            ContainmentSet.OPERATOR operator = operatorStack.pop();
+            ContainOperator operator = operatorStack.pop();
             int cursor = predicates.getAtomicPredicates().size() - 1;
-            switch (operator) {
-                case AND:
+            switch (operator.getOperator()) {
+                case "AND":
                     Details details = predicates.getAtomicPredicates().get(cursor);
 //                        Predicates.Details details = predicates.new Details(item, null);
                     predicates.getIntersectPredicates().add(details);
                     predicates.getAtomicPredicates().remove(cursor);
                     break;
-                case OR:
+                case "OR":
                     details = predicates.getAtomicPredicates().get(cursor);
 //                        Predicates.Details details = predicates.new Details(item, null);
                     predicates.getUnionPredicates().add(details);
                     predicates.getAtomicPredicates().remove(cursor);
                     break;
-                case XOR:
+                case "XOR":
 //                        item = predicates.atomicPredicates.get(indexLast).expression;
                     details = predicates.getAtomicPredicates().get(cursor);
                     predicates.getExceptPredicates().add(details);
@@ -112,7 +113,7 @@ class PredicatesBinder {
         if (containmentSet == null)
             return null;
         this.predicates = new Predicates(containmentSet);
-        Deque<ContainmentSet.OPERATOR> operatorStack = new ArrayDeque<>();
+        Deque<ContainOperator> operatorStack = new ArrayDeque<>();
 
         StringBuilder containedPredicateLtree = new StringBuilder();
         for (int i = 0; i < containmentSet.getContainmentList().size(); i++) {
@@ -132,9 +133,9 @@ class PredicatesBinder {
 //                    containedPredicateLtree.append(RIGHT_WILDCARD);
 //                }
             } else if (isOperator(item)) {
-                ContainmentSet.OPERATOR operator = (ContainmentSet.OPERATOR) item;
-                switch (operator) {
-                    case OR:
+                ContainOperator operator = (ContainOperator) item;
+                switch (operator.getOperator()) {
+                    case "OR":
 //                        containedPredicateLtree.append("|");
 //                        break;
                         if (containedPredicateLtree.length() == 0) { //promote the atomicPredicates to intersectPredicates, it is a AND on two nested groups
@@ -145,7 +146,7 @@ class PredicatesBinder {
                         }
                         containedPredicateLtree = new StringBuilder();
                         break;
-                    case XOR:
+                    case "XOR":
                         if (containedPredicateLtree.length() == 0) { //promote the atomicPredicates to intersectPredicates, it is a AND on two nested groups
                             containedPredicateLtree = buildBooleanExpression(containedPredicateLtree, EXCEPT_EXPRESSION, predicates.getExceptPredicates(), containmentSet.getParentSet(), containmentSet.getEnclosing());
                         } else {
@@ -154,7 +155,7 @@ class PredicatesBinder {
                         }
                         containedPredicateLtree = new StringBuilder();
                         break;
-                    case AND:
+                    case "AND":
                         if (containedPredicateLtree.length() == 0) { //promote the atomicPredicates to intersectPredicates, it is a AND on two nested groups
                             containedPredicateLtree = buildBooleanExpression(containedPredicateLtree, INTERSECT_EXPRESSION, predicates.getIntersectPredicates(), containmentSet.getParentSet(), containmentSet.getEnclosing());
                         } else {

--- a/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass1Test.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass1Test.java
@@ -18,10 +18,7 @@
 
 package org.ehrbase.aql.compiler;
 
-import org.ehrbase.aql.containment.Containment;
-import org.ehrbase.aql.containment.ContainmentSet;
-import org.ehrbase.aql.containment.ContainmentTest;
-import org.ehrbase.aql.containment.IdentifierMapper;
+import org.ehrbase.aql.containment.*;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.junit.Test;
@@ -211,7 +208,7 @@ public class QueryCompilerPass1Test {
             Containment expected1 = ContainmentTest.buildContainment(null, "a", "openEHR-EHR-COMPOSITION.health_summary.v1", "COMPOSITION", null);
             ContainmentTest.checkEqual(containment1, expected1);
 
-            assertThat(containmentSet.getContainmentList().get(1)).isEqualTo(ContainmentSet.OPERATOR.AND);
+            assertThat(((ContainOperator)containmentSet.getContainmentList().get(1)).getOperator()).isEqualTo("AND");
 
             Containment containment2 = (Containment) containmentSet.getContainmentList().get(2);
             Containment expected2 = ContainmentTest.buildContainment(null, "d", "openEHR-EHR-COMPOSITION.referral.v1", "COMPOSITION", null);
@@ -230,7 +227,7 @@ public class QueryCompilerPass1Test {
             ContainmentSet containmentSet = actual.get(0);
             assertThat(containmentSet.getEnclosing()).isNull();
             assertThat(containmentSet.getParentSet()).isNull();
-            assertThat(containmentSet.getContainmentList()).size().isEqualTo(4);
+            assertThat(containmentSet.getContainmentList()).size().isEqualTo(5);
 
 
             Containment containment1 = (Containment) containmentSet.getContainmentList().get(0);
@@ -238,13 +235,15 @@ public class QueryCompilerPass1Test {
             ContainmentTest.checkEqual(containment1, expected1);
 
 
-            Containment containment2 = (Containment) containmentSet.getContainmentList().get(1);
+            assertThat(((ContainOperator)containmentSet.getContainmentList().get(1)).getOperator()).isEqualTo("XOR");
+
+            Containment containment2 = (Containment) containmentSet.getContainmentList().get(2);
             Containment expected2 = ContainmentTest.buildContainment(null, "d", "openEHR-EHR-COMPOSITION.administrative_encounter.v1", "COMPOSITION", null);
             ContainmentTest.checkEqual(containment2, expected2);
 
-            assertThat(containmentSet.getContainmentList().get(2)).isEqualTo(ContainmentSet.OPERATOR.XOR);
+            assertThat(((ContainOperator)containmentSet.getContainmentList().get(3)).getOperator()).isEqualTo("XOR");
 
-            Containment containment3 = (Containment) containmentSet.getContainmentList().get(3);
+            Containment containment3 = (Containment) containmentSet.getContainmentList().get(4);
             Containment expected3 = ContainmentTest.buildContainment(null, "c", "openEHR-EHR-COMPOSITION.referral.v1", "COMPOSITION", null);
             ContainmentTest.checkEqual(containment3, expected3);
         }
@@ -268,13 +267,13 @@ public class QueryCompilerPass1Test {
             Containment expected1 = ContainmentTest.buildContainment(null, "a", "openEHR-EHR-COMPOSITION.health_summary.v1", "COMPOSITION", null);
             ContainmentTest.checkEqual(containment1, expected1);
 
-            assertThat(containmentSet.getContainmentList().get(1)).isEqualTo(ContainmentSet.OPERATOR.XOR);
+            assertThat(((ContainOperator)containmentSet.getContainmentList().get(1)).getOperator()).isEqualTo("XOR");
 
             Containment containment2 = (Containment) containmentSet.getContainmentList().get(2);
             Containment expected2 = ContainmentTest.buildContainment(null, "d", "openEHR-EHR-ACTION.immunisation_procedure.v1", "ACTION", null);
             ContainmentTest.checkEqual(containment2, expected2);
 
-            assertThat(containmentSet.getContainmentList().get(3)).isEqualTo(ContainmentSet.OPERATOR.AND);
+            assertThat(((ContainOperator)containmentSet.getContainmentList().get(3)).getOperator()).isEqualTo("AND");
 
             Containment containment3 = (Containment) containmentSet.getContainmentList().get(4);
             Containment expected3 = ContainmentTest.buildContainment(null, "c", "openEHR-EHR-COMPOSITION.referral.v1", "COMPOSITION", null);
@@ -314,7 +313,7 @@ public class QueryCompilerPass1Test {
             Containment expected12 = ContainmentTest.buildContainment(containment1, "o", "openEHR-EHR-OBSERVATION.laboratory-hba1c.v1", "OBSERVATION", null);
             ContainmentTest.checkEqual(containment2, expected12);
 
-            assertThat(containmentSet1.getContainmentList().get(1)).isEqualTo(ContainmentSet.OPERATOR.AND);
+            assertThat(((ContainOperator)containmentSet1.getContainmentList().get(1)).getOperator()).isEqualTo("AND");
 
             Containment containment3 = (Containment) containmentSet1.getContainmentList().get(2);
             Containment expected3 = ContainmentTest.buildContainment(containment1, "o1", "openEHR-EHR-OBSERVATION.laboratory-glucose.v1", "OBSERVATION", null);
@@ -339,7 +338,7 @@ public class QueryCompilerPass1Test {
             assertThat(containmentSet2.getParentSet()).isNull();
             assertThat(containmentSet2.getContainmentList()).size().isEqualTo(2);
 
-            assertThat(containmentSet2.getContainmentList().get(0)).isEqualTo(ContainmentSet.OPERATOR.OR);
+            assertThat(((ContainOperator)containmentSet2.getContainmentList().get(0)).getOperator()).isEqualTo("OR");
 
             Containment containment3 = (Containment) containmentSet2.getContainmentList().get(1);
             Containment expected3 = ContainmentTest.buildContainment(null, "c2", "openEHR-EHR-COMPOSITION.health_summary.v1", "COMPOSITION", null);

--- a/service/src/test/java/org/ehrbase/aql/containment/ContainmentTest.java
+++ b/service/src/test/java/org/ehrbase/aql/containment/ContainmentTest.java
@@ -18,9 +18,6 @@
 
 package org.ehrbase.aql.containment;
 
-import org.ehrbase.aql.compiler.AqlExpression;
-import org.ehrbase.aql.compiler.Contains;
-import org.ehrbase.aql.compiler.Statements;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,28 +55,6 @@ public class ContainmentTest {
         assertThat(containment.getClassName()).isEqualTo(expected.getClassName());
         assertThat(containment.getPath()).isEqualTo(expected.getPath());
         assertThat(containment.getEnclosingContainment()).isEqualTo(expected.getEnclosingContainment());
-    }
-
-    @Test
-    public void testInterpretContainement(){
-
-        String query = "select\n" +
-                "c\n" +
-                "from EHR e\n" +
-                "contains COMPOSITION c[openEHR-EHR-COMPOSITION.report-result.v1]\n" +
-                "contains (\n" +
-                "CLUSTER f[openEHR-EHR-CLUSTER.case_identification.v0] and\n" +
-                "CLUSTER z[openEHR-EHR-CLUSTER.specimen.v1] and\n" +
-                "CLUSTER j[openEHR-EHR-CLUSTER.laboratory_test_panel.v0]\n" +
-                "contains CLUSTER g[openEHR-EHR-CLUSTER.laboratory_test_analyte.v1])\n" +
-                "where\n" +
-                "c/name/value='Virologischer Befund' and\n" +
-                "g/items[at0001]/name='Nachweis' and\n" +
-                "g/items[at0024]/name='Virus'\n";
-
-        AqlExpression aqlExpression = new AqlExpression().parse(query);
-        Contains contains = new Contains(aqlExpression.getParseTree()).process();
-        Statements statements = new Statements(aqlExpression.getParseTree(), contains.getIdentifierMapper()).process() ;
     }
 
 }

--- a/service/src/test/java/org/ehrbase/aql/containment/ContainmentTest.java
+++ b/service/src/test/java/org/ehrbase/aql/containment/ContainmentTest.java
@@ -18,6 +18,9 @@
 
 package org.ehrbase.aql.containment;
 
+import org.ehrbase.aql.compiler.AqlExpression;
+import org.ehrbase.aql.compiler.Contains;
+import org.ehrbase.aql.compiler.Statements;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +58,28 @@ public class ContainmentTest {
         assertThat(containment.getClassName()).isEqualTo(expected.getClassName());
         assertThat(containment.getPath()).isEqualTo(expected.getPath());
         assertThat(containment.getEnclosingContainment()).isEqualTo(expected.getEnclosingContainment());
+    }
+
+    @Test
+    public void testInterpretContainement(){
+
+        String query = "select\n" +
+                "c\n" +
+                "from EHR e\n" +
+                "contains COMPOSITION c[openEHR-EHR-COMPOSITION.report-result.v1]\n" +
+                "contains (\n" +
+                "CLUSTER f[openEHR-EHR-CLUSTER.case_identification.v0] and\n" +
+                "CLUSTER z[openEHR-EHR-CLUSTER.specimen.v1] and\n" +
+                "CLUSTER j[openEHR-EHR-CLUSTER.laboratory_test_panel.v0]\n" +
+                "contains CLUSTER g[openEHR-EHR-CLUSTER.laboratory_test_analyte.v1])\n" +
+                "where\n" +
+                "c/name/value='Virologischer Befund' and\n" +
+                "g/items[at0001]/name='Nachweis' and\n" +
+                "g/items[at0024]/name='Virus'\n";
+
+        AqlExpression aqlExpression = new AqlExpression().parse(query);
+        Contains contains = new Contains(aqlExpression.getParseTree()).process();
+        Statements statements = new Statements(aqlExpression.getParseTree(), contains.getIdentifierMapper()).process() ;
     }
 
 }

--- a/service/src/test/java/org/ehrbase/aql/sql/binding/PredicatesBinderTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/binding/PredicatesBinderTest.java
@@ -18,6 +18,7 @@
 
 package org.ehrbase.aql.sql.binding;
 
+import org.ehrbase.aql.containment.ContainOperator;
 import org.ehrbase.aql.containment.ContainmentSet;
 import org.ehrbase.aql.containment.ContainmentTest;
 import org.ehrbase.aql.containment.Predicates;
@@ -52,7 +53,7 @@ public class PredicatesBinderTest {
             //represents CONTAINS COMPOSITION a [openEHR-EHR-COMPOSITION.health_summary.v1] AND COMPOSITION d [openEHR-EHR-COMPOSITION.referral.v1]
             ContainmentSet containmentSet = new ContainmentSet(1, null);
             containmentSet.add(ContainmentTest.buildContainment(null, "a", "openEHR-EHR-COMPOSITION.health_summary.v1", "COMPOSITION", null));
-            containmentSet.add(ContainmentSet.OPERATOR.AND.name());
+            containmentSet.add(new ContainOperator("AND").getOperator());
             containmentSet.add(ContainmentTest.buildContainment(null, "d", "openEHR-EHR-COMPOSITION.referral.v1", "COMPOSITION", null));
 
             PredicatesBinder cut = new PredicatesBinder();


### PR DESCRIPTION
## Changes

Supports more complex CONTAINS expressions f.e.
```
contains COMPOSITION c[openEHR-EHR-COMPOSITION.report-result.v1]
contains 
    (
        CLUSTER f[openEHR-EHR-CLUSTER.case_identification.v0] and
        CLUSTER z[openEHR-EHR-CLUSTER.specimen.v1] and
        CLUSTER j[openEHR-EHR-CLUSTER.laboratory_test_panel.v0]
        contains 
               CLUSTER g[openEHR-EHR-CLUSTER.laboratory_test_analyte.v1]
    )
```
IMPORTANT: containment resolution is based on stored composition actual content. That is, in the above example, only compositions with satisfying all conditions will be identified and be included in the result set. This is somehow a _super  WHERE_ statement.

## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/256

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
