### PR TITLE
Add duplicate detection for directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Detect duplicates on POST Directory
+- Detect duplicates on POST Directory (see: https://github.com/ehrbase/ehrbase/pull/281)
 
 ## [0.13.0] (beta)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Detect duplicates on POST Directory
+
 ## [0.13.0] (beta)
 
 ### Added

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/OpenehrDirectoryController.java
@@ -20,8 +20,10 @@ package org.ehrbase.rest.openehr.controller;
 
 import com.nedap.archie.rm.directory.Folder;
 import io.swagger.annotations.*;
+import org.ehrbase.api.exception.DuplicateObjectException;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
+import org.ehrbase.api.exception.StateConflictException;
 import org.ehrbase.api.service.EhrService;
 import org.ehrbase.api.service.FolderService;
 import org.ehrbase.response.ehrscape.FolderDto;
@@ -114,6 +116,14 @@ public class OpenehrDirectoryController extends BaseController {
                     "EHR with id " + ehrId + " not found."
             );
         }
+
+        // Check for duplicate directories
+        if (this.ehrService.getDirectoryId(ehrId) != null) {
+            throw new StateConflictException(
+                    String.format("EHR with id %s already contains a directory.", ehrId.toString())
+            );
+        }
+
         // Insert New folder
         UUID folderId = this.folderService.create(
                 ehrId,


### PR DESCRIPTION
## Changes

- Add detection for already existing Directory of an EHR
- Respond with 409 - CONFLICT in case of detected folder

## Related issue

Fixes https://github.com/ehrbase/project_management/issues/231

## Additional information and checks

- [x] Pull request linked in changelog
