### PR TITLE
Status endpoint for version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Admin API endpoints: Del EHR, Del Composition and Del Contribution (see: https://github.com/ehrbase/ehrbase/pull/344)
 - Add ATNA logging configuration capabilities (see https://github.com/ehrbase/ehrbase/pull/355)
 - Support for EHR_STATUS and (partial) FOLDER version objects in contributions (see: https://github.com/ehrbase/ehrbase/pull/372)
+- Add status endpoint to retrieve version information on running EHRbase instance and for heartbeat checks.
 
 ### Changed
 - support AQL querying on full EHR (f.e. SELECT e) (see )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Admin API endpoints: Del EHR, Del Composition and Del Contribution (see: https://github.com/ehrbase/ehrbase/pull/344)
 - Add ATNA logging configuration capabilities (see https://github.com/ehrbase/ehrbase/pull/355)
 - Support for EHR_STATUS and (partial) FOLDER version objects in contributions (see: https://github.com/ehrbase/ehrbase/pull/372)
-- Add status endpoint to retrieve version information on running EHRbase instance and for heartbeat checks.
+- Add status endpoint to retrieve version information on running EHRbase instance and for heartbeat checks. (see: https://github.com/ehrbase/ehrbase/pull/393)
 
 ### Changed
 - support AQL querying on full EHR (f.e. SELECT e) (see )

--- a/api/src/main/java/org/ehrbase/api/service/StatusService.java
+++ b/api/src/main/java/org/ehrbase/api/service/StatusService.java
@@ -48,4 +48,25 @@ public interface StatusService extends BaseService {
      * @return Database information
      */
     String getDatabaseInformation();
+
+    /**
+     * Returns current version of EHRbase build that is running.
+     *
+     * @return Current EHRbase version
+     */
+    String getEhrbaseVersion();
+
+    /**
+     * Returns current version of archie which has been used to build the running EHRbase instance.
+     *
+     * @return Current used Archie version
+     */
+    String getArchieVersion();
+
+    /**
+     * Returns the current version of openEHR_SDK which has been used to build the running EHRbase instance.
+     *
+     * @return Current used openEHR_SDK version
+     */
+    String getOpenEHR_SDK_Version();
 }

--- a/api/src/main/java/org/ehrbase/api/service/StatusService.java
+++ b/api/src/main/java/org/ehrbase/api/service/StatusService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Axel Siebert (Vitasystems GmbH) and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.api.service;
+
+/**
+ * Status service to get information about the running EHRbase instance
+ */
+public interface StatusService extends BaseService {
+
+    /**
+     * Returns information on the current operating system this EHRbase instance is running on.
+     * The resulting info string contains the name, the architecture and the version of the
+     * operating system, e.g. "Mac OS X x86_64 10.15.7"
+     *
+     * @return OS information
+     */
+    String getOperatingSystemInformation();
+
+    /**
+     * Returns information on the current Java Virtual Machine that is running this EHRbase
+     * instance. Provide information on the JVM vendor and the full java runtime version, e.g.
+     * "Eclipse OpenJ9 11.0.9+11".
+     *
+     * @return JVM Version string
+     */
+    String getJavaVMInformation();
+
+    /**
+     * Returns information on the current connected Database instance version. This contains the
+     * major version and additionally also the operating system it is running on, e.g. useful
+     * if the database runs on a remote server or inside a docker container.
+     *
+     * @return Database information
+     */
+    String getDatabaseInformation();
+}

--- a/base/src/main/resources/db/migration/V40__get_system_version_function.sql
+++ b/base/src/main/resources/db/migration/V40__get_system_version_function.sql
@@ -1,0 +1,18 @@
+-- ====================================================================
+-- Author: Axel Siebert (axel.siebert@vitagroup.ag)
+-- Create date: 2020-11-24
+-- Description: Retrieves all information on running db system including environment os by running VERSION() function.
+--
+-- Returns: Version string of running db server including os information
+-- =====================================================================
+DROP FUNCTION IF EXISTS ehr.get_system_version;
+
+CREATE OR REPLACE FUNCTION ehr.get_system_version()
+RETURNS TEXT
+AS $$
+DECLARE
+  version_string TEXT;
+BEGIN
+	SELECT VERSION() INTO version_string;
+	RETURN version_string;
+END; $$ LANGUAGE plpgsql;

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <swagger.version>1.6.2</swagger.version>
         <swagger-snapshot.version>2.0.0-rc2</swagger-snapshot.version>
         <postgressql.version>42.2.5</postgressql.version>
-        <ehrbase.sdk.version>ab5b9da</ehrbase.sdk.version>
+        <ehrbase.sdk.version>36e41af</ehrbase.sdk.version>
         <flyway.version>6.5.7</flyway.version>
         <joda.version>2.10.6</joda.version>
         <database.name>ehrbase</database.name>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <commons.io.version>2.6</commons.io.version>
         <commons.lang3.version>3.11</commons.lang3.version>
+        <archie.version>738152e</archie.version>
         <assertj.core>3.11.1</assertj.core>
         <json.path.version>2.4.0</json.path.version>
         <jooq.version>3.12.3</jooq.version>
@@ -129,7 +130,7 @@
         <swagger.version>1.6.2</swagger.version>
         <swagger-snapshot.version>2.0.0-rc2</swagger-snapshot.version>
         <postgressql.version>42.2.5</postgressql.version>
-        <ehrbase.sdk.version>36e41af</ehrbase.sdk.version>
+        <ehrbase.sdk.version>c44284e</ehrbase.sdk.version>
         <flyway.version>6.5.7</flyway.version>
         <joda.version>2.10.6</joda.version>
         <database.name>ehrbase</database.name>
@@ -274,7 +275,7 @@
             <dependency>
                 <groupId>com.github.openEHR</groupId>
                 <artifactId>archie</artifactId>
-                <version>738152e</version>
+                <version>${archie.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -634,6 +635,20 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>build-info</id>
+                            <goals>
+                                <goal>build-info</goal>
+                            </goals>
+                            <configuration>
+                                <additionalProperties>
+                                    <archie.version>${archie.version}</archie.version>
+                                    <openEHR_SDK.version>${ehrbase.sdk.version}</openEHR_SDK.version>
+                                </additionalProperties>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/StatusController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/StatusController.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Axel Siebert (Vitasystems GmbH) and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.rest.openehr.controller;
+
+import io.swagger.annotations.*;
+import org.ehrbase.api.service.StatusService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import org.ehrbase.response.openehr.StatusResponseData;
+
+import java.util.Objects;
+
+/**
+ * API endpoint to get status of EHRbase and version information on used dependencies as archie or openEHR_sdk as well
+ * as the current used JVM version or target PostgreSQL server version.
+ */
+@Api(tags = {"Heartbeat", "Version info", "Status"})
+@RestController
+@RequestMapping(path = "/rest/openehr/v1", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+public class StatusController extends BaseController {
+
+    private final StatusService statusService;
+
+    @Autowired
+    public StatusController(StatusService statusService) {
+        this.statusService = Objects.requireNonNull(statusService);
+    }
+
+    @GetMapping(path = "/status")
+    @ApiOperation(
+            value = "Get status information on running EHRbase server instance",
+            response = StatusResponseData.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "EHRbase is available. Basic information on runtime and build is returned in body.",
+                    responseHeaders = {
+                            @ResponseHeader(name = CONTENT_TYPE, description = RESP_CONTENT_TYPE_DESC, response = MediaType.class)
+                    }
+            )
+    })
+    @ResponseStatus(value = HttpStatus.OK)
+    public ResponseEntity<StatusResponseData> getEhrbaseStatus(
+            @ApiParam(value = "Client desired response data format")
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false, defaultValue = MediaType.APPLICATION_JSON_VALUE)
+            String accept
+    ) {
+        StatusResponseData responseData = new StatusResponseData();
+        // Java VM version
+        responseData.setJvmVersion(this.statusService.getJavaVMInformation());
+        // OS Identifier and version
+        responseData.setOsVersion(this.statusService.getOperatingSystemInformation());
+        // Database server version
+        responseData.setPostgresVersion(this.statusService.getDatabaseInformation());
+
+        return ResponseEntity.ok(responseData);
+    }
+}

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/StatusController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/controller/StatusController.java
@@ -73,6 +73,12 @@ public class StatusController extends BaseController {
         responseData.setOsVersion(this.statusService.getOperatingSystemInformation());
         // Database server version
         responseData.setPostgresVersion(this.statusService.getDatabaseInformation());
+        // EHRbase version
+        responseData.setEhrbaseVersion(this.statusService.getEhrbaseVersion());
+        // Client SDK Version
+        responseData.setOpenEhrSdkVersion(this.statusService.getOpenEHR_SDK_Version());
+        // Archie version
+        responseData.setArchieVersion(this.statusService.getArchieVersion());
 
         return ResponseEntity.ok(responseData);
     }

--- a/service/src/main/java/org/ehrbase/dao/access/interfaces/I_DatabaseStatusAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/interfaces/I_DatabaseStatusAccess.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Axel Siebert (Vitasystems GmbH) and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.dao.access.interfaces;
+
+import org.ehrbase.dao.access.jooq.DatabaseStatusAccess;
+
+public interface I_DatabaseStatusAccess {
+
+    static String retrieveDatabaseVersion(I_DomainAccess domainAccess) {
+        return DatabaseStatusAccess.getDatabaseVersion(domainAccess);
+    }
+}

--- a/service/src/main/java/org/ehrbase/dao/access/jooq/DatabaseStatusAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/jooq/DatabaseStatusAccess.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Axel Siebert (Vitasystems GmbH) and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.dao.access.jooq;
+
+import org.ehrbase.api.definitions.ServerConfig;
+import org.ehrbase.dao.access.interfaces.I_DatabaseStatusAccess;
+import org.ehrbase.dao.access.interfaces.I_DomainAccess;
+import org.ehrbase.dao.access.support.DataAccess;
+import org.ehrbase.jooq.pg.Routines;
+import org.jooq.DSLContext;
+
+public class DatabaseStatusAccess extends DataAccess implements I_DatabaseStatusAccess {
+
+    public DatabaseStatusAccess(DSLContext dslContext, ServerConfig serverConfig) {
+        super(dslContext, null, null, serverConfig);
+    }
+
+    @Override
+    public DataAccess getDataAccess() {
+        return this;
+    }
+
+    public static String getDatabaseVersion(I_DomainAccess domainAccess) {
+        return Routines.getSystemVersion(domainAccess.getContext().configuration());
+    }
+}

--- a/service/src/main/java/org/ehrbase/service/StatusServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/StatusServiceImp.java
@@ -22,6 +22,7 @@ import org.ehrbase.api.service.StatusService;
 import org.ehrbase.dao.access.interfaces.I_DatabaseStatusAccess;
 import org.jooq.DSLContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,9 @@ import java.lang.management.ManagementFactory;
 @Service
 @Transactional
 public class StatusServiceImp extends BaseService implements StatusService {
+
+    @Autowired
+    private BuildProperties buildProperties;
 
     @Autowired
     public StatusServiceImp(
@@ -71,5 +75,29 @@ public class StatusServiceImp extends BaseService implements StatusService {
     @Override
     public String getDatabaseInformation() {
         return I_DatabaseStatusAccess.retrieveDatabaseVersion(getDataAccess());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEhrbaseVersion() {
+        return this.buildProperties.getVersion();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getArchieVersion() {
+        return this.buildProperties.get("archie.version");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOpenEHR_SDK_Version() {
+        return this.buildProperties.get("openEHR_SDK.version");
     }
 }

--- a/service/src/main/java/org/ehrbase/service/StatusServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/StatusServiceImp.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Axel Siebert (Vitasystems GmbH) and Hannover Medical School.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.service;
+
+import org.ehrbase.api.definitions.ServerConfig;
+import org.ehrbase.api.service.StatusService;
+import org.ehrbase.dao.access.interfaces.I_DatabaseStatusAccess;
+import org.jooq.DSLContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.management.ManagementFactory;
+
+@Service
+@Transactional
+public class StatusServiceImp extends BaseService implements StatusService {
+
+    @Autowired
+    public StatusServiceImp(
+            KnowledgeCacheService knowledgeCacheService,
+            DSLContext dslContext,
+            ServerConfig serverConfig
+    ) {
+        super(knowledgeCacheService, dslContext, serverConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOperatingSystemInformation() {
+        return String.format(
+                "%s %s %s",
+                ManagementFactory.getOperatingSystemMXBean().getName(),
+                ManagementFactory.getOperatingSystemMXBean().getArch(),
+                ManagementFactory.getOperatingSystemMXBean().getVersion()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getJavaVMInformation() {
+        return String.format(
+                "%s %s",
+                ManagementFactory.getRuntimeMXBean().getVmVendor(),
+                ManagementFactory.getRuntimeMXBean().getSystemProperties().get("java.runtime.version")
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDatabaseInformation() {
+        return I_DatabaseStatusAccess.retrieveDatabaseVersion(getDataAccess());
+    }
+}


### PR DESCRIPTION
## Changes

- Add endpoint controller to serve from http://${ehrbase_host:port}/ehrbase/rest/openehr/v1/status
- Add DatabaseStatusAccess to retrieve the PostgreSQL server version from running database
- Add stored procedure to migrations to get the full version string from database
- Add service to extract OS, JVM, PostgreSQL and dependency versions from running instance
- Add build property exposure to build process with maven


## Additional information and checks

- [x] Pull request linked in changelog
