### PR TITLE
Feature/344 sml cs query

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/definition/I_VariableDefinition.java
+++ b/service/src/main/java/org/ehrbase/aql/definition/I_VariableDefinition.java
@@ -54,4 +54,6 @@ public interface I_VariableDefinition extends Cloneable {
     void setHidden(boolean hidden);
 
     void setAlias(String alias);
+
+    String toString();
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/CompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/CompositionAttribute.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Christian Chevalley, Vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.binding;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.queryImpl.CompositionAttributeQuery;
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
+import org.jooq.Field;
+
+/**
+ * convert a select or where AQL field into its SQL equivalent for a composition attribute.
+ * This applies to standard attributes f.e. c/name/value etc.
+ */
+public class CompositionAttribute {
+
+    private final CompositionAttributeQuery compositionAttributeQuery;
+    private final JsonbEntryQuery jsonbEntryQuery;
+    private final I_QueryImpl.Clause clause;
+    private boolean containsJsonDataBlock;
+    private String jsonbItemPath;
+    private String optionalPath;
+
+    public CompositionAttribute(CompositionAttributeQuery compositionAttributeQuery, JsonbEntryQuery jsonbEntryQuery, I_QueryImpl.Clause clause) {
+        this.compositionAttributeQuery = compositionAttributeQuery;
+        this.jsonbEntryQuery = jsonbEntryQuery;
+        this.clause = clause;
+    }
+
+    public Field<?> toSql(I_VariableDefinition variableDefinition, String template_id, String identifier){
+        Field<?> field;
+
+        if (variableDefinition.getPath() != null && variableDefinition.getPath().startsWith("content")) {
+            field = jsonbEntryQuery.makeField(template_id, identifier, variableDefinition, clause);
+            containsJsonDataBlock = jsonbEntryQuery.isJsonDataBlock();
+            jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
+        } else {
+            field = compositionAttributeQuery.makeField(template_id, identifier, variableDefinition, clause);
+            containsJsonDataBlock = compositionAttributeQuery.isJsonDataBlock();
+        }
+        optionalPath = variableDefinition.getPath();
+        return field;
+    }
+
+    public boolean isContainsJsonDataBlock() {
+        return containsJsonDataBlock;
+    }
+
+    public String getJsonbItemPath() {
+        return jsonbItemPath;
+    }
+
+    public String getOptionalPath() {
+        return optionalPath;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/ContextualAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/ContextualAttribute.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 Christian Chevalley, Vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.binding;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.queryImpl.CompositionAttributeQuery;
+import org.ehrbase.aql.sql.queryImpl.I_QueryImpl;
+import org.ehrbase.aql.sql.queryImpl.JsonbEntryQuery;
+import org.jooq.Field;
+
+/**
+ * convert a field that is not identied as an EHR or a COMPOSITION (content or attribute). For example a CLUSTER
+ * in other_context
+ */
+public class ContextualAttribute {
+
+    private final CompositionAttributeQuery compositionAttributeQuery;
+    private final JsonbEntryQuery jsonbEntryQuery;
+    private final I_QueryImpl.Clause clause;
+
+    private boolean containsJsonDataBlock;
+    private String jsonbItemPath;
+    private String optionalPath;
+
+    public ContextualAttribute(CompositionAttributeQuery compositionAttributeQuery, JsonbEntryQuery jsonbEntryQuery, I_QueryImpl.Clause clause) {
+        this.compositionAttributeQuery = compositionAttributeQuery;
+        this.jsonbEntryQuery = jsonbEntryQuery;
+        this.clause = clause;
+    }
+
+    public Field<?> toSql(String template_id, I_VariableDefinition variableDefinition){
+        String inTemplatePath = compositionAttributeQuery.variableTemplatePath(template_id, variableDefinition.getIdentifier());
+        if (inTemplatePath.startsWith("/"))
+            inTemplatePath = inTemplatePath.substring(1); //conventionally, composition attribute path have the leading '/' striped.
+        String originalPath = variableDefinition.getPath();
+        variableDefinition.setPath(inTemplatePath+(variableDefinition.getPath() == null? "": "/"+variableDefinition.getPath()));
+        CompositionAttribute compositionAttribute = new CompositionAttribute(compositionAttributeQuery, jsonbEntryQuery, clause);
+        Field field = compositionAttribute.toSql(variableDefinition, template_id, variableDefinition.getIdentifier());
+
+        if (clause.equals(I_QueryImpl.Clause.SELECT)) {
+            variableDefinition.setPath(originalPath);
+            field = field.as("/"+originalPath);
+        }
+
+        jsonbItemPath = compositionAttribute.getJsonbItemPath();
+        containsJsonDataBlock = compositionAttribute.isContainsJsonDataBlock();
+        optionalPath = compositionAttribute.getOptionalPath();
+
+        return field;
+    }
+
+    public boolean isContainsJsonDataBlock() {
+        return containsJsonDataBlock;
+    }
+
+    public String getJsonbItemPath() {
+        return jsonbItemPath;
+    }
+
+    public String getOptionalPath() {
+        return optionalPath;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/ExpressionField.java
@@ -26,6 +26,7 @@ import org.ehrbase.aql.sql.queryImpl.attribute.ehr.EhrResolver;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import java.util.Objects;
 import java.util.UUID;
 
 class ExpressionField {
@@ -50,9 +51,15 @@ class ExpressionField {
         Field<?> field;
 
         switch (className) {
+            //COMPOSITION attributes
             case "COMPOSITION":
-                field = compositionAttributeToSql(template_id, identifier);
+                CompositionAttribute compositionAttribute = new CompositionAttribute(compositionAttributeQuery, jsonbEntryQuery, I_QueryImpl.Clause.SELECT);
+                field = compositionAttribute.toSql(variableDefinition, template_id, identifier);
+                jsonbItemPath = compositionAttribute.getJsonbItemPath();
+                containsJsonDataBlock = compositionAttribute.isContainsJsonDataBlock();
+                optionalPath = compositionAttribute.getOptionalPath();
                 break;
+            // EHR attributes
             case "EHR":
                 if (EhrResolver.isEhrAttribute(variableDefinition.getPath()))
                     variableDefinition.setDistinct(true);
@@ -61,23 +68,33 @@ class ExpressionField {
                 containsJsonDataBlock = compositionAttributeQuery.isJsonDataBlock();
                 optionalPath = variableDefinition.getPath();
                 break;
+            // other, f.e. CLUSTER, ADMIN_ENTRY, OBSERVATION etc.
             default:
+                // other_details f.e.
                 if (compositionAttributeQuery.isCompositionAttributeItemStructure(template_id, variableDefinition.getIdentifier())) {
-                    String inTemplatePath = compositionAttributeQuery.variableTemplatePath(template_id, variableDefinition.getIdentifier());
-                    if (inTemplatePath.startsWith("/"))
-                        inTemplatePath = inTemplatePath.substring(1); //conventionally, composition attribute path have the leading '/' striped.
-                    variableDefinition.setPath(inTemplatePath+(variableDefinition.getPath() == null? "": "/"+variableDefinition.getPath()));
-                    field = compositionAttributeToSql(template_id, variableDefinition.getIdentifier());
+                    ContextualAttribute contextualAttribute = new ContextualAttribute(compositionAttributeQuery, jsonbEntryQuery, I_QueryImpl.Clause.SELECT);
+                    field = contextualAttribute.toSql(template_id, variableDefinition);
+                    jsonbItemPath = contextualAttribute.getJsonbItemPath();
+                    containsJsonDataBlock = contextualAttribute.isContainsJsonDataBlock();
+                    optionalPath = contextualAttribute.getOptionalPath();
                 }
-                else
-                    field = locatableItemToSql(template_id, variableDefinition.getIdentifier(), className);
+                else {
+                    // all other that are supported as simpleClassExpr (most common resolution)
+                    LocatableItem locatableItem = new LocatableItem(compositionAttributeQuery, jsonbEntryQuery, I_QueryImpl.Clause.SELECT);
+                    field = locatableItem.toSql(template_id, variableDefinition, className);
+                    jsonbItemPath = locatableItem.getJsonbItemPath();
+                    containsJsonDataBlock = containsJsonDataBlock | locatableItem.isContainsJsonDataBlock();
+                    optionalPath = locatableItem.getOptionalPath();
+                    rootJsonKey = locatableItem.getRootJsonKey();
+                    jsonbItemPath = locatableItem.getJsonbItemPath();
+                }
                 break;
         }
 
         return field;
     }
 
-    private Field<?> compositionAttributeToSql(String template_id, String identifier){
+    private Field<?> _compositionAttributeToSql(String template_id, String identifier){
         Field<?> field;
 
         if (variableDefinition.getPath() != null && variableDefinition.getPath().startsWith("content")) {
@@ -92,7 +109,7 @@ class ExpressionField {
         return field;
     }
 
-    private Field<?> locatableItemToSql(String template_id, String identifier, String className){
+    private Field<?> _locatableItemToSql(String template_id, String identifier, String className){
         Field<?> field;
 
         field = jsonbEntryQuery.makeField(template_id, identifier, variableDefinition, I_QueryImpl.Clause.SELECT);
@@ -109,7 +126,7 @@ class ExpressionField {
                 if (DataValue.class.isAssignableFrom(itemClass)) {
                     VariableAqlPath variableAqlPath = new VariableAqlPath(variableDefinition.getPath());
                     if (variableAqlPath.getSuffix().equals("value")){
-                        if (className.equals("COMPOSITION")) { //assumes this is a data value within an ELEMENT
+                        if (Objects.equals(className, "COMPOSITION")) { //assumes this is a data value within an ELEMENT
                             try {
                                 I_VariableDefinition variableDefinition1 = variableDefinition.clone();
                                 variableDefinition1.setPath(variableAqlPath.getInfix());
@@ -139,6 +156,8 @@ class ExpressionField {
         }
         return field;
     }
+
+
 
     boolean isContainsJsonDataBlock() {
         return containsJsonDataBlock;

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Christian Chevalley, Vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.binding;
+
+import com.nedap.archie.rm.datavalues.DataValue;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import org.ehrbase.api.exception.InternalServerException;
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.queryImpl.*;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+/**
+ * evaluate the SQL expression for locatables in the ITEM_STRUCTURE: OBSERVATION, INSTRUCTION, CLUSTER etc.
+ * NB. At the moment, direct resolution of ELEMENT is not supported.
+ */
+public class LocatableItem {
+
+    private final CompositionAttributeQuery compositionAttributeQuery;
+    private final JsonbEntryQuery jsonbEntryQuery;
+    private final I_QueryImpl.Clause clause;
+    private boolean containsJsonDataBlock;
+    private String jsonbItemPath;
+    private String optionalPath;
+    private String rootJsonKey;
+
+    public LocatableItem(CompositionAttributeQuery compositionAttributeQuery, JsonbEntryQuery jsonbEntryQuery, I_QueryImpl.Clause clause) {
+        this.compositionAttributeQuery = compositionAttributeQuery;
+        this.jsonbEntryQuery = jsonbEntryQuery;
+        this.clause = clause;
+    }
+
+    public Field<?> toSql(String template_id, I_VariableDefinition variableDefinition, String className){
+        Field<?> field;
+
+        field = jsonbEntryQuery.makeField(template_id, variableDefinition.getIdentifier(), variableDefinition, I_QueryImpl.Clause.SELECT);
+        jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
+        containsJsonDataBlock = containsJsonDataBlock | jsonbEntryQuery.isJsonDataBlock();
+        if (jsonbEntryQuery.isJsonDataBlock() ) {
+
+            if (jsonbEntryQuery.getItemType() != null){
+                Class itemClass = ArchieRMInfoLookup.getInstance().getClass(jsonbEntryQuery.getItemType());
+
+                if (itemClass == null && className != null) //this may occur f.e. for itemType 'MULTIPLE'. try we classname
+                    itemClass = ArchieRMInfoLookup.getInstance().getClass(className);
+
+                if (DataValue.class.isAssignableFrom(itemClass)) {
+                    VariableAqlPath variableAqlPath = new VariableAqlPath(variableDefinition.getPath());
+                    if (variableAqlPath.getSuffix().equals("value")){
+                        if (className.equals("COMPOSITION")) { //assumes this is a data value within an ELEMENT
+                            try {
+                                I_VariableDefinition variableDefinition1 = variableDefinition.clone();
+                                variableDefinition1.setPath(variableAqlPath.getInfix());
+                                field = jsonbEntryQuery.makeField(template_id, variableDefinition.getIdentifier(), variableDefinition1, I_QueryImpl.Clause.SELECT);
+                                jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
+                                rootJsonKey = variableAqlPath.getSuffix();
+                            } catch (CloneNotSupportedException e) {
+                                throw new InternalServerException("Couldn't handle variable:" + variableDefinition.toString() + "Code error:" + e);
+                            }
+                        }
+                        else if (jsonbEntryQuery.getItemCategory().equals("ELEMENT") || jsonbEntryQuery.getItemCategory().equals("CLUSTER")){
+                            int cut = jsonbItemPath.lastIndexOf(",/value");
+                            if (cut != -1)
+                                //we keep the path that select the json element value block, and call the formatting function
+                                //to pass the actual value datatype into the json block
+                                field = DSL.field("(ehr.js_typed_element_value(" + jsonbItemPath.substring(0, cut) + "}')::jsonb))");
+
+                            String alias = variableDefinition.getAlias();
+                            if (alias == null)
+                                alias = new DefaultColumnId().value(variableDefinition);
+                            field = field.as(alias);
+                        }
+                    }
+
+                }
+            }
+            else
+                throw new IllegalStateException("Internal: unsupported item type for:"+variableDefinition);
+        }
+        return field;
+    }
+
+    public boolean isContainsJsonDataBlock() {
+        return containsJsonDataBlock;
+    }
+
+    public String getJsonbItemPath() {
+        return jsonbItemPath;
+    }
+
+    public String getOptionalPath() {
+        return optionalPath;
+    }
+
+    public String getRootJsonKey() {
+        return rootJsonKey;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
@@ -25,6 +25,8 @@ import org.ehrbase.aql.sql.queryImpl.*;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import java.util.Objects;
+
 /**
  * evaluate the SQL expression for locatables in the ITEM_STRUCTURE: OBSERVATION, INSTRUCTION, CLUSTER etc.
  * NB. At the moment, direct resolution of ELEMENT is not supported.
@@ -45,12 +47,12 @@ public class LocatableItem {
         this.clause = clause;
     }
 
-    public Field<?> toSql(String template_id, I_VariableDefinition variableDefinition, String className){
+    public Field<?> toSql(String templateId, I_VariableDefinition variableDefinition, String className){
         Field<?> field;
 
-        field = jsonbEntryQuery.makeField(template_id, variableDefinition.getIdentifier(), variableDefinition, I_QueryImpl.Clause.SELECT);
+        field = jsonbEntryQuery.makeField(templateId, variableDefinition.getIdentifier(), variableDefinition, I_QueryImpl.Clause.SELECT);
         jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
-        containsJsonDataBlock = containsJsonDataBlock | jsonbEntryQuery.isJsonDataBlock();
+        containsJsonDataBlock |= jsonbEntryQuery.isJsonDataBlock();
         if (jsonbEntryQuery.isJsonDataBlock() ) {
 
             if (jsonbEntryQuery.getItemType() != null){
@@ -62,11 +64,11 @@ public class LocatableItem {
                 if (DataValue.class.isAssignableFrom(itemClass)) {
                     VariableAqlPath variableAqlPath = new VariableAqlPath(variableDefinition.getPath());
                     if (variableAqlPath.getSuffix().equals("value")){
-                        if (className.equals("COMPOSITION")) { //assumes this is a data value within an ELEMENT
+                        if (Objects.equals(className, "COMPOSITION")) { //assumes this is a data value within an ELEMENT
                             try {
                                 I_VariableDefinition variableDefinition1 = variableDefinition.clone();
                                 variableDefinition1.setPath(variableAqlPath.getInfix());
-                                field = jsonbEntryQuery.makeField(template_id, variableDefinition.getIdentifier(), variableDefinition1, I_QueryImpl.Clause.SELECT);
+                                field = jsonbEntryQuery.makeField(templateId, variableDefinition.getIdentifier(), variableDefinition1, I_QueryImpl.Clause.SELECT);
                                 jsonbItemPath = jsonbEntryQuery.getJsonbItemPath();
                                 rootJsonKey = variableAqlPath.getSuffix();
                             } catch (CloneNotSupportedException e) {

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/SuperQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/SuperQuery.java
@@ -50,13 +50,15 @@ public class SuperQuery {
     }
 
     @SuppressWarnings( "deprecation" )
-    private List<Field> selectFields() {
+    private List<Field> selectDistinctFields() {
 
         List<Field> fields = new ArrayList<>();
         Iterator<I_VariableDefinition> iterator = variableDefinitions.iterator();
 
         while (iterator.hasNext()) {
             I_VariableDefinition variableDefinition = iterator.next();
+            if (!variableDefinition.isDistinct())
+                continue;
             if (variableDefinition instanceof FunctionDefinition){
                 StringBuilder stringBuilder = new StringBuilder();
                 for (FuncParameter funcParameter: ((FunctionDefinition) variableDefinition).getParameters()){
@@ -81,7 +83,7 @@ public class SuperQuery {
     @SuppressWarnings("unchecked")
     private SelectQuery selectDistinct(SelectQuery selectQuery) {
 
-        List<Field> fields = selectFields();
+        List<Field> fields = selectDistinctFields();
 
         selectQuery.addDistinctOn(fields);
 

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/VariableDefinitions.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/VariableDefinitions.java
@@ -20,6 +20,7 @@ package org.ehrbase.aql.sql.binding;
 import org.ehrbase.aql.definition.I_VariableDefinition;
 import org.ehrbase.aql.definition.VariableDefinition;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -67,5 +68,19 @@ public class VariableDefinitions implements Iterator<I_VariableDefinition>{
                 return variableDefinition.isDistinct();
         }
         return false;
+    }
+
+    public VariableDefinitions clone(){
+        List<I_VariableDefinition> variableDefinitionClone = new ArrayList<>();
+
+        for (I_VariableDefinition variableDefinition: variableDefinitionList){
+            try {
+                variableDefinitionClone.add(variableDefinition.clone());
+            } catch (CloneNotSupportedException e){
+                throw new IllegalStateException("Internal error, clone failed:"+e);
+            }
+        }
+
+        return new VariableDefinitions(variableDefinitionClone);
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -107,8 +107,14 @@ public class WhereBinder {
                     return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.SQLQUERY);
 
                 default:
-                    field = jsonbEntryQuery.whereField(templateId, identifier, variableDefinition);
-                    return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.JSQUERY);
+                    if (compositionAttributeQuery.isCompositionAttributeItemStructure(templateId, identifier)){
+                        field = new ContextualAttribute(compositionAttributeQuery, jsonbEntryQuery, I_QueryImpl.Clause.WHERE).toSql(templateId, variableDefinition);
+                        return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.SQLQUERY);
+                    }
+                    else {
+                        field = jsonbEntryQuery.whereField(templateId, identifier, variableDefinition);
+                        return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.JSQUERY);
+                    }
             }
         }
     }

--- a/service/src/main/java/org/ehrbase/opt/query/QueryOptMetaData.java
+++ b/service/src/main/java/org/ehrbase/opt/query/QueryOptMetaData.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 /**
  * Created by christian on 5/7/2018.
+ * TODO: a lot of caching should be done there
  */
 public class QueryOptMetaData implements I_QueryOptMetaData {
 
@@ -91,6 +92,7 @@ public class QueryOptMetaData implements I_QueryOptMetaData {
      */
     @Override
     public List upperNotBounded() {
+        //TODO: potentially time consuming, should be cached as it depends on immutable templates
         return JsonPath.read(document, "$..children[?(@.max == -1)]");
     }
 


### PR DESCRIPTION
## Changes

Refactored AQL handling of items resolved in context/other_context (such as a CLUSTER).

Fixed 3 related issues:

1. WHERE clause SQL translation was wrong for these items (was still assuming it located in the entry content)
2. The SELECT was not properly formatted relatively to the item path and aliasing
3. DISTINCT ON clause was using ALL variables instead of only the ones requiring this clause

NB. Sonar seems not happy about coverage, however this is usually tested by the DSK tests...

## Related issue
Fixes: https://github.com/ehrbase/project_management/issues/344

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
