### PR TITLE
Feature/206 unquoted substitution

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/compiler/AqlErrorHandlerNoRecovery.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/AqlErrorHandlerNoRecovery.java
@@ -25,7 +25,7 @@ import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
-import org.ehrbase.aql.compiler.recovery.RecoverArchetypeId;
+import org.ehrbase.aql.parser.AqlParser;
 
 import java.util.BitSet;
 
@@ -34,13 +34,13 @@ import java.util.BitSet;
  * Allows to return more meaningful messages during AQL parsing
  * Created by christian on 4/15/2016.
  */
-public class AqlErrorHandler extends BaseErrorListener {
+public class AqlErrorHandlerNoRecovery extends BaseErrorListener {
 
-    public static final AqlErrorHandler INSTANCE = new AqlErrorHandler();
+    public static final AqlErrorHandlerNoRecovery INSTANCE = new AqlErrorHandlerNoRecovery();
     public static final boolean REPORT_SYNTAX_ERRORS = true;
 
     @Override
-    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e)  {
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) throws ParseCancellationException {
         if (!REPORT_SYNTAX_ERRORS) {
             return;
         }
@@ -48,10 +48,6 @@ public class AqlErrorHandler extends BaseErrorListener {
         String sourceName = recognizer.getInputStream().getSourceName();
         if (!sourceName.isEmpty()) {
             sourceName = String.format("%s:%d:%d: ", sourceName, line, charPositionInLine);
-        }
-
-        if (e != null && new RecoverArchetypeId().isRecoverableArchetypeId(e.getCtx(), offendingSymbol)){
-                return; //ignore since it will be 'fixed' by the recognizer
         }
 
         throw new ParseCancellationException("AQL Parse exception: " + (sourceName.isEmpty() ? "source:" + sourceName : "") + "line " + line + ": char " + charPositionInLine + " " + msg);

--- a/service/src/main/java/org/ehrbase/aql/compiler/AqlExpressionWithParameters.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/AqlExpressionWithParameters.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 public class AqlExpressionWithParameters extends AqlExpression {
 
-    public final String PARAMETERS_KEY = "query-parameters";
+    public static final String PARAMETERS_KEY = "query-parameters";
 
     public AqlExpressionWithParameters parse(String query, Map<String, Object> parameterValues){
         String query1 = substitute(query, parameterValues);
@@ -45,11 +45,12 @@ public class AqlExpressionWithParameters extends AqlExpression {
      *     "systolic_bp": 140
      *   }
      *
-     * @param query
+     * @param expression
      * @param jsonParameterMap
      * @return
      */
-    public AqlExpressionWithParameters parse(String query, String jsonParameterMap){
+    @Override
+    public AqlExpressionWithParameters parse(String expression, String jsonParameterMap){
 
         //get the map from the json expression
         Gson gson = new GsonBuilder().create();
@@ -62,7 +63,7 @@ public class AqlExpressionWithParameters extends AqlExpression {
 
         parameterMap = (Map<String, Object>) parameterMap.get(PARAMETERS_KEY);
 
-        return parse(query, parameterMap);
+        return parse(expression, parameterMap);
     }
 
     /**
@@ -86,7 +87,7 @@ public class AqlExpressionWithParameters extends AqlExpression {
                 throw new IllegalArgumentException("Could not substitute parameter in AQL expression: '"+variable+"'");
             Object parameterValue = parameterValues.get(variable.substring(1));
 
-            if (parameterValue instanceof String || parameterValue instanceof UUID)
+            if (isSingleQuotedArgument(parameterValue))
                 parameterValue = "'"+parameterValue+"'";
 
             matcher.appendReplacement(stringBuffer, String.valueOf(parameterValue));
@@ -94,5 +95,9 @@ public class AqlExpressionWithParameters extends AqlExpression {
 
         matcher.appendTail(stringBuffer);
         return stringBuffer.toString();
+    }
+
+    private boolean isSingleQuotedArgument(Object parameterValue){
+       return parameterValue instanceof UUID || parameterValue instanceof String;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/compiler/recovery/RecoverArchetypeId.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/recovery/RecoverArchetypeId.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2020 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+
+package org.ehrbase.aql.compiler.recovery;
+
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.RuleContext;
+import org.apache.commons.lang3.StringUtils;
+import org.ehrbase.aql.compiler.AqlExpression;
+import org.ehrbase.aql.parser.AqlParser;
+
+public class RecoverArchetypeId {
+    /**
+     * archetype id is potentially recoverable if it is a single quoted string.
+     * We check however, that the unquoted string is still a valid archetype id.
+     *
+     * @param context
+     * @param offendingSymbol
+     * @return
+     */
+    public boolean isRecoverableArchetypeId(RuleContext context, Object offendingSymbol) {
+        if (context instanceof AqlParser.ArchetypedClassExprContext && offendingSymbol instanceof CommonToken) {
+            CommonToken symbol = (CommonToken) offendingSymbol;
+            if (symbol.getText().startsWith("'") && symbol.getText().endsWith("'"))
+                return true; //ignore since it will be 'fixed' by the recognizer
+        }
+        return false;
+    }
+
+    public String recoverInvalidArchetypeId(RuleContext context, CommonToken offendingSymbol) {
+        String offendingToken = offendingSymbol.getText();
+        String archetypeId = StringUtils.stripEnd(StringUtils.stripStart(offendingToken, "'"), "'");
+        String expression = context.getText().replace(offendingToken, archetypeId);
+
+        //will throw an exception if not valid
+        new AqlExpression().parse(expression, "archetypedClassExpr");
+
+        return archetypeId;
+    }
+}

--- a/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
@@ -134,5 +134,15 @@ public class AqlExpressionTest extends TestAqlBase {
 
     }
 
+    @Test
+    public void testSpecificRule1() {
+
+        String query = "COMPOSITIONc[openEHR-EHR-COMPOSITION.123.minimal.v1]";
+        AqlExpression cut = new AqlExpression().parse(query, "archetypedClassExpr");
+
+        assertThat(cut.getParseTree()).isNotNull();
+
+    }
+
 
 }

--- a/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/AqlExpressionTest.java
@@ -138,9 +138,11 @@ public class AqlExpressionTest extends TestAqlBase {
     public void testSpecificRule1() {
 
         String query = "COMPOSITIONc[openEHR-EHR-COMPOSITION.123.minimal.v1]";
-        AqlExpression cut = new AqlExpression().parse(query, "archetypedClassExpr");
+        try {
+            AqlExpression cut = new AqlExpression().parse(query, "archetypedClassExpr");
 
-        assertThat(cut.getParseTree()).isNotNull();
+            fail("the invalid archetype id should have been rejected");
+        } catch (Exception e){}
 
     }
 

--- a/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__a_Loaded_DB.robot
@@ -325,17 +325,17 @@ D-304 Execute Ad-HOc Query - Get Data
 D-306 Execute Ad-HOc Query - Get Data
     [Documentation]     Get Data related query.
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              206    not-ready
+    [Tags]              205    not-ready
     D/306_select_data_values_from_all_ehrs_contains_composition_with_archetype.json    D/306.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  206  bug
+    [Teardown]          TRACE GITHUB ISSUE  205  bug
 
 
 D-307 Execute Ad-HOc Query - Get Data
     [Documentation]     Get Data related query.
     [Template]          execute ad-hoc query and check result (loaded DB)
-    [Tags]              206    not-ready
+    [Tags]              205    not-ready
     D/307_select_data_values_from_all_ehrs_contains_composition_with_archetype.json    D/307.tmp.json
-    [Teardown]          TRACE GITHUB ISSUE  206  bug
+    [Teardown]          TRACE GITHUB ISSUE  205  bug
 
 
 D-308 Execute Ad-HOc Query - Get Data

--- a/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__z_Empty_DB.robot
+++ b/tests/robot/QUERY_SERVICE_TESTS/A.1_EXECUTE_AD-HOC_QUERY/A.1__z_Empty_DB.robot
@@ -281,16 +281,14 @@ D-300 Execute Ad-Hoc Query - Get Data
 
 D-306 Execute Ad-Hoc Query - Get Data
     [Template]          execute ad-hoc query and check result (empty DB)
-    [Tags]              AQL_data    206    not-ready
+    [Tags]              AQL_data
     D/306_select_data_values_from_all_ehrs_contains_composition_with_archetype.json
-    [Teardown]          TRACE GITHUB ISSUE  206  bug
 
 
 D-307 Execute Ad-Hoc Query - Get Data
     [Template]          execute ad-hoc query and check result (empty DB)
-    [Tags]              AQL_data    206    not-ready
+    [Tags]              AQL_data
     D/307_select_data_values_from_all_ehrs_contains_composition_with_archetype.json
-    [Teardown]          TRACE GITHUB ISSUE  206  bug
 
 
 D-311 Execute Ad-Hoc Query - Get Data


### PR DESCRIPTION
## Changes

Fix variable substitution in node archetype id predicate by handling the quoted argument properly (remove the single quotes). 
This fix uses parse error recovery at ANTLR parsing time. Hence, the fix is compatible with future grammar enhancement.

## Related issue

fixes: https://github.com/ehrbase/project_management/issues/206

## Additional information and checks


- [ ] Pull request linked in changelog
