### PR TITLE
fix unproper indexing jsquery on name/value

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/JsonbEntryQuery.java
@@ -416,8 +416,11 @@ public class JsonbEntryQuery extends ObjectQuery implements I_QueryImpl {
         StringBuffer jsqueryPath = new StringBuffer();
 
         for (int i = 0; i < itemPathArray.size(); i++) {
-            if (!itemPathArray.get(i).equals("#"))
+            if (!itemPathArray.get(i).equals("#") && !itemPathArray.get(i).equals("0"))
                 jsqueryPath.append("\"" + itemPathArray.get(i) + "\"");
+            else if (itemPathArray.get(i).equals("0")){ //case /name/value -> /name,0,value
+                jsqueryPath.append("#");
+            }
             else
                 jsqueryPath.append(itemPathArray.get(i));
             if (i < itemPathArray.size() - 1)


### PR DESCRIPTION
## Changes
Fix the jsquery for name/value attribute in the WHERE clause

## Related issue

closes: https://github.com/ehrbase/project_management/issues/262

## Additional information and checks

- [ ] Pull request linked in changelog
