### PR TITLE
Replace SYSTEM_NAME by SERVER_NODENAME

### DIFF
--- a/.env.ehrbase
+++ b/.env.ehrbase
@@ -1,4 +1,4 @@
-SYSTEM_NAME=local.ehrbase.org
+SERVER_NODENAME=local.ehrbase.org
 SECURITY_AUTHTYPE=BASIC
 SECURITY_AUTHUSER=ehrbase-user
 SECURITY_AUTHPASSWORD=SuperSecretPassword

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN echo "EHRBASE_VERSION: $(cat ehrbase_version)"
 ARG DB_URL=jdbc:postgresql://ehrdb:5432/ehrbase
 ARG DB_USER="ehrbase"
 ARG DB_PASS="ehrbase"
-ARG SYSTEM_NAME=docker.ehrbase.org
+ARG SERVER_NODENAME=docker.ehrbase.org
 
 # These environment variables are also applied to startup of the container and can be overwritten by setting it with
 # the '-e' flag on 'docker run' command
@@ -145,7 +145,7 @@ ENV EHRBASE_VERSION=${EHRBASE_VERSION}
 ENV DB_USER=$DB_USER
 ENV DB_PASS=$DB_PASS
 ENV DB_URL=$DB_URL
-ENV SYSTEM_NAME=$SYSTEM_NAME
+ENV SERVER_NODENAME=$SERVER_NODENAME
 
 # Security
 ENV SECURITY_AUTHTYPE="NONE"

--- a/application/src/main/java/org/ehrbase/application/config/ServerConfigImp.java
+++ b/application/src/main/java/org/ehrbase/application/config/ServerConfigImp.java
@@ -17,7 +17,6 @@
  */
 package org.ehrbase.application.config;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,7 +30,7 @@ public class ServerConfigImp implements org.ehrbase.api.definitions.ServerConfig
     @Min(1025)
     @Max(65536)
     private int port;
-    private String nodename;
+    private String nodename = "local.ehrbase.org";
     private AqlConfig aqlConfig;
 
     public int getPort() {
@@ -43,8 +42,6 @@ public class ServerConfigImp implements org.ehrbase.api.definitions.ServerConfig
     }
 
     public String getNodename() {
-        if (StringUtils.isBlank(nodename))
-            return "local.ehrbase.org";
         return nodename;
     }
 
@@ -72,11 +69,11 @@ public class ServerConfigImp implements org.ehrbase.api.definitions.ServerConfig
         aqlConfig.setUseJsQuery(b);
     }
 
-    public AqlConfig getAqlConfig(){
+    public AqlConfig getAqlConfig() {
         return aqlConfig;
     }
 
-    public void setAqlConfig(AqlConfig aqlConfig){
+    public void setAqlConfig(AqlConfig aqlConfig) {
         this.aqlConfig = aqlConfig;
     }
 

--- a/application/src/main/resources/application-cloud.yml
+++ b/application/src/main/resources/application-cloud.yml
@@ -27,7 +27,3 @@ server:
 
   servlet:
     context-path: /ehrbase
-
-system:
-  type: LOCAL
-

--- a/application/src/main/resources/application-docker.yml
+++ b/application/src/main/resources/application-docker.yml
@@ -41,7 +41,3 @@ server:
     ignoreIterativeNodeList: 'events,activities,content'
     # how many embedded jsonb_array_elements(..) are acceptable? Recommended == 1
     iterationScanDepth: 1
-
-system:
-  type: ${SYSTEM_NAME}
-

--- a/application/src/main/resources/application-local.yml
+++ b/application/src/main/resources/application-local.yml
@@ -46,9 +46,6 @@ admin-api:
   active: true
   allowDeleteAll: true
 
-system:
-  type: LOCAL
-
 terminology_server:
   tsUrl: 'https://r4.ontoserver.csiro.au/fhir/'
   codePath: '$["expansion"]["contains"][*]["code"]'

--- a/base/docker-example/docker-compose.yml
+++ b/base/docker-example/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       DB_URL: "jdbc:postgresql://postgres:5432/ehrbase"
       DB_USER: postgres
       DB_PASS: postgres
-      SYSTEM_NAME: local
+      SERVER_NODENAME: local
       OUTH2_REALM_NAME: demo
       OUTH2_CLIENT_NAME: myclient
       OUTH2_SERVER_URL: "http://keycloak:8080/auth"

--- a/service/src/main/java/org/ehrbase/service/BaseService.java
+++ b/service/src/main/java/org/ehrbase/service/BaseService.java
@@ -27,9 +27,6 @@ import org.ehrbase.dao.access.interfaces.I_SystemAccess;
 import org.ehrbase.dao.access.jooq.party.PersistedPartyProxy;
 import org.ehrbase.dao.access.support.ServiceDataAccess;
 import org.jooq.DSLContext;
-import org.springframework.beans.factory.annotation.Value;
-
-import com.nedap.archie.rm.datavalues.DvCodedText;
 
 import java.util.UUID;
 
@@ -38,25 +35,14 @@ public class BaseService {
     public static final String DEMOGRAPHIC = "DEMOGRAPHIC";
     public static final String PARTY = "PARTY";
 
-    @Value("${system.type}")
-    private String systemType = "POSTGRES";
-    @Value("${spring.datasource.url}")
-    private String datasourceUrl = "url";
-    @Value("${spring.datasource.password}")
-    private String datasourcePass = "luis";
-    @Value("${spring.datasource.username}")
-    private String datasourceUser = "luis";
-
     private final ServerConfig serverConfig;
     private final KnowledgeCacheService knowledgeCacheService;
     private final DSLContext context;
-   // private final OpenehrTerminologyServer<DvCodedText, String> openehrTerminologyServer;
 
-    public BaseService(KnowledgeCacheService knowledgeCacheService, DSLContext context, ServerConfig serverConfig/*, OpenehrTerminologyServer<DvCodedText, String> openehrTerminologyServer*/) {
-		this.knowledgeCacheService = knowledgeCacheService;
+    public BaseService(KnowledgeCacheService knowledgeCacheService, DSLContext context, ServerConfig serverConfig) {
+        this.knowledgeCacheService = knowledgeCacheService;
         this.context = context;
         this.serverConfig = serverConfig;
-       // this.openehrTerminologyServer = openehrTerminologyServer;
     }
 
     protected I_DomainAccess getDataAccess() {
@@ -75,9 +61,4 @@ public class BaseService {
     public ServerConfig getServerConfig() {
         return this.serverConfig;
     }
-    
-    /*public OpenehrTerminologyServer<DvCodedText, String> getOpenehrTerminologyServer() {
-        return this.openehrTerminologyServer;
-    }*/
-
 }


### PR DESCRIPTION
## Changes

- Replace SYSTEM_NAME by SERVER_NODENAME in dockerfile and configuration files
- Cleanup property `system.type` and unused properties from `BaseService` class

## Related issue

Resolves ehrbase/project_management#536
