### PR TITLE
generalize using lateral join

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <swagger.version>1.6.2</swagger.version>
         <swagger-snapshot.version>2.0.0-rc2</swagger-snapshot.version>
         <postgressql.version>42.2.18</postgressql.version>
-        <ehrbase.sdk.version>2930e3e</ehrbase.sdk.version>
+        <ehrbase.sdk.version>0fbf24f</ehrbase.sdk.version>
         <flyway.version>6.5.7</flyway.version>
         <joda.version>2.10.6</joda.version>
         <database.name>ehrbase</database.name>


### PR DESCRIPTION
## Changes

Generalize use of Lateral join for WHERE expression not using MATCHES (or IN) operator. F.e. 

```
a/items[at0001]/value/magnitude > 11.0
```
In this scenario, the left operand may result in multiple values (set). Using the lateral join technique, this statement is now supported.

## Related issue

on going enhancement

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
