### PR TITLE
allow cartesian product whenever a set is empty

### DIFF
--- a/base/src/main/resources/db/migration/V49__deal_with_jsonb_empty_resultset.sql
+++ b/base/src/main/resources/db/migration/V49__deal_with_jsonb_empty_resultset.sql
@@ -16,18 +16,19 @@
  *  See the License for the specific language governing permissions and  limitations under the License.
  *
  */
+-- extend standard jsonb_array_elements to return an empty json object instead of an empty resultset
+-- this is required to avoid empty results due to performing cartesian product with an empty set.
+-- NB. this function is used when dealing with ITEM_STRUCTURE (composition entry f.e.)
+CREATE OR REPLACE FUNCTION ehr.xjsonb_array_elements(entry JSONB)
+    RETURNS SETOF JSONB AS
+$$
+BEGIN
+    IF (entry IS NULL) THEN
+        RETURN QUERY SELECT NULL::jsonb ;
+    ELSE
+        RETURN QUERY SELECT jsonb_array_elements(entry);
+    END IF;
 
-package org.ehrbase.aql.sql.queryimpl;
-
-public class QueryImplConstants {
-
-    public static final String AQL_NODE_NAME_PREDICATE_MARKER = "$AQL_NODE_NAME_PREDICATE$";
-    public static final String AQL_NODE_ITERATIVE_MARKER = "$AQL_NODE_ITERATIVE$";
-    public static final String AQL_NODE_NAME_PREDICATE_FUNCTION = "ehr.aql_node_name_predicate";
-    //we use an extended jsonb array elements function that returns a null jsonb object instead of an empty resultset
-    //see  https://www.postgresql.org/docs/current/static/functions-json.html for more on usage
-    public static final String AQL_NODE_ITERATIVE_FUNCTION = "ehr.xjsonb_array_elements";
-
-    private QueryImplConstants() {
-    }
-}
+END
+$$
+    LANGUAGE plpgsql;

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
@@ -95,7 +95,7 @@ public class LocatableItem {
                 }
             }
             else
-                throw new IllegalStateException("Internal: unsupported item type for:"+variableDefinition);
+                throw new IllegalArgumentException("Unresolved aql path:"+variableDefinition.getPath());
         }
         return field;
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/JsonbEntryQueryTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/JsonbEntryQueryTest.java
@@ -74,7 +74,7 @@ public class JsonbEntryQueryTest extends TestAqlBase {
         Field<?> actual = cut.makeField("IDCR - Immunisation summary.v0", "d", I_VariableDefinitionHelper.build("description[at0001]/items[at0002]/value/value", "test", "d", false, false, false), IQueryImpl.Clause.SELECT);
 
         SelectSelectStep<? extends Record1<?>> selectQuery = DSL.select(actual);
-        assertThat(selectQuery.getQuery().toString()).isEqualToIgnoringWhitespace("select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') \"test\"");
+        assertThat(selectQuery.getQuery().toString()).isEqualToIgnoringWhitespace("select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') \"test\"");
         assertThat(actual.toString()).hasToString("\"test\"");
     }
 

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/jsquery/TestUC16.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/jsquery/TestUC16.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.jsquery;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC16;
 
 public class TestUC16 extends UC16 {
@@ -27,7 +28,7 @@ public class TestUC16 extends UC16 {
         super();
         this.expectedSqlExpression =
                 "select " +
-                        "(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"/description[at0001]/items[openEHR-EHR-CLUSTER.test_all_types.v1]/items[at0001]/items[at0002]/items[at0003]/value/value\" from \"ehr\".\"entry\" where (\"ehr\".\"entry\".\"template_id\" = ? and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1]\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0001]\".#.\"/items[at0002]\".#.\"/items[at0003]\".#.\"/value\".\"value\"=true '::jsquery " +
+                        "("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"/description[at0001]/items[openEHR-EHR-CLUSTER.test_all_types.v1]/items[at0001]/items[at0002]/items[at0003]/value/value\" from \"ehr\".\"entry\" where (\"ehr\".\"entry\".\"template_id\" = ? and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1]\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0001]\".#.\"/items[at0002]\".#.\"/items[at0003]\".#.\"/value\".\"value\"=true '::jsquery " +
                         "OR " +
                         "(" +
                         "\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1]\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0001]\".#.\"/items[at0002]\".#.\"/items[at0003]\".#.\"/value\".\"value\"=true '::jsquery " +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/jsquery/TestUC7.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/jsquery/TestUC7.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.jsquery;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC7;
 
 public class TestUC7 extends UC7 {
@@ -26,7 +27,7 @@ public class TestUC7 extends UC7 {
     public TestUC7(){
         super();
         this.expectedSqlExpression =
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
+                "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr\".\"entry\".\"entry\" @@ '\"/composition[openEHR-EHR-COMPOSITION.health_summary.v1]\".\"/content[openEHR-EHR-ACTION.immunisation_procedure.v1]\".#.\"/description[at0001]\".\"/items[at0002]\".#.\"/value\".\"value\"=\"Hepatitis A\" '::jsquery))";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC13.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC13.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC13;
 
 //@Ignore("CR #375")
@@ -28,7 +29,7 @@ public class TestUC13 extends UC13 {
         super();
         this.expectedSqlExpression =
                 "select count(\"count_magnitude\") as \"count_magnitude\" " +
-                        "from (select ((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"count_magnitude\" " +
+                        "from (select (("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"count_magnitude\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?" +
                         ") as \"\"";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC16.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC16.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC16;
 
 public class TestUC16 extends UC16 {
@@ -27,7 +28,7 @@ public class TestUC16 extends UC16 {
         super();
         this.expectedSqlExpression =
                 "select " +
-                 "(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"/description[at0001]/items[openEHR-EHR-CLUSTER.test_all_types.v1]/items[at0001]/items[at0002]/items[at0003]/value/value\"" +
+                 "("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"/description[at0001]/items[openEHR-EHR-CLUSTER.test_all_types.v1]/items[at0001]/items[at0002]/items[at0003]/value/value\"" +
                         " from \"ehr\".\"entry\"" +
                         " where (\"ehr\".\"entry\".\"template_id\" = ?" +
                         " and (\"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1],0,/description[at0001],/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}'=true OR (\"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1],0,/description[at0001],/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}'=true AND \"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1],0,/description[at0001],/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}'=true)))";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC17.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC17.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC17;
 
 public class TestUC17 extends UC17 {
@@ -26,7 +27,7 @@ public class TestUC17 extends UC17 {
     public TestUC17(){
         super();
         this.expectedSqlExpression =
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\" " +
+                "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\" " +
                         "from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr_join\".\"id\"='4a7c01cf-bb1c-4d3d-8385-4ae0674befb1'))";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC18.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC18.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC18;
 
 public class TestUC18 extends UC18 {
@@ -26,7 +27,7 @@ public class TestUC18 extends UC18 {
     public TestUC18(){
         super();
         this.expectedSqlExpression =
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\" " +
+                "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\" " +
                         "from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" right outer join \"ehr\".\"ehr\" as \"ehr_join\" on \"ehr_join\".\"id\" = \"composition_join\".\"ehr_id\" " +
                         "where (\"ehr\".\"entry\".\"template_id\" = ? " +
                         "and (\"ehr\".\"entry\".\"template_id\"='openEHR-EHR-COMPOSITION.health_summary.v1' " +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC22.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC22.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC22;
 
 public class TestUC22 extends UC22 {
@@ -27,6 +28,6 @@ public class TestUC22 extends UC22 {
         super();
         this.expectedSqlExpression =
                 "select count(\"_FCT_ARG_0\",\"_FCT_ARG_1\") as \"count\"" +
-                        " from (select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0004],0,/value,value}') as \"_FCT_ARG_1\", (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"_FCT_ARG_0\" from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?) as \"\"";
+                        " from (select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0004],0,/value,value}') as \"_FCT_ARG_1\", ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[openEHR-EHR-CLUSTER.test_all_types.v1],0,/items[at0001],0,/items[at0002],0,/items[at0003],0,/value,value}') as \"_FCT_ARG_0\" from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?) as \"\"";
     }
 }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC27.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC27.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC27;
 
 public class TestUC27 extends UC27 {
@@ -26,14 +27,14 @@ public class TestUC27 extends UC27 {
     public TestUC27(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                "select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value') as \"/folders/name/value\"" +
                         " from \"ehr\".\"ehr\" as \"ehr_join\" " +
                         " where (\"ehr_join\".\"id\"='c2561bab-4d2b-4ffd-a893-4382e9048f8c'" +
                         " and 'case1'IN((\n" +
-                        "  select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                        "  select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value')\n" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC28.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC28.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC28;
 
 public class TestUC28 extends UC28 {
@@ -26,11 +27,11 @@ public class TestUC28 extends UC28 {
     public TestUC28(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                "select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value') as \"/folders/name/value\" from \"ehr\".\"ehr\" as \"ehr_join\" where (\"ehr_join\".\"id\"='c2561bab-4d2b-4ffd-a893-4382e9048f8c' and 'case1'=SOME((\n" +
-                        "  select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                        "  select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value')\n" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC29.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC29.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC29;
 
 public class TestUC29 extends UC29 {
@@ -26,11 +27,11 @@ public class TestUC29 extends UC29 {
     public TestUC29(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                "select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value') as \"/folders/name/value\" from \"ehr\".\"ehr\" as \"ehr_join\" where (\"ehr_join\".\"id\"='c2561bab-4d2b-4ffd-a893-4382e9048f8c' and 'case1'=ANY((\n" +
-                        "  select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                        "  select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value')\n" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC30.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC30.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC30;
 
 public class TestUC30 extends UC30 {
@@ -26,11 +27,11 @@ public class TestUC30 extends UC30 {
     public TestUC30(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                "select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value') as \"/folders/name/value\" from \"ehr\".\"ehr\" as \"ehr_join\" where (\"ehr_join\".\"id\"='c2561bab-4d2b-4ffd-a893-4382e9048f8c' and 'case1'=ALL((\n" +
-                        "  select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                        "  select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value')\n" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC31.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC31.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC31;
 import org.junit.Ignore;
 
@@ -28,10 +29,10 @@ public class TestUC31 extends UC31 {
     public TestUC31(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_array_elements(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}' as \"/folders/name/value\"" +
+                "select "+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}' as \"/folders/name/value\"" +
                         " from \"ehr\".\"ehr\" as \"ehr_join\"" +
                         " where (" +
-                        "   'case1'=ALL(SELECT jsonb_array_elements(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}')" +
+                        "   'case1'=ALL(SELECT "+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}')" +
                         "        and " +
                         "       \"ehr_join\".\"id\"='c2561bab-4d2b-4ffd-a893-4382e9048f8c')";
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC32.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC32.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC32;
 import org.junit.Ignore;
 
@@ -28,7 +29,7 @@ public class TestUC32 extends UC32 {
     public TestUC32(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_array_elements(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}' as \"/folders/name/value\"" +
+                "select "+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(ehr.js_ehr(ehr_join.id,'local')::jsonb #>'{folders}') #>>'{name,value}' as \"/folders/name/value\"" +
                         " from \"ehr\".\"ehr\" as \"ehr_join\"" +
                         " where (" +
                         "   'case1' IN (SELECT regexp_split_to_array('case1,case2', ','))" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC33.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC33.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC33;
 
 public class TestUC33 extends UC33 {
@@ -26,7 +27,7 @@ public class TestUC33 extends UC33 {
     public TestUC33(){
         super();
         this.expectedSqlExpression =
-                "select jsonb_extract_path_text(cast(jsonb_array_elements(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
+                "select jsonb_extract_path_text(cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(cast(jsonb_extract_path(cast(\"ehr\".\"js_ehr\"(\n" +
                         "  cast(ehr_join.id as uuid), \n" +
                         "  'local'\n" +
                         ") as jsonb),'folders') as jsonb)) as jsonb),'name','value') as \"/folders/name/value\" from \"ehr\".\"ehr\" as \"ehr_join\"" +

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC37.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC37.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC37;
 
 //@Ignore("CR #375")
@@ -28,7 +29,7 @@ public class TestUC37 extends UC37 {
         super();
         this.expectedSqlExpression =
                 "select avg(\"avg_magnitude\") as \"avg_magnitude\" " +
-                        "from (select ((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"avg_magnitude\" " +
+                        "from (select (("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"avg_magnitude\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?" +
                         ") as \"\"";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC38.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC38.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC38;
 
 //@Ignore("CR #375")
@@ -28,7 +29,7 @@ public class TestUC38 extends UC38 {
         super();
         this.expectedSqlExpression =
                 "select min(\"min_magnitude\") as \"min_magnitude\" " +
-                        "from (select ((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"min_magnitude\" " +
+                        "from (select (("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"min_magnitude\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?" +
                         ") as \"\"";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC39.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC39.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC39;
 
 //@Ignore("CR #375")
@@ -28,7 +29,7 @@ public class TestUC39 extends UC39 {
         super();
         this.expectedSqlExpression =
                 "select max(\"max_magnitude\") as \"max_magnitude\" " +
-                        "from (select ((jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"max_magnitude\" " +
+                        "from (select (("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0004],0,/value,magnitude}'))::numeric as \"max_magnitude\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?" +
                         ") as \"\"";

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC5.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC5.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC5;
 
 public class TestUC5 extends UC5 {
@@ -26,7 +27,7 @@ public class TestUC5 extends UC5 {
     public TestUC5(){
         super();
         this.expectedSqlExpression =
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
+                "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\" " +
                         "from \"ehr\".\"entry\" " +
                         "where \"ehr\".\"entry\".\"template_id\" = ?";
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC6.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC6.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC6;
 
 public class TestUC6 extends UC6 {
@@ -28,7 +29,7 @@ public class TestUC6 extends UC6 {
         this.expectedSqlExpression =
                 "select \"\".\"description\" " +
                         "from (" +
-                        "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') " +
+                        "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') " +
                         "as \"description\" from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?" +
                         ") as \"\" order by \"description\" asc";
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC7.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC7.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC7;
 
 public class TestUC7 extends UC7 {
@@ -27,7 +28,7 @@ public class TestUC7 extends UC7 {
         super();
         this.expectedSqlExpression =
                 "select " +
-                "(jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\"" +
+                "("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{/description[at0001],/items[at0002],0,/value,value}') as \"/description[at0001]/items[at0002]/value/value\"" +
                 " from \"ehr\".\"entry\"" +
                 " where (\"ehr\".\"entry\".\"template_id\" = ? and (\"ehr\".\"entry\".\"entry\" #>> '{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1],0,/description[at0001],/items[at0002],0,/value,value}'='Hepatitis A'))";
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC9.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/TestUC9.java
@@ -19,6 +19,7 @@
 
 package org.ehrbase.aql.sql.queryimpl.translator.testcase.pg10.pgsql;
 
+import org.ehrbase.aql.sql.queryimpl.QueryImplConstants;
 import org.ehrbase.aql.sql.queryimpl.translator.testcase.UC9;
 
 public class TestUC9 extends UC9 {
@@ -26,7 +27,7 @@ public class TestUC9 extends UC9 {
     public TestUC9(){
         super();
         this.expectedSqlExpression =
-                "select (jsonb_array_elements((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\"" +
+                "select ("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"((\"ehr\".\"entry\".\"entry\"#>>'{/composition[openEHR-EHR-COMPOSITION.health_summary.v1],/content[openEHR-EHR-ACTION.immunisation_procedure.v1]}')::jsonb)#>>'{}') as \"a\"" +
                         "from \"ehr\".\"entry\" where \"ehr\".\"entry\".\"template_id\" = ?";
     }
 }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonFieldTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/value_field/GenericJsonFieldTest.java
@@ -97,7 +97,7 @@ public class GenericJsonFieldTest extends TestAqlBase {
                 .as(jsonPath)
                 .isEqualToIgnoringWhitespace("select" +
                         " jsonb_extract_path_text(" +
-                        "       cast(jsonb_array_elements(" +
+                        "       cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(" +
                         "           cast(cast(jsonb_extract_path(" +
                         "               cast(\"ehr\".\"js_dv_coded_text_inner\"(\"ehr\".\"entry\".\"category\") as jsonb),'mappings')" +
                         "            as jsonb)" +
@@ -119,9 +119,9 @@ public class GenericJsonFieldTest extends TestAqlBase {
                 .isEqualToIgnoringWhitespace(
                         "select" +
                                 " jsonb_extract_path_text(" +
-                                "   cast(jsonb_array_elements(" +
+                                "   cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(" +
                                 "       cast(jsonb_extract_path_text(" +
-                                "           cast(jsonb_array_elements(" +
+                                "           cast("+ QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION+"(" +
                                 "               cast(cast(" +
                                 "                   jsonb_extract_path(" +
                                 "                           cast(\"ehr\".\"js_dv_coded_text_inner\"(\"ehr\".\"entry\".\"category\") as jsonb)," +


### PR DESCRIPTION
## Changes

Extended the standard `jsonb_array_element` to return a set of NULL instead of an empty set. The issue with the standard function is that a cartesian product against an empty set is also empty. Hence, a surprisingly empty resultset when selecting multiple values. Please  note that, with an ITEM_STRUCTURE, we often have arrays (f.e. items[at...]) that are implicitly iterated upon. This is similar to an SQL inner JOIN but is not trivially seen when querying it.

## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/510

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
