### PR TITLE
create null select for node not defined in template

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/containment/IdentifierMapper.java
+++ b/service/src/main/java/org/ehrbase/aql/containment/IdentifierMapper.java
@@ -25,6 +25,7 @@ import org.ehrbase.aql.definition.FromEhrDefinition;
 import org.ehrbase.aql.definition.FromForeignDataDefinition;
 import org.ehrbase.aql.sql.queryimpl.JsonbEntryQuery;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -149,7 +150,7 @@ public class IdentifierMapper {
         if (containment instanceof Containment) {
             return ((Containment) containment).getPath(template);
         }
-        return null;
+        return Collections.emptySet();
     }
 
     public void setPath(String template, String symbol, Set<String> path) {
@@ -205,16 +206,19 @@ public class IdentifierMapper {
 
     public boolean requiresTemplateWhereClause() {
         boolean resolveTemplateRequired = false;
+        boolean hasNonCompositionNode = false;
         for (Map.Entry map: mapper.entrySet()){
             Mapper mapper1 = (Mapper)map.getValue();
             if (mapper1.getContainer() instanceof Containment){
                 Containment containment = (Containment)mapper1.getContainer();
                 //check if this containment specifies an archetype (triggering a template resolution)
                 //f.e. COMPOSITION a [openEHR-EHR-COMPOSITION.report-result.v1] contains OBSERVATION
-                if (containment.getArchetypeId() != null && !containment.getArchetypeId().isBlank()) //archetype is defined
-                {
-                        resolveTemplateRequired = true;
-                }
+                if (!containment.getClassName().equals(COMPOSITION))
+                    hasNonCompositionNode = true;
+
+                if (hasNonCompositionNode)
+                    resolveTemplateRequired = true;
+
             }
         }
         return resolveTemplateRequired;

--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -129,7 +129,7 @@ public class QueryProcessor extends TemplateMetaData {
 
         if (contains.getTemplates().isEmpty()) {
             if (contains.hasContains() && contains.requiresTemplateWhereClause()) {
-                cacheQuery.put(NIL_TEMPLATE, buildQuerySteps(NIL_TEMPLATE));
+                cacheQuery.put(NIL_TEMPLATE, buildNullSelect(NIL_TEMPLATE));
                 containsJson = false;
             } else
                 cacheQuery.put(NIL_TEMPLATE, buildQuerySteps(NIL_TEMPLATE));
@@ -266,6 +266,9 @@ public class QueryProcessor extends TemplateMetaData {
     }
 
     private SelectQuery<?> setLateralJoins(List<Table<?>> lateralJoins, SelectQuery<?> selectQuery) {
+        if (lateralJoins == null)
+            return selectQuery;
+
         for (Table<?> joinLateralTable : lateralJoins) {
                 selectQuery.addFrom(joinLateralTable);
         }
@@ -321,5 +324,19 @@ public class QueryProcessor extends TemplateMetaData {
         }
         explainList.add(details);
         return explainList;
+    }
+
+    private List<QuerySteps> buildNullSelect(String templateId) {
+        SelectBinder selectBinder = new SelectBinder(domainAccess, introspectCache, contains, statements, serverNodeId);
+
+        List<QuerySteps> querySteps = new ArrayList<>();
+
+        querySteps.add(new QuerySteps(domainAccess.getContext().selectQuery(),
+                DSL.condition("1 = 0"),
+                null,
+                templateId,
+                selectBinder.getCompositionAttributeQuery(),
+                selectBinder.getJsonDataBlock(), false));
+        return querySteps;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -327,16 +327,14 @@ public class QueryProcessor extends TemplateMetaData {
     }
 
     private List<QuerySteps> buildNullSelect(String templateId) {
-        SelectBinder selectBinder = new SelectBinder(domainAccess, introspectCache, contains, statements, serverNodeId);
 
-        List<QuerySteps> querySteps = new ArrayList<>();
+        List<QuerySteps> queryStepsList = buildQuerySteps(templateId);
 
-        querySteps.add(new QuerySteps(domainAccess.getContext().selectQuery(),
-                DSL.condition("1 = 0"),
-                null,
-                templateId,
-                selectBinder.getCompositionAttributeQuery(),
-                selectBinder.getJsonDataBlock(), false));
-        return querySteps;
+        //force a null condition for these steps
+        for (QuerySteps querySteps: queryStepsList){
+            querySteps.setWhereCondition(DSL.condition("1 = 0"));
+        }
+
+        return queryStepsList;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/QuerySteps.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QuerySteps.java
@@ -35,7 +35,7 @@ import java.util.List;
 @SuppressWarnings({"java:S3740"})
 public class QuerySteps {
     private final SelectQuery selectQuery;
-    private final Condition whereCondition;
+    private Condition whereCondition; //can be force to a NULL condition (f.e. 1 = 0)
     private final List<Table<?>> lateralJoins;
     private final String templateId;
     private final CompositionAttributeQuery compositionAttributeQuery;
@@ -88,5 +88,9 @@ public class QuerySteps {
 
     public List<Table<?>> getLateralJoins() {
         return lateralJoins;
+    }
+
+    public void setWhereCondition(Condition whereCondition){
+        this.whereCondition = whereCondition;
     }
 }

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/ObjectQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/ObjectQuery.java
@@ -25,6 +25,7 @@ import org.ehrbase.aql.sql.PathResolver;
 import org.ehrbase.dao.access.interfaces.I_DomainAccess;
 import org.jooq.DSLContext;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -56,8 +57,9 @@ public abstract class ObjectQuery {
     }
 
     public String variableTemplatePath(String templateId, String identifier){
+        Set<String> pathSet = pathResolver.pathOf(templateId, identifier);
 
-        if (pathResolver.pathOf(templateId, identifier) == null)
+        if (pathSet.isEmpty())
             return null;
 
         return pathResolver.pathOf(templateId, identifier).stream().collect(Collectors.joining());

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/ObjectQuery.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/ObjectQuery.java
@@ -59,7 +59,7 @@ public abstract class ObjectQuery {
     public String variableTemplatePath(String templateId, String identifier){
         Set<String> pathSet = pathResolver.pathOf(templateId, identifier);
 
-        if (pathSet.isEmpty())
+        if (pathSet == null || pathSet.isEmpty())
             return null;
 
         return pathResolver.pathOf(templateId, identifier).stream().collect(Collectors.joining());


### PR DESCRIPTION
## Changes

This fix force a NULL select (e.g. SELECT 1 ... WHERE 1 = 0) whenever a query refers to a non template defined node. F.e. 

```
SELECT c FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION
```
applied to a single composition where the template definition doesn't specify such an OBSERVATION. The result then should be NULL and hence empty resultset.


## Related issue

Fixes: https://github.com/ehrbase/project_management/issues/360

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
