### PR TITLE
Automatic Docker image releases via DockerHub's Autobuilds

### DIFF
--- a/.docker_scripts/create-ehrbase-user.sh
+++ b/.docker_scripts/create-ehrbase-user.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE ROLE ${EHRBASE_USER} LOGIN PASSWORD '${EHRBASE_PASSWORD}';
+    CREATE DATABASE ehrbase ENCODING 'UTF-8' TEMPLATE template0;
+    GRANT ALL PRIVILEGES ON DATABASE ehrbase TO ${EHRBASE_USER};
+    CREATE USER root WITH SUPERUSER;
+EOSQL
+
+# Stop database before proceeding
+su - postgres -c "pg_ctl -D ${PGDATA} -w stop"

--- a/.docker_scripts/docker-entrypoint.sh
+++ b/.docker_scripts/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo 
+echo "EHRBASE_VERSION: $(cat ehrbase_version)"
+java -Dspring.profiles.active=docker -jar ehrbase.jar

--- a/.docker_scripts/install-jsquery.sh
+++ b/.docker_scripts/install-jsquery.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Fetch from remote repository
+git clone https://github.com/postgrespro/jsquery.git
+cd jsquery
+
+# Build jsQuery plugin
+make USE_PGXS=1 && \
+make USE_PGXS=1 install && \
+
+cd ..

--- a/.docker_scripts/install-temporal-tables.sh
+++ b/.docker_scripts/install-temporal-tables.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Start server
+su - postgres -c "pg_ctl -D ${PGDATA} -w start"
+
+# Fetch from branch "mlt" which has full support of Postgres 11
+git clone https://github.com/mlt/temporal_tables.git --branch mlt
+cd temporal_tables
+
+# Build from source
+make PGUSER=postgres &&
+make install &&
+make installcheck
+
+# Stop server
+su - postgres -c "pg_ctl -D ${PGDATA} -w stop"
+
+cd ..

--- a/.docker_scripts/prepare-databases.sh
+++ b/.docker_scripts/prepare-databases.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# Start server
+su - postgres -c "pg_ctl -D ${PGDATA} -w start"
+
+# Setup schemas and activate extensions
+psql --username="$POSTGRES_USER" --dbname "ehrbase" <<-EOSQL
+  CREATE SCHEMA IF NOT EXISTS ehr AUTHORIZATION "$EHRBASE_USER";
+  CREATE SCHEMA IF NOT EXISTS ext AUTHORIZATION "$EHRBASE_USER";
+  CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA ext;
+  CREATE EXTENSION IF NOT EXISTS "temporal_tables" SCHEMA ext;
+  CREATE EXTENSION IF NOT EXISTS "jsquery" SCHEMA ext;
+  CREATE EXTENSION IF NOT EXISTS "ltree" SCHEMA ext;
+  ALTER DATABASE ehrbase SET search_path to "$EHRBASE_USER",public,ext;
+  GRANT ALL ON ALL FUNCTIONS IN SCHEMA ext TO $EHRBASE_USER;
+EOSQL
+
+# Stop server
+su - postgres -c "pg_ctl -D ${PGDATA} -w stop"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.pgdata
+.circleci
+tests

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
 .git
-.pgdata
+.gitattributes
+.gitignore
 .circleci
+.circleciignore
+.dockerignore
+.pgdata
+CHANGELOG.md
+LICENSE.md
+Notice .md
+README.md
+sonar-project.properties
+
 tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,154 @@
+FROM postgres:11.5-alpine AS builder
+
+# Set default values for database user and passwords
+ARG EHRBASE_USER="ehrbase"
+ARG EHRBASE_PASSWORD="ehrbase"
+ENV EHRBASE_USER=${EHRBASE_USER}
+ENV EHRBASE_PASSWORD=${EHRBASE_PASSWORD}
+
+# Set Postgres data directory to custom folder
+ENV PGDATA="/var/lib/postgresql/pgdata"
+
+# Create custom data directory and change ownership to postgres user
+RUN mkdir -p ${PGDATA}
+RUN chown postgres: ${PGDATA}
+RUN chmod 0700 ${PGDATA}
+
+# Define Postgres version for easier upgrades for the future
+ENV PG_MAJOR=11.9
+
+# Adding locales to an alpine container as described
+# here: https://github.com/Auswaschbar/alpine-localized-docker
+# set our environment variable
+ENV MUSL_LOCPATH="/usr/share/i18n/locales/musl"
+
+# install libintl
+# then install dev dependencies for musl-locales
+# clone the sources
+# build and install musl-locales
+# remove sources and compile artifacts
+# lastly remove dev dependencies again
+RUN apk --no-cache add libintl && \
+	apk --no-cache --virtual .locale_build add cmake make musl-dev gcc gettext-dev git && \
+	git clone https://gitlab.com/rilian-la-te/musl-locales && \
+	cd musl-locales && cmake -DLOCALE_PROFILE=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr . && make && make install && \
+	cd .. && rm -r musl-locales && \
+	apk del .locale_build
+
+# Copy init scripts to init directory
+COPY .docker_scripts/create-ehrbase-user.sh /docker-entrypoint-initdb.d/
+
+# Initialize basic database cluster
+RUN sh -c "/usr/local/bin/docker-entrypoint.sh postgres & " && \
+    sleep 20 && \
+    echo "Database initialized"
+
+# Allow connections from all adresses & Listen to all interfaces
+RUN echo "host  all  all   0.0.0.0/0  scram-sha-256" >> ${PGDATA}/pg_hba.conf
+RUN echo "listen_addresses='*'" >> ${PGDATA}/postgresql.conf
+
+# Install python and dependencies
+RUN apk add --update postgresql-dev \
+                     build-base \
+                     git \
+                     flex \
+                     bison
+
+# Install temporary_tables plugin
+COPY .docker_scripts/install-temporal-tables.sh .
+RUN chmod +x ./install-temporal-tables.sh
+RUN sh -c "./install-temporal-tables.sh"
+
+# Install jsquery plugin
+COPY .docker_scripts/install-jsquery.sh .
+RUN chmod +x ./install-jsquery.sh 
+RUN sh -c "./install-jsquery.sh"
+
+# Prepare database schemas
+COPY .docker_scripts/prepare-databases.sh .
+RUN chmod +x ./prepare-databases.sh
+RUN sh -c "./prepare-databases.sh"
+
+# Cleanup
+RUN rm -f -r ./jsquery
+RUN rm -f -r ./temporal_tables
+
+EXPOSE 5432
+
+# INSTALL JAVA 11 JDK
+RUN apk --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+  && java --version
+
+# INSTALL MAVEN
+ENV MAVEN_VERSION 3.6.3
+ENV MAVEN_HOME /usr/lib/mvn
+ENV PATH $MAVEN_HOME/bin:$PATH
+RUN wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  rm apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  mv apache-maven-$MAVEN_VERSION /usr/lib/mvn \
+  && mvn --version
+
+# CACHE EHRBASE DEPENDENCIES
+RUN ls -la
+COPY ./pom.xml ./pom.xml
+COPY ./api/pom.xml ./api/pom.xml
+COPY ./application/pom.xml ./application/pom.xml
+COPY ./base/pom.xml ./base/pom.xml
+COPY ./jooq-pq/pom.xml ./jooq-pq/pom.xml
+COPY ./rest-ehr-scape/pom.xml ./rest-ehr-scape/pom.xml
+COPY ./rest-openehr/pom.xml ./rest-openehr/pom.xml
+COPY ./service/pom.xml ./service/pom.xml
+COPY ./api/src ./api/src
+COPY ./application/src ./application/src
+COPY ./base/src ./base/src
+COPY ./jooq-pq/src ./jooq-pq/src
+COPY ./rest-ehr-scape/src ./rest-ehr-scape/src
+COPY ./rest-openehr/src ./rest-openehr/src
+COPY ./service/src ./service/src
+RUN mvn compile dependency:go-offline \
+    -Dflyway.skip=true \
+    -Djooq.codegen.skip=true \
+    -Dmaven.main.skip
+
+# COMPILE EHRBASE
+RUN su - postgres -c "pg_ctl -D ${PGDATA} -w start" \
+  && mvn compile
+
+# PACKAGE EHRBASE .JAR
+RUN ls -la
+RUN su - postgres -c "pg_ctl -D ${PGDATA} -w start" \
+  && mvn package -Dmaven.javadoc.skip=true
+
+RUN ls -la
+RUN EHRBASE_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec) \
+  && echo ${EHRBASE_VERSION} > /tmp/ehrbase_version \
+  && cp application/target/application-${EHRBASE_VERSION}.jar /tmp/ehrbase.jar
+
+
+
+# FINAL IMAGE WITH JRE AND JAR ONLY
+FROM openjdk:11-jre-slim AS pusher
+COPY --from=builder /tmp/ehrbase.jar .
+COPY --from=builder /tmp/ehrbase_version .
+COPY .docker_scripts/docker-entrypoint.sh .
+RUN chmod +x ./docker-entrypoint.sh
+RUN echo "EHRBASE_VERSION: $(cat ehrbase_version)"
+
+
+# Set default ENVs (can be overriten from cli via --build-arg flag)
+ARG DB_URL=jdbc:postgresql://ehrdb:5432/ehrbase
+ARG DB_USER="ehrbase"
+ARG DB_PASS="ehrbase"
+ARG SYSTEM_NAME=docker.ehrbase.org
+ARG SECURITY_AUTHTYPE=NONE
+
+ENV EHRBASE_VERSION=${EHRBASE_VERSION}
+ENV DB_USER=$DB_USER
+ENV DB_PASS=$DB_PASS
+ENV DB_URL=$DB_URL
+ENV SYSTEM_NAME=$SYSTEM_NAME
+ENV SECURITY_AUTHTYPE=$SECURITY_AUTHTYPE
+
+EXPOSE 8080
+CMD ./docker-entrypoint.sh


### PR DESCRIPTION
An EHRbase docker image is created and published on DockerHub regestry:
- Pushes/merges to ~~develop~~ master branch publish a docker image w/ `latest` tag, i.e. **ehrbaseorg/ehrbase:latest**
- Pushes/merges to develop branch publish a docker image w/ `next` tag, i.e. **ehrbaseorg/ehrbase:next**
- Pushes to release-* branches publish a docker image w/ version `1.2.3` tag, i.e. **ehrbaseorg/ehrbase:0.13.0**
- Uses DockerHub infrastructure (no resources of CircleCI used)


## Changes

- Adds multi stage Dockerfile with scripts to build ehrbase inside a docker container

## Related issue

- closes https://github.com/ehrbase/project_management/issues/333
- closes https://github.com/ehrbase/project_management/issues/342


## DockerHub Configuration Docs
It was not sufficient to connect our ehrbase-tech-user, instead the "real" owner of the Github Org had to be connected to enable Autobuild on Docker Hub. Now that the connection is established everything else can be configured w/ the ehrbase-tech-user login to DockerHub (docker.com)

![image](https://user-images.githubusercontent.com/64201310/93017121-7399a400-f5c6-11ea-9a6e-899449a0e343.png)
---
![image](https://user-images.githubusercontent.com/64201310/93017184-06d2d980-f5c7-11ea-9c82-ea3caecd0360.png)
---
![image](https://user-images.githubusercontent.com/64201310/93017284-a8f2c180-f5c7-11ea-9271-6f882d9adbe8.png)



