### PR TITLE
Adds active folder audit DB migration

### DIFF
--- a/base/src/main/resources/db/migration/V50__folder_audit.sql
+++ b/base/src/main/resources/db/migration/V50__folder_audit.sql
@@ -30,11 +30,11 @@ BEGIN
         party_type,
         object_id_type
     )
-    SELECT 'migration_dummy',
+    SELECT 'migration_dummy_65a3da3a-476f-4b1e-ab04-fa1c42edeac0',
            'party_self',
            'undefined'
     WHERE NOT EXISTS (
-		SELECT 1 FROM ehr.party_identified WHERE name='migration_dummy'
+		SELECT 1 FROM ehr.party_identified WHERE name='migration_dummy_65a3da3a-476f-4b1e-ab04-fa1c42edeac0'
 	);
 
     -- Helper queries to:
@@ -51,7 +51,7 @@ BEGIN
         ),
     -- 2) Find the dummy party
         party AS (
-            SELECT id FROM ehr.party_identified WHERE name  = 'migration_dummy' LIMIT 1
+            SELECT id FROM ehr.party_identified WHERE name  = 'migration_dummy_65a3da3a-476f-4b1e-ab04-fa1c42edeac0' LIMIT 1
         )
 
     -- Copy the values of the oldest/initial audit
@@ -99,18 +99,6 @@ ALTER TABLE ehr.folder_history
     USING ehr.migrate_folder_audit(),
     -- And finally set the column to NOT NULL
     ALTER COLUMN has_audit SET NOT NULL;
-
--- Backup of function to just use the oldest audit
-CREATE OR REPLACE FUNCTION ehr.migrate_folder_audit()
-  RETURNS UUID AS
-$$
-BEGIN
-RETURN (
-    SELECT id FROM ehr.audit_details ORDER BY time_committed asc LIMIT 1
-    );
-END
-$$
-LANGUAGE plpgsql;
 
 -- Also modify the admin deletion of a folder function to include the new audits.
 DROP FUNCTION admin_delete_folder(uuid);

--- a/base/src/main/resources/db/migration/V50__folder_audit.sql
+++ b/base/src/main/resources/db/migration/V50__folder_audit.sql
@@ -72,7 +72,7 @@ ALTER TABLE ehr.folder_history
     ALTER COLUMN has_audit SET NOT NULL;
 
 -- Backup of function to just use the oldest audit
-/*CREATE OR REPLACE FUNCTION ehr.migrate_folder_audit()
+CREATE OR REPLACE FUNCTION ehr.migrate_folder_audit()
   RETURNS UUID AS
 $$
 BEGIN


### PR DESCRIPTION
## Changes

<!-- Describe your changes in a short list -->

**Note**: Bricks all DB instances, that were initialized with migration V50 before. (Clean installs and datasets with non-conflicting data, which were updated to the newest version.)

- Adds active folder audit DB migration

## Related issue

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->
https://github.com/ehrbase/ehrbase/issues/553

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
