### PR TITLE
Fixed time drift (was still using a previous fct)

### DIFF
--- a/base/src/main/resources/db/migration/V33__fix_AQL_time_retrieval.sql
+++ b/base/src/main/resources/db/migration/V33__fix_AQL_time_retrieval.sql
@@ -1,0 +1,9 @@
+-- ensures that date/time handling is the same for time with or without timezone
+CREATE OR REPLACE FUNCTION ehr.js_dv_date_time(datetime TIMESTAMP, timezone TEXT)
+    RETURNS JSON AS
+$$
+BEGIN
+    RETURN ehr.js_dv_date_time(datetime::TIMESTAMPTZ, timezone);
+END
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Changes
Fix time representation in ehr.js_dv_date_time(datetime TIMESTAMP, timezone TEXT). Make sure it uses the newer ehr.js_dv_date_time(datetime TIMESTAMPTZ, timezone TEXT)

## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/355

## Additional information and checks

- [ ] Pull request linked in changelog
