### PR TITLE
Feature/ehrbase/project management/issues/423 handle errors knowlage

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/containment/ContainPropositions.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/ContainPropositions.java
@@ -94,9 +94,6 @@ public class ContainPropositions {
                                     + entry.getKey()
                                     + ", as in:" + entry.getValue());
 
-                    } catch (IllegalArgumentException e) {
-                        //this is for an unresolved template id
-                            continue;
                     } catch (Exception e) {
                         throw new IllegalArgumentException("Could not traverse cached templates:" + e);
                     }

--- a/service/src/main/java/org/ehrbase/aql/containment/ContainPropositions.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/ContainPropositions.java
@@ -17,7 +17,6 @@
  */
 package org.ehrbase.aql.containment;
 
-import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import org.apache.commons.collections4.SetUtils;
 import org.ehrbase.service.KnowledgeCacheService;
 import org.ehrbase.webtemplate.parser.NodeId;
@@ -89,11 +88,7 @@ public class ContainPropositions {
                                 }
                             }
 
-                        } else if (ArchieRMInfoLookup.getInstance().getClass(entry.getValue().getSymbol()) == null) //if true, this is a valid class item
-                            throw new IllegalArgumentException("Containment definition does not exist in any defined template, Could not resolve:"
-                                    + entry.getKey()
-                                    + ", as in:" + entry.getValue());
-
+                        }
                     } catch (Exception e) {
                         throw new IllegalArgumentException("Could not traverse cached templates:" + e);
                     }

--- a/service/src/main/java/org/ehrbase/configuration/CacheConfiguration.java
+++ b/service/src/main/java/org/ehrbase/configuration/CacheConfiguration.java
@@ -117,6 +117,7 @@ public class CacheConfiguration {
         if (!enabled) {
             config.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(Duration.ZERO));
         }
+
         cacheManager.createCache(cacheName, config);
     }
 }

--- a/service/src/main/java/org/ehrbase/service/KnowledgeCacheService.java
+++ b/service/src/main/java/org/ehrbase/service/KnowledgeCacheService.java
@@ -24,7 +24,6 @@ package org.ehrbase.service;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.xmlbeans.XmlException;
-import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.StateConflictException;
 import org.ehrbase.aql.containment.JsonPathQueryResult;
@@ -48,7 +47,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
@@ -101,7 +99,7 @@ import static org.ehrbase.configuration.CacheConfiguration.QUERY_CACHE;
  * @author C. Chevalley
  */
 @Service
-@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Transactional
 public class KnowledgeCacheService implements I_KnowledgeCache, IntrospectService {
 
 
@@ -333,6 +331,7 @@ public class KnowledgeCacheService implements I_KnowledgeCache, IntrospectServic
     private void invalidateCache(OPERATIONALTEMPLATE template) {
 
         //invalidate the cache for this template
+        allTemplateId.remove(template.getTemplateId().getValue());
         webTemplateCache.remove(UUID.fromString(template.getUid().getValue()));
         atOptCache.remove(template.getTemplateId().getValue());
 
@@ -455,8 +454,8 @@ public class KnowledgeCacheService implements I_KnowledgeCache, IntrospectServic
         try {
             visitor = new OPTParser(operationaltemplate).parse();
         } catch (Exception e) {
-            log.error("Invalidate template {}", operationaltemplate.getTemplateId().getValue());
-            throw new InternalServerException(e.getMessage(), e);
+            log.error("Invalid template {}", operationaltemplate.getTemplateId().getValue(), e);
+            throw new IllegalArgumentException(String.format("Invalid template: %s", e.getMessage()));
         }
 
         webTemplateCache.put(UUID.fromString(operationaltemplate.getUid().getValue()), visitor);

--- a/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/QueryServiceImp.java
@@ -43,7 +43,6 @@ import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
@@ -52,7 +51,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/service/src/main/java/org/ehrbase/service/TemplateDBStorageService.java
+++ b/service/src/main/java/org/ehrbase/service/TemplateDBStorageService.java
@@ -29,11 +29,13 @@ import org.jooq.DSLContext;
 import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@Transactional()
 public class TemplateDBStorageService implements TemplateStorage {
     private final DSLContext context;
     private final ServerConfig serverConfig;

--- a/service/src/main/java/org/ehrbase/service/TemplateServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/TemplateServiceImp.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.xml.namespace.QName;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +50,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class TemplateServiceImp extends BaseService implements TemplateService {
 
     private final KnowledgeCacheService knowledgeCacheService;


### PR DESCRIPTION
Hardened the knowledge Cache against errors:

- Reject templates when query Metadaten can not be build from it
- Allow startup of ehrbase even if there are errors in the knowledge Cache
- during startup remove missing templates form Cache. should fix https://github.com/ehrbase/ehrbase/issues/336
- fixed a "Transaction rolled back because it has been marked as rollback-only" wenn a  IllegalArgumentException was thrown from  knowledge Cache
- treat errors during deserialization from Cache entries as Cache miss  (happens wenn the java class  changed  but old one are on the disc Cache)


closes https://github.com/ehrbase/ehrbase/issues/336
closes https://github.com/ehrbase/project_management/issues/423
 