### PR TITLE
fix unproper aliasing of json query in where, wrapped exception messa…

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/compiler/Statements.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/Statements.java
@@ -125,4 +125,8 @@ public class Statements {
     public void put(I_VariableDefinition variableDefinition) {
         variables.add(variableDefinition);
     }
+
+    public String getParsedExpression(){
+        return parseTree.getText();
+    }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -208,7 +208,18 @@ public class QueryProcessor extends TemplateMetaData {
 
 
     private Result<Record> fetchResultSet(Select<?> select, Result<Record> result) {
-        Result<Record> intermediary = (Result<Record>) select.fetch();
+        Result<Record> intermediary;
+        try {
+            intermediary = (Result<Record>) select.fetch();
+        } catch (Exception e){
+
+            String reason = "Could not perform SQL query:" + e.getCause() +
+                    ", AQL expression:" +
+                    statements.getParsedExpression() +
+                    ", Translated SQL:" +
+                    select.getSQL();
+            throw new IllegalArgumentException(reason);
+        }
         if (result != null) {
             result.addAll(intermediary);
         } else if (intermediary != null) {

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/CompositionAttributeQuery.java
@@ -74,6 +74,9 @@ public class CompositionAttributeQuery extends ObjectQuery implements I_QueryImp
 
         Field retField;
 
+        if (clause.equals(Clause.WHERE))
+            fieldResolutionContext.setWithAlias(false);
+
         if (columnAlias == null) {
             if (clause.equals(Clause.SELECT)) {
                 if (pathResolver.classNameOf(variableDefinition.getIdentifier()).equals("COMPOSITION"))

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/FieldResolutionContext.java
@@ -31,7 +31,7 @@ public class FieldResolutionContext {
 //    private final UUID compositionId;
     private final String identifier;
     private final I_VariableDefinition variableDefinition;
-    private final boolean withAlias;
+    private boolean withAlias;
     private final I_QueryImpl.Clause clause;
     private final DSLContext context;
     private final String serverNodeId;
@@ -113,5 +113,9 @@ public class FieldResolutionContext {
 
     public void setJsonDatablock(boolean jsonDatablock) {
         this.jsonDatablock = jsonDatablock;
+    }
+
+    public void setWithAlias(boolean b) {
+        withAlias = b;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/composition/FullCompositionJson.java
@@ -57,7 +57,7 @@ public class FullCompositionJson extends CompositionAttribute {
         if (fieldContext.isWithAlias())
             return aliased(DSL.field(jsonFullComposition));
         else
-            return DSL.field(jsonFullComposition).as(fieldContext.getIdentifier());
+            return defaultAliased(jsonFullComposition);
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/FullEhrJson.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryImpl/attribute/ehr/FullEhrJson.java
@@ -81,7 +81,7 @@ public class FullEhrJson extends EhrAttribute {
         if (fieldContext.isWithAlias())
             return aliased(DSL.field(jsonFullEhr));
         else
-            return DSL.field(jsonFullEhr).as(fieldContext.getIdentifier());
+            return defaultAliased(jsonFullEhr);
     }
 
     @Override

--- a/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
@@ -43,21 +43,17 @@ import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 @Service
-@Transactional
 @SuppressWarnings("unchecked")
 public class QueryServiceImp extends BaseService implements QueryService {
     private Logger logger = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
## Changes

- removed aliasing for field in where clause
- handle SQL exception with a more meaningful message
- removed Transactional directive for QueryServiceImp.java since it is a SELECT only processor and doesn't need transaction support. This was causing a Rollback failure exception in Spring whenever a SQL expression was broken (here: set function in where clause).

## Related issue
fixes: https://github.com/ehrbase/project_management/issues/407 & https://github.com/ehrbase/project_management/issues/406

## Additional information and checks

- [ ] Pull request linked in changelog
