### PR TITLE
Make ATNA logging configurable in EHRbase #403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add ATNA logging configuration capabilities (see https://github.com/ehrbase/ehrbase/pull/355)
+
 ### Changed
 
 ### Fixed

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openehealth.ipf.boot</groupId>
+            <artifactId>ipf-atna-spring-boot-starter</artifactId>
+            <version>3.7.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -1,0 +1,4 @@
+ipf:
+  atna:
+    audit-enabled: true
+    audit-repository-port: 3001


### PR DESCRIPTION
## Changes

<!-- Describe your changes in a short list -->

- Add ipf-atna-spring-boot-starter library
- Configure atna for the local profile in `application-local.yaml`

## Related issue

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->

Fixes [https://github.com/ehrbase/project_management/issues/403](url)

## Additional information

<!-- If there are more checks or data to be provided, put it here -->

Usage example:

1. Configure the ATNA properties like audit log repository host, port and other in the application.yaml.
See https://oehf.github.io/ipf-docs/docs/boot-atna/

2. Inject the AuditContext bean:
`
@Autowire
private AuditContext auditContext;
`

3. Use it to send audit logs:
`
auditContext.audit( new ApplicationActivityBuilder.ApplicationStart(EventOutcomeIndicator.Success, "Application Started") .getMessage());
`