### PR TITLE
Add CORS configuration to security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Junit5 support via spring-boot-starter-test (https://github.com/ehrbase/ehrbase/pull/298)
 - Enable cartesian products on embedded arrays in JSONB (see https://github.com/ehrbase/ehrbase/pull/309)
 - Use new OPT-Parser from sdk (see https://github.com/ehrbase/ehrbase/pull/314)
+- Add CORS config to enable clients to detect auth method.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Junit5 support via spring-boot-starter-test (https://github.com/ehrbase/ehrbase/pull/298)
 - Enable cartesian products on embedded arrays in JSONB (see https://github.com/ehrbase/ehrbase/pull/309)
 - Use new OPT-Parser from sdk (see https://github.com/ehrbase/ehrbase/pull/314)
-- Add CORS config to enable clients to detect auth method.
+- Add CORS config to enable clients to detect auth method (see https://github.com/ehrbase/ehrbase/pull/354).
 
 ### Fixed
 

--- a/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
+++ b/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -36,10 +35,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Formatter;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Configuration
@@ -83,6 +83,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "Username: %s Password: %s", securityYAMLConfig.getAuthUser(), securityYAMLConfig.getAuthPassword()
                 ).toString());
                 http
+                        .cors()
+                        .and()
                         .csrf().disable()
                         .authorizeRequests()
                         // Specific routes with ../admin/.. require admin role
@@ -97,6 +99,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             case OAUTH:
                 logger.info("Using OAuth2 authentication.");
                 http
+                        .cors()
+                        .and()
                         .authorizeRequests()
                         // Specific routes with ../admin/.. require admin role
                         .antMatchers("/rest/openehr/v1/admin/**").hasRole(ADMIN)
@@ -112,6 +116,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 logger.warn("Authentication disabled!");
                 logger.warn("To enable security set security.authType to BASIC or OAUTH in yaml properties file.");
                 http
+                        .cors()
+                        .and()
                         .csrf().disable()
                         .authorizeRequests().anyRequest().permitAll();
                 break;
@@ -134,5 +140,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .collect(Collectors.toList());
         });
         return converter;
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // Allow all origins to access EHRbase
+        configuration.setAllowedOrigins(Collections.singletonList("*"));
+        // Allowed HTTP methods
+        configuration.setAllowedMethods(Arrays.asList("GET","POST", "PUT", "DELETE", "HEAD", "OPTIONS"));
+        // Exposed headers that can be read by clients. Includes also all safe-listed headers
+        // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+        configuration.setExposedHeaders(Collections.singletonList("WWW-Authenticate"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // Apply for all paths
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
+++ b/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
@@ -117,7 +117,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 logger.warn("To enable security set security.authType to BASIC or OAUTH in yaml properties file.");
                 http
                         .cors()
-                        .configurationSource(corsConfigurationSource())
                         .and()
                         .csrf().disable()
                         .authorizeRequests().anyRequest().permitAll();

--- a/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
+++ b/application/src/main/java/org/ehrbase/application/config/SecurityConfig.java
@@ -117,12 +117,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 logger.warn("To enable security set security.authType to BASIC or OAUTH in yaml properties file.");
                 http
                         .cors()
+                        .configurationSource(corsConfigurationSource())
                         .and()
                         .csrf().disable()
                         .authorizeRequests().anyRequest().permitAll();
                 break;
         }
     }
+
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -151,7 +154,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         configuration.setAllowedMethods(Arrays.asList("GET","POST", "PUT", "DELETE", "HEAD", "OPTIONS"));
         // Exposed headers that can be read by clients. Includes also all safe-listed headers
         // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
-        configuration.setExposedHeaders(Collections.singletonList("WWW-Authenticate"));
+        configuration.setExposedHeaders(Arrays.asList(
+                "Access-Control-Allow-Methods",
+                "Access-Control-Allow-Origin",
+                "ETag",
+                "Content-Type",
+                "Last-Modified",
+                "Location",
+                "WWW-Authenticate"
+        ));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         // Apply for all paths


### PR DESCRIPTION

## Changes

- Add CORS configuration to expose WWW-Authenticate header on 401 responses
- Allow all sources for CORS

## Related issue

project_management#409

## Additional information and checks

The changes are required to implement the EHRcontrol UI with a detection mechanism for the target authentication method. As specified in the MDN this header should be sent if a request has been rejected by the server due to authorization failed: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate

- [x] Pull request linked in changelog
