### PR TITLE
Sync/regressions in aql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <swagger.version>1.6.2</swagger.version>
         <swagger-snapshot.version>2.0.0-rc2</swagger-snapshot.version>
         <postgressql.version>42.2.18</postgressql.version>
-        <ehrbase.sdk.version>9dc1adb</ehrbase.sdk.version>
+        <ehrbase.sdk.version>1.0.0</ehrbase.sdk.version>
         <flyway.version>6.5.7</flyway.version>
         <joda.version>2.10.6</joda.version>
         <database.name>ehrbase</database.name>

--- a/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/postprocessing/RawJsonTransform.java
@@ -35,6 +35,7 @@ import org.jooq.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Created by christian on 2/21/2017.
@@ -110,8 +111,13 @@ public class RawJsonTransform implements IRawJsonTransform {
 
     private static boolean hasPredicate(String path){
 
-        List<String> segments = LocatableHelper.dividePathIntoSegments(path);
+        try {
+            List<String> segments = LocatableHelper.dividePathIntoSegments(path);
 
-        return (segments.get(segments.size() - 1).contains("["));
+            return (segments.get(segments.size() - 1).contains("["));
+        }
+        catch (NoSuchElementException e) { //not an AQL path (f.e. function based)
+            return false;
+        }
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/IterativeNode.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/IterativeNode.java
@@ -103,7 +103,10 @@ public class IterativeNode implements IIterativeNode {
         resultingPath.addAll(segmentedPath);
 
         for (Integer pos : clipPos) {
-            resultingPath.set(pos, QueryImplConstants.AQL_NODE_ITERATIVE_MARKER);
+            if (pos == resultingPath.size())
+                resultingPath.add(QueryImplConstants.AQL_NODE_ITERATIVE_MARKER);
+            else
+                resultingPath.set(pos, QueryImplConstants.AQL_NODE_ITERATIVE_MARKER);
         }
         return resultingPath;
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/JsonDataBlockCheck.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/JsonDataBlockCheck.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2020 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+
+package org.ehrbase.aql.sql.queryimpl;
+
+import java.util.List;
+
+public class JsonDataBlockCheck {
+
+    //CCH 191018 EHR-163 matches trailing '/value'
+    // '/name,0' is to matches path relative to the name array
+
+    public static final String MATCH_NODE_PREDICATE = "(/(content|events|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\])|" +
+            "(/value|/value,definingCode|/time|/name,0|/origin|/origin,/name,0|/origin,/value|/value,mappings)|" +
+            "(/value,mappings,0)(|,purpose|,target|,purpose,definingCode|,purpose,definingCode,terminologyId|,target,terminologyId)|" +
+            // common locatable attributes
+            "(/uid,/value|/language|/language,terminologyId|/encoding|/encoding,terminologyId)";
+    
+    private final List<String> jqueryPath;
+
+    public JsonDataBlockCheck(List<String> jqueryPath){
+        this.jqueryPath = jqueryPath;
+    }
+
+    public boolean isJsonBlock(){
+        if (jqueryPath.isEmpty())
+            return true;
+        
+        if (jqueryPath.get(0).startsWith("/feeder_audit"))
+            return checkFeederAuditPath();
+        else
+            return jqueryPath.get(jqueryPath.size() - 1).matches(MATCH_NODE_PREDICATE);
+    }
+
+    private boolean checkFeederAuditPath(){
+        String[] tokens = jqueryPath.get(0).split(",");
+
+        String lastItem = tokens[tokens.length - 1];
+        
+        return !(lastItem.equalsIgnoreCase("value")||
+                 lastItem.equalsIgnoreCase("system_id")||
+                lastItem.equalsIgnoreCase("version_id")||
+                 //PartyIdentified
+                 lastItem.equalsIgnoreCase("name")||
+                 //PartyRef
+                lastItem.equalsIgnoreCase("namespace")||
+                //dvIdentifier
+                 lastItem.equalsIgnoreCase("issuer")||
+                 lastItem.equalsIgnoreCase("assigner")||
+                 lastItem.equalsIgnoreCase("id")||
+                 lastItem.equalsIgnoreCase("type"));
+
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/JsonbEntryQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/JsonbEntryQuery.java
@@ -99,12 +99,6 @@ public class JsonbEntryQuery extends ObjectQuery implements IQueryImpl {
     public static final String PURPOSE = "purpose";
     public static final String TARGET = "target";
     public static final String TERMINOLOGY_ID = "terminologyId";
-    //CCH 191018 EHR-163 matches trailing '/value'
-    // '/name,0' is to matches path relative to the name array
-
-    public static final String MATCH_NODE_PREDICATE = "(/(content|events|protocol|data|description|instruction|items|activities|activity|composition|entry|evaluation|observation|action)\\[([(0-9)|(A-Z)|(a-z)|\\-|_|\\.]*)\\])|" +
-            "(/value|/value,definingCode|/time|/name,0|/origin|/origin,/name,0|/origin,/value|/value,mappings)|" +
-            "(/value,mappings,0)(|,purpose|,target|,purpose,definingCode|,purpose,definingCode,terminologyId|,target,terminologyId)";
 
     //Generic stuff
     private static final String JSONB_SELECTOR_CLOSE = "}'";
@@ -151,7 +145,7 @@ public class JsonbEntryQuery extends ObjectQuery implements IQueryImpl {
     public enum OTHER_ITEM {OTHER_DETAILS, OTHER_CONTEXT}
 
     //deals with special tree based entities
-    //this is required to encode structure like events of events (events:{events[at0001] ... events[at000x]}
+    //this is required to encode structure like events of events
     //the same is applicable to activities. These are in fact pseudo arrays.
     private static void encodeTreeMapNodeId(List<String> jqueryPath, String nodeId) {
         if (nodeId.startsWith(TAG_EVENTS)) {
@@ -230,8 +224,8 @@ public class JsonbEntryQuery extends ObjectQuery implements IQueryImpl {
         }
 
         //CHC 191018 EHR-163 '/value' for an ELEMENT will return a structure
-        if (pathPart.equals(PATH_PART.VARIABLE_PATH_PART) && jqueryPath.get(jqueryPath.size() - 1).matches(MATCH_NODE_PREDICATE)) {
-            jsonDataBlock = true;
+        if (pathPart.equals(PATH_PART.VARIABLE_PATH_PART)) {
+            jsonDataBlock = new JsonDataBlockCheck(jqueryPath).isJsonBlock();
         }
 
         return jqueryPath;

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/GenericJsonPath.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/GenericJsonPath.java
@@ -17,6 +17,7 @@ public class GenericJsonPath {
     public static final String ORIGINATING_SYSTEM_AUDIT = "originating_system_audit";
     public static final String FEEDER_SYSTEM_AUDIT = "feeder_system_audit";
     public static final String SETTING = "setting";
+    public static final String HEALTH_CARE_FACILITY = "health_care_facility";
     public static final String ITEMS = "items";
     public static final String CONTENT = "content";
     public static final String VALUE = "value";
@@ -32,66 +33,41 @@ public class GenericJsonPath {
         this.path = path;
     }
 
-    public String jqueryPath(){
+    public String jqueryPath() {
         if (path == null || path.isEmpty())
             return path;
 
         List<String> jqueryPaths = Arrays.asList(path.split("/|,"));
         List<String> actualPaths = new ArrayList<>();
 
-        for (int i = 0; i < jqueryPaths.size(); i++){
+        for (int i = 0; i < jqueryPaths.size(); i++) {
             String segment = jqueryPaths.get(i);
-            if (segment.startsWith(ITEMS)){
-                actualPaths.add("/"+ segment);
+            if (segment.startsWith(ITEMS)) {
+                actualPaths.add("/" + segment);
                 //takes care of array expression (unless the occurrence is specified)
                 actualPaths.add("0");
-            }
-            else if (segment.startsWith(CONTENT)){
-                actualPaths.add(CONTENT+",/"+ segment);
+            } else if (segment.startsWith(CONTENT)) {
+                actualPaths.add(CONTENT + ",/" + segment);
                 actualPaths.add("0"); //as above
-            }
-            else if (segment.matches(VALUE + "|" + NAME) && !isTerminalValue(jqueryPaths, i)){
-                actualPaths.add("/"+ segment);
+            } else if (segment.matches(VALUE + "|" + NAME) && !isTerminalValue(jqueryPaths, i)) {
+                actualPaths.add("/" + segment);
                 if (segment.matches(NAME))
                     actualPaths.add("0");
-            }
-            else if (segment.matches(OTHER_DETAILS + "|" + OTHER_CONTEXT))
+            } else
                 actualPaths.add(segment);
-            else if (isNonItemStructureAttribute(path))
-                actualPaths.add(segment);
-            else
-                actualPaths.add(NodeIds.toCamelCase(segment));
 
         }
 
-        return "'{"+String.join(",", actualPaths)+"}'";
+        return "'{" + String.join(",", actualPaths) + "}'";
     }
 
-    public boolean isTerminalValue(List<String> paths, int index){
+    public boolean isTerminalValue(List<String> paths, int index) {
         return paths.size() == 1
                 || (paths.size() > 1
-                        && index == paths.size() - 1
-                        && paths.get(index).matches(VALUE + "|" + NAME + "|" + TERMINOLOGY_ID + "|" + PURPOSE + "|" + TARGET)
-                        //check if this 'terminal attribute' is actually a node attribute
-                        //match node predicate regexp starts with '/' which is not the case when splitting the path
-                        && !paths.get(index - 1).matches(I_DvTypeAdapter.matchNodePredicate.substring(1)));
-    }
-
-    /**
-     * identifies if the encoding comes from a db canonical function
-     * NB. the DB encoding still uses camel case instead of snake case for datavalues
-     * @param path locatable path
-     * @return true if non structural
-     */
-    private boolean isNonItemStructureAttribute(String path){
-        return (path.contains(CONTEXT)
-                || path.contains(FEEDER_AUDIT)
-                || path.contains(ORIGINATING_SYSTEM_ITEM_IDS)
-                || path.contains(FEEDER_SYSTEM_ITEM_IDS)
-                || path.contains(ORIGINAL_CONTENT)
-                || path.contains(ORIGINATING_SYSTEM_AUDIT)
-                || path.contains(FEEDER_SYSTEM_AUDIT)
-                || path.contains(SETTING)
-        );
+                && index == paths.size() - 1
+                && paths.get(index).matches(VALUE + "|" + NAME + "|" + TERMINOLOGY_ID + "|" + PURPOSE + "|" + TARGET)
+                //check if this 'terminal attribute' is actually a node attribute
+                //match node predicate regexp starts with '/' which is not the case when splitting the path
+                && !paths.get(index - 1).matches(I_DvTypeAdapter.matchNodePredicate.substring(1)));
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/setting/SettingAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/setting/SettingAttribute.java
@@ -31,8 +31,7 @@ import org.jooq.impl.DSL;
 
 import java.util.Optional;
 
-import static org.ehrbase.aql.sql.queryimpl.AqlRoutines.jsonpathItem;
-import static org.ehrbase.aql.sql.queryimpl.AqlRoutines.jsonpathParameters;
+import static org.ehrbase.aql.sql.queryimpl.AqlRoutines.*;
 import static org.ehrbase.jooq.pg.tables.EventContext.EVENT_CONTEXT;
 @SuppressWarnings({"java:S3740","java:S1452"})
 public class SettingAttribute extends EventContextAttribute {
@@ -52,11 +51,11 @@ public class SettingAttribute extends EventContextAttribute {
                 return new GenericJsonField(fieldContext, joinSetup).forJsonPath(jsonPath.get()).eventContext(EVENT_CONTEXT.ID);
 
             Field jsonContextField = DSL.field(
-                    jsonpathItem(fieldContext.getContext().configuration(),
-                            Routines.jsContextSetting(tableField).cast(JSONB.class),
+                    jsonpathItemAsText(fieldContext.getContext().configuration(),
+                            Routines.jsDvCodedText2(tableField).cast(JSONB.class),
                             jsonpathParameters(new GenericJsonPath(jsonPath.get()).jqueryPath())
                     )
-            );
+            ).cast(String.class);
 
             return as(DSL.field(jsonContextField));
         }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonField.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonField.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import static org.ehrbase.aql.sql.queryimpl.AqlRoutines.*;
+import static org.ehrbase.aql.sql.queryimpl.QueryImplConstants.AQL_NODE_ITERATIVE_MARKER;
 import static org.ehrbase.aql.sql.queryimpl.value_field.Functions.apply;
 
 @SuppressWarnings({"java:S3776","java:S3740"})
@@ -25,9 +26,9 @@ public class GenericJsonField extends RMObjectAttribute {
 
     protected Optional<String> jsonPath = Optional.empty();
 
-    private static final String AQLNODEITERATIVE = "'$AQLNODEITERATIVE$'";
-
     private boolean isJsonDataBlock = true; //by default, can be overriden
+
+    private static final String ITERATIVE_MARKER = "'"+AQL_NODE_ITERATIVE_MARKER+"'";
 
     public GenericJsonField(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
         super(fieldContext, joinSetup);
@@ -98,7 +99,7 @@ public class GenericJsonField extends RMObjectAttribute {
         if (jsonPath.isPresent()) {
             List<String> tokenized = Arrays.asList(jsonpathParameters(jsonPath.get()));
 
-            if (tokenized.contains(AQLNODEITERATIVE))
+            if (tokenized.contains(ITERATIVE_MARKER))
                 jsonField = fieldWithJsonArrayIteration(configuration, tokenized, function, tableFields);
             else
                 jsonField =
@@ -115,8 +116,8 @@ public class GenericJsonField extends RMObjectAttribute {
 
     private Field fieldWithJsonArrayIteration(Configuration configuration, List<String> tokenized, Object function, TableField... tableFields){
 
-        String[] prefix = tokenized.subList(0, tokenized.indexOf(AQLNODEITERATIVE)).toArray(new String[]{});
-        String[] remaining = tokenized.subList(tokenized.indexOf(AQLNODEITERATIVE)+1, tokenized.size()).toArray(new String[]{});
+        String[] prefix = tokenized.subList(0, tokenized.indexOf(ITERATIVE_MARKER)).toArray(new String[]{});
+        String[] remaining = tokenized.subList(tokenized.indexOf(ITERATIVE_MARKER)+1, tokenized.size()).toArray(new String[]{});
 
         //initial
         Field field = jsonpathItem(
@@ -127,9 +128,9 @@ public class GenericJsonField extends RMObjectAttribute {
 
         while (remaining.length > 0){
             List<String> tokens = Arrays.asList(remaining.clone());
-            if (tokens.contains(AQLNODEITERATIVE)) {
-                prefix = tokens.subList(0, tokens.indexOf(AQLNODEITERATIVE)).toArray(new String[]{});
-                remaining = tokens.subList(tokens.indexOf(AQLNODEITERATIVE) + 1, tokens.size()).toArray(new String[]{});
+            if (tokens.contains(ITERATIVE_MARKER)) {
+                prefix = tokens.subList(0, tokens.indexOf(ITERATIVE_MARKER)).toArray(new String[]{});
+                remaining = tokens.subList(tokens.indexOf(ITERATIVE_MARKER) + 1, tokens.size()).toArray(new String[]{});
             }
             else {
                 prefix = remaining;

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonFieldTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonFieldTest.java
@@ -79,8 +79,8 @@ public class GenericJsonFieldTest extends TestAqlBase {
                 .isEqualToIgnoringWhitespace("select" +
                         " jsonb_extract_path_text(" +
                         "       cast(\"ehr\".\"js_dv_coded_text_inner\"(\"ehr\".\"entry\".\"category\") as jsonb)," +
-                        "   'definingCode'," +
-                        "  'codeString') \"/test\"");
+                        "   'defining_code'," +
+                        "  'code_string') \"/test\"");
 
     }
 


### PR DESCRIPTION
## Changes
- handle querying feeder_audit attribute at content item level
- proper predicate handling for fct based sql path (caused an exception previously)
- correct sql encoding for setting (was using table based resolution previously)
- fixed multiple sql json path encoding for locatable and context attributes
- fixed handling of json path element when querying an array at the end of the path (f.e. terminated like .../items[at0027])
- refactored json block detection (that is query not yielding a terminal node)

## Related issue

related to multiple comments.

## Additional information and checks

- [ ] Pull request linked in changelog
