### PR TITLE
Allow duplicated column ids in aql results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Detect duplicates on POST Directory (see: https://github.com/ehrbase/ehrbase/pull/281)
+- Allow duplicated paths in AQL resultsets (see: )
 
 ## [0.13.0] (beta)
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <swagger.version>1.5.23</swagger.version>
         <swagger-snapshot.version>2.0.0-rc2</swagger-snapshot.version>
         <postgressql.version>42.2.5</postgressql.version>
-        <ehrbase.sdk.version>0656b7f</ehrbase.sdk.version>
+        <ehrbase.sdk.version>87ab518</ehrbase.sdk.version>
         <flyway.version>6.2.0</flyway.version>
         <joda.version>2.10.6</joda.version>
         <database.name>ehrbase</database.name>

--- a/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/responsedata/QueryResponseData.java
+++ b/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/responsedata/QueryResponseData.java
@@ -19,6 +19,7 @@
 package org.ehrbase.rest.ehrscape.responsedata;
 
 import org.ehrbase.response.ehrscape.QueryResultDto;
+import org.ehrbase.response.ehrscape.query.ResultHolder;
 
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,7 @@ import java.util.Map;
 public class QueryResponseData extends ActionRestResponseData {
     private String executedAQL;
     private List<List<String>> explain;
-    private List<Map<String, Object>> resultSet;
+    private List<ResultHolder> resultSet;
 
     public QueryResponseData(QueryResultDto dto) {
         executedAQL = dto.getExecutedAQL();
@@ -50,11 +51,11 @@ public class QueryResponseData extends ActionRestResponseData {
         this.explain = explain;
     }
 
-    public List<Map<String, Object>> getResultSet() {
+    public List<ResultHolder> getResultSet() {
         return resultSet;
     }
 
-    public void setResultSet(List<Map<String, Object>> resultSet) {
+    public void setResultSet(List<ResultHolder> resultSet) {
         this.resultSet = resultSet;
     }
 }

--- a/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
@@ -35,6 +35,7 @@ import org.ehrbase.response.ehrscape.QueryDefinitionResultDto;
 import org.ehrbase.response.ehrscape.QueryResultDto;
 import org.ehrbase.response.ehrscape.StructuredString;
 import org.ehrbase.response.ehrscape.StructuredStringFormat;
+import org.ehrbase.response.ehrscape.query.ResultHolder;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
@@ -107,16 +108,17 @@ public class QueryServiceImp extends BaseService implements QueryService {
         dto.setExecutedAQL(queryString);
         dto.setVariables(aqlResult.getVariables());
 
-        List<Map<String, Object>> resultList = new ArrayList<>();
+        List<ResultHolder> resultList = new ArrayList<>();
         for (Record record : aqlResult.getRecords()) {
-            Map<String, Object> fieldMap = new LinkedHashMap<>();
+            ResultHolder fieldMap = new ResultHolder();
             for (Field field : record.fields()) {
                 //process non-hidden variables
                 if (aqlResult.variablesContains(field.getName())) {
+                    //check whether to use field name or alias
                     if (record.getValue(field) instanceof JsonElement) {
-                        fieldMap.put(field.getName(), new StructuredString((record.getValue(field)).toString(), StructuredStringFormat.JSON));
+                        fieldMap.putResult(field.getName(), new StructuredString((record.getValue(field)).toString(), StructuredStringFormat.JSON));
                     } else
-                        fieldMap.put(field.getName(), record.getValue(field));
+                        fieldMap.putResult(field.getName(), record.getValue(field));
                 }
             }
 
@@ -174,7 +176,7 @@ public class QueryServiceImp extends BaseService implements QueryService {
 
         QueryResultDto dto = new QueryResultDto();
         dto.setExecutedAQL((String) result.get("executedAQL"));
-        dto.setResultSet((List<Map<String, Object>>) result.get("resultSet"));
+        dto.setResultSet((List<ResultHolder>) result.get("resultSet"));
         dto.setExplain((List<List<String>>) result.get("explain"));
         return dto;
     }


### PR DESCRIPTION
## Changes

Allow duplicate paths in AQL resultset:

```
{
  "q": "SELECT o1/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value,
               o2/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value
               from EHR e contains composition a contains (observation o1 [openEHR-EHR-OBSERVATION.laboratory_test_result.v1] and observation o2 [openEHR-EHR-OBSERVATION.laboratory_test_result.v1])"
}
```
Returns:
```
{
    "q": "SELECT o1/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value,\r\n               o2/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value\r\n               from EHR e contains composition a contains (observation o1 [openEHR-EHR-OBSERVATION.laboratory_test_result.v1] and observation o2 [openEHR-EHR-OBSERVATION.laboratory_test_result.v1])",
    "columns": [
        {
            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value",
            "name": "#0"
        },
        {
            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/value/value",
            "name": "#1"
        }
    ],
    "rows": [
        [
            "Virologische Untersuchung",
            "Virologische Untersuchung"
        ],
        [
            "Virologische Untersuchung",
            "Virologische Untersuchung"
 ...
```

- First change

## Related issue
closes: https://github.com/ehrbase/ehrbase/issues/263


## Additional information and checks

- [ ] Pull request linked in changelog
