### PR TITLE
Force retrieval of operational template from DB

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -114,6 +114,16 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.ehrbase.application.EhrBase</mainClass>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.spotify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -647,6 +647,9 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
+                    <configuration>
+                        <mainClass>org.ehrbase.application.EhrBase</mainClass>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>build-info</id>

--- a/service/src/main/java/org/ehrbase/service/KnowledgeCacheService.java
+++ b/service/src/main/java/org/ehrbase/service/KnowledgeCacheService.java
@@ -328,7 +328,10 @@ public class KnowledgeCacheService implements I_KnowledgeCache, IntrospectServic
     @Override
     public Optional<OPERATIONALTEMPLATE> retrieveOperationalTemplate(String key) {
         log.debug("retrieveOperationalTemplate({})", key);
-        OPERATIONALTEMPLATE template = getFromCache(key, atOptCache);
+        //CCH, 29.3.21: systematically retrieve the operational template from the DB.
+//        OPERATIONALTEMPLATE template = getFromCache(key, atOptCache);
+        OPERATIONALTEMPLATE template = null;
+
         if (template == null) {     // null if not in cache already, which triggers the following retrieval and putting into cache
             template = getOperationaltemplateFromFileStorage(key);
         }


### PR DESCRIPTION
## Changes

Force retrieval of operational templates from the DB. (NB. this is initially done, at least for AQL, thus performance is not that impacted).

## Related issue

None, this has been observed during tests


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
