### PR TITLE
Beta Release v0.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN chown postgres: ${PGDATA}
 RUN chmod 0700 ${PGDATA}
 
 # Define Postgres version for easier upgrades for the future
-ENV PG_MAJOR=11.10
+ENV PG_MAJOR=11.11
 
 # Adding locales to an alpine container as described
 # here: https://github.com/Auswaschbar/alpine-localized-docker
@@ -119,7 +119,7 @@ RUN su - postgres -c "pg_ctl -D ${PGDATA} -w start" \
 # PACKAGE EHRBASE .JAR
 RUN ls -la
 RUN su - postgres -c "pg_ctl -D ${PGDATA} -w start" \
-  && mvn package -Dmaven.javadoc.skip=true
+  && mvn package -Dmaven.javadoc.skip=true -Djacoco.skip=true
 
 RUN ls -la
 RUN EHRBASE_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec) \


### PR DESCRIPTION
Beta Release v0.15.0 - second try

- fixed postgres version issue in dockerfile which broke Docker Hub build (s. error below)
- turned off Jacoco for mvn build in dockerfile 


```
...
Step 17/89 : RUN apk add --update postgresql=${PG_MAJOR}-r0 build-base git flex bison
---> Running in f6e23724a79c
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
[91mERROR: unsatisfiable constraints:
[0m
postgresql-11.11-r0:
breaks: world[postgresql=11.10-r0]
Removing intermediate container f6e23724a79c
The command '/bin/sh -c apk add --update postgresql=${PG_MAJOR}-r0 build-base git flex bison' returned a non-zero code: 1
```


