### PR TITLE
before closing branch

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/binding/InSetWhereClause.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/InSetWhereClause.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2020 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+
+package org.ehrbase.aql.sql.binding;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.PathResolver;
+import org.ehrbase.aql.sql.queryimpl.CompositionAttributeQuery;
+import org.ehrbase.aql.sql.queryimpl.JsonbEntryQuery;
+import org.ehrbase.dao.access.interfaces.I_DomainAccess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.ehrbase.aql.sql.queryimpl.QueryImplConstants.AQL_NODE_ITERATIVE_FUNCTION;
+
+/**
+ * deals with "transparent" swap of arguments whenever the left operand is an IdentifiedPath in a (NOT)'IN' clause:
+ * | OPEN_PAR* identifiedOperand NOT? IN OPEN_PAR  (identifiedOperand|matchesOperand) CLOSE_PAR CLOSE_PAR*
+ * The expected result is an expression compatible with scalar 'IN' (set).
+ * This is hack is currently (12.4.21) required due to SDK limitation (IN is not supported). It should be removed whenever updated
+ * NB. MATCHES is already substituted as IN by QueryCompilerPass2
+ * TODO: deprecate whenever SDK supports the IN operator
+ */
+
+public class InSetWhereClause {
+
+    private final List<Object> whereItems;
+    private final PathResolver pathResolver;
+    private final I_DomainAccess domainAccess;
+    private final JsonbEntryQuery jsonbEntryQuery;
+    private final CompositionAttributeQuery compositionAttributeQuery;
+
+    public InSetWhereClause(List<Object> whereItems, PathResolver pathResolver, I_DomainAccess domainAccess, JsonbEntryQuery jsonbEntryQuery, CompositionAttributeQuery compositionAttributeQuery) {
+        this.whereItems = whereItems;
+        this.pathResolver = pathResolver;
+        this.domainAccess = domainAccess;
+        this.jsonbEntryQuery = jsonbEntryQuery;
+        this.compositionAttributeQuery = compositionAttributeQuery;
+    }
+
+    public List<Object> swapIfRequired(String templateId, String compositionName){
+
+        List<Object> updatedList = new ArrayList<>(whereItems);
+
+        for (int cursor = 0; cursor < updatedList.size(); cursor++) {
+
+            if (updatedList.get(cursor) instanceof I_VariableDefinition){
+                //we check if the variable encoding implies set returning function
+                TaggedStringBuilder taggedStringBuilder = new WhereVariable(pathResolver, domainAccess, jsonbEntryQuery, compositionAttributeQuery).encode(templateId, (I_VariableDefinition) updatedList.get(cursor), true, compositionName);
+                if (!taggedStringBuilder.toString().contains(AQL_NODE_ITERATIVE_FUNCTION))
+                    break;
+                //lookahead to check if the condition deals with IN | NOT IN set containment condition
+                if (cursor+1 >= updatedList.size()||cursor+2 >= updatedList.size())
+                    break;
+                if (updatedList.get(cursor + 1) instanceof String){
+                    String lookahead1 = ((String)updatedList.get(cursor + 1)).strip();
+                    if (lookahead1.equalsIgnoreCase("NOT")){
+                        String lookahead2 = ((String)updatedList.get(cursor + 2)).strip();
+                        if (lookahead2.equalsIgnoreCase("IN")){
+                            //perform swap of argument at location
+                            swapItemsAtOffset(updatedList, cursor, 4);
+                        }
+                    }
+                    else {
+                        String lookahead2 = ((String) updatedList.get(cursor + 1)).strip();
+                        if (lookahead2.equalsIgnoreCase("IN")){
+                            //perform swap of argument at location
+                            swapItemsAtOffset(updatedList, cursor, 3);
+                        }
+                    }
+                }
+            }
+        }
+        return updatedList;
+    }
+
+    private void swapItemsAtOffset(List<Object> itemList, int cursor, int offset){
+        //perform swap of argument at location
+        Object arg1 = itemList.get(cursor);
+        itemList.set(cursor, itemList.get(cursor+offset));
+        itemList.set(cursor+offset, arg1);
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereBinder.java
@@ -185,6 +185,9 @@ public class WhereBinder {
         List<Object> whereItems = new ArrayList<>(whereClause);
         boolean notExists = false;
 
+        //TODO: remove when SDK supports IN operator
+        whereItems = new InSetWhereClause(whereItems, pathResolver, domainAccess, jsonbEntryQuery, compositionAttributeQuery).swapIfRequired(templateId, compositionName);
+
         for (int cursor = 0; cursor < whereItems.size(); cursor++) {
             Object item = whereItems.get(cursor);
             if (item instanceof String) {

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/WhereVariable.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/WhereVariable.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2020 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+
+package org.ehrbase.aql.sql.binding;
+
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.sql.PathResolver;
+import org.ehrbase.aql.sql.queryimpl.CompositionAttributeQuery;
+import org.ehrbase.aql.sql.queryimpl.IQueryImpl;
+import org.ehrbase.aql.sql.queryimpl.JsonbEntryQuery;
+import org.ehrbase.dao.access.interfaces.I_DomainAccess;
+import org.ehrbase.serialisation.dbencoding.CompositionSerializer;
+import org.jooq.Field;
+
+import static org.ehrbase.aql.sql.queryimpl.IterativeNodeConstants.ENV_AQL_USE_JSQUERY;
+
+public class WhereVariable {
+
+    public static final String COMPOSITION = "COMPOSITION";
+    public static final String CONTENT = "content";
+    public static final String EHR = "EHR";
+
+    private final PathResolver pathResolver;
+    private final I_DomainAccess domainAccess;
+    private final JsonbEntryQuery jsonbEntryQuery;
+    private final CompositionAttributeQuery compositionAttributeQuery;
+
+    private boolean isFollowedBySQLConditionalOperator = false;
+
+    public WhereVariable(PathResolver pathResolver, I_DomainAccess domainAccess, JsonbEntryQuery jsonbEntryQuery, CompositionAttributeQuery compositionAttributeQuery) {
+        this.pathResolver = pathResolver;
+        this.domainAccess = domainAccess;
+        this.jsonbEntryQuery = jsonbEntryQuery;
+        this.compositionAttributeQuery = compositionAttributeQuery;
+    }
+
+    public  TaggedStringBuilder encode(String templateId, I_VariableDefinition variableDefinition, boolean forceSQL, String compositionName) {
+        String identifier = variableDefinition.getIdentifier();
+        String className = pathResolver.classNameOf(identifier);
+        if (className == null)
+            throw new IllegalArgumentException("Could not bind identifier in WHERE clause:'" + identifier + "'");
+        Field<?> field;
+        //EHR-327: if force SQL is set to true via environment, jsquery extension is not required
+        //this allows to deploy on AWS since jsquery is not supported by this provider
+        Boolean usePgExtensions;
+        if (System.getenv(ENV_AQL_USE_JSQUERY) != null)
+            usePgExtensions = Boolean.parseBoolean(System.getenv(ENV_AQL_USE_JSQUERY));
+        else if (domainAccess.getServerConfig().getUseJsQuery() != null)
+            usePgExtensions = domainAccess.getServerConfig().getUseJsQuery();
+        else
+            usePgExtensions = false;
+
+        if (forceSQL || Boolean.FALSE.equals(usePgExtensions)) {
+            //EHR-327: also supports EHR attributes in WHERE clause
+            ExpressionField expressionField = new ExpressionField(variableDefinition, jsonbEntryQuery, compositionAttributeQuery);
+            field = expressionField.toSql(className, templateId, identifier, IQueryImpl.Clause.WHERE);
+
+            if (field == null)
+                return null;
+            return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.SQLQUERY);
+
+        } else {
+            switch (className) {
+                case COMPOSITION:
+                    if (variableDefinition.getPath().startsWith(CONTENT)) {
+                        field = jsonbEntryQuery.whereField(templateId, identifier, variableDefinition);
+                        TaggedStringBuilder taggedStringBuilder = new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.JSQUERY);
+                        if (compositionName != null && taggedStringBuilder.startWith(CompositionSerializer.TAG_COMPOSITION)) {
+                            //add the composition name into the composition predicate
+                            taggedStringBuilder.replace("]", " and name/value='" + compositionName + "']");
+                        }
+                        return taggedStringBuilder;
+                    }
+                    break;
+                case EHR:
+                    field = compositionAttributeQuery.whereField(templateId, identifier, variableDefinition);
+                    if (field == null)
+                        return null;
+                    isFollowedBySQLConditionalOperator = true;
+                    return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.SQLQUERY);
+
+                default:
+                    if (compositionAttributeQuery.isCompositionAttributeItemStructure(templateId, identifier)){
+                        field = new ContextualAttribute(compositionAttributeQuery, jsonbEntryQuery, IQueryImpl.Clause.WHERE).toSql(templateId, variableDefinition);
+                        return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.SQLQUERY);
+                    }
+                    else {
+                        field = jsonbEntryQuery.whereField(templateId, identifier, variableDefinition);
+                        return new TaggedStringBuilder(field.toString(), I_TaggedStringBuilder.TagField.JSQUERY);
+                    }
+            }
+            throw new IllegalStateException("Unhandled class name:"+className);
+        }
+    }
+
+    public boolean isFollowedBySQLConditionalOperator() {
+        return isFollowedBySQLConditionalOperator;
+    }
+}


### PR DESCRIPTION
## Changes

Temporary (?) hack to "transparently" swap arguments of the MATCHES operator whenever the left operand is actually a set (or a function returning a set). F.e.
```
a_a/data[at0001]/events[at0002]/data[at0005]/items[at0027]/name/value MATCHES {'Ableitung III'}
```
Is internally interpreted as:
```
'Ableitung III' MATCHES {a_a/data[at0001]/events[at0002]/data[at0005]/items[at0027]/name/value}
```
The logic checks whether the left operand requires this transform (that is, it contains json array unnesting using function such as jsonb_array_elements)


NB. `MATCHES` is always converted as `IN` by the AQL->SQL translator (matches is an operator for string operands in the postgresql dialect)

## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/513


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
