### PR TITLE
Feature/sync/563 clean up party identified

### DIFF
--- a/api/src/main/java/org/ehrbase/api/service/EhrService.java
+++ b/api/src/main/java/org/ehrbase/api/service/EhrService.java
@@ -159,6 +159,8 @@ public interface EhrService extends BaseService {
      */
     void adminDeleteEhr(UUID ehrId);
 
+    void adminPurgePartyIdentified();
+
     /**
      * Helper to directly get the linked subject ID to given EHR.
      * @param ehrId Given EHR ID

--- a/api/src/main/java/org/ehrbase/api/service/EhrService.java
+++ b/api/src/main/java/org/ehrbase/api/service/EhrService.java
@@ -161,6 +161,8 @@ public interface EhrService extends BaseService {
 
     void adminPurgePartyIdentified();
 
+    void adminDeleteOrphanHistory();
+
     /**
      * Helper to directly get the linked subject ID to given EHR.
      * @param ehrId Given EHR ID

--- a/base/src/main/resources/db/migration/V55__purge_unused_party_identified.sql
+++ b/base/src/main/resources/db/migration/V55__purge_unused_party_identified.sql
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2021 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+-- returns the count of occurrences of a party_identified accross table having it as argument
+CREATE OR REPLACE FUNCTION ehr.party_usage(party_uuid UUID)
+  RETURNS BIGINT AS
+$$
+BEGIN
+	RETURN (
+		with usage_uuid as (
+			SELECT facility as uuid from ehr.event_context where facility = party_uuid
+		UNION
+			SELECT facility  as uuid from ehr.event_context_history where facility = party_uuid
+		UNION
+			SELECT composer  as uuid from ehr.composition where composer = party_uuid
+		UNION
+			SELECT composer  as uuid from ehr.composition_history where composer = party_uuid
+		UNION
+			SELECT performer  as uuid from ehr.participation where performer = party_uuid
+		UNION
+			SELECT performer  as uuid from ehr.participation_history where performer = party_uuid
+		UNION
+			SELECT party  as uuid from ehr.status where party = party_uuid
+		UNION
+			SELECT party  as uuid from ehr.status_history where party = party_uuid
+        UNION
+            SELECT committer as uuid from ehr.audit_details where committer = party_uuid
+		)
+		SELECT count(usage_uuid.uuid)
+			FROM usage_uuid
+	);
+END
+$$
+LANGUAGE plpgsql;
+
+-- use this function for debugging purpose
+-- identifies where the party_identified is referenced
+CREATE OR REPLACE FUNCTION ehr.party_usage_identification(party_uuid UUID)
+  RETURNS table(id UUID, entity TEXT) AS
+$$
+		with usage_uuid as (
+			SELECT facility as uuid, 'FACILITY' as entity from ehr.event_context where facility = party_uuid
+		UNION
+			SELECT facility  as uuid, 'FACILITY_HISTORY' as entity  from ehr.event_context_history where facility = party_uuid
+		UNION
+			SELECT composer  as uuid, 'COMPOSER' as entity  from ehr.composition where composer = party_uuid
+		UNION
+			SELECT composer  as uuid, 'COMPOSER_HISTORY' as entity from ehr.composition_history where composer = party_uuid
+		UNION
+			SELECT performer  as uuid, 'PERFORMER' as entity from ehr.participation where performer = party_uuid
+		UNION
+			SELECT performer  as uuid, 'PERFORMER_HISTORY' as entity from ehr.participation_history where performer = party_uuid
+		UNION
+			SELECT party  as uuid, 'SUBJECT' as entity from ehr.status where party = party_uuid
+		UNION
+			SELECT party  as uuid, 'SUBJECT_HISTORY' as entity from ehr.status_history where party = party_uuid
+        UNION
+            SELECT committer  as uuid, 'AUDIT_DETAILS' as entity from ehr.audit_details where committer = party_uuid
+		)
+		SELECT usage_uuid.uuid, usage_uuid.entity
+			FROM usage_uuid;
+$$
+LANGUAGE sql;
+
+-- alter table identifier to add the missing on delete...cascade
+alter table ehr.identifier
+drop constraint identifier_party_fkey,
+add constraint identifier_party_fkey
+   foreign key (party)
+   references ehr.party_identified(id)
+   on delete cascade;
+
+-- garbage collection: delete all party_identified where usage count is 0
+--	DELETE FROM party_identified WHERE  ehr.party_usage(party_identified.id) = 0;
+

--- a/base/src/main/resources/db/migration/V55__purge_unused_party_identified.sql
+++ b/base/src/main/resources/db/migration/V55__purge_unused_party_identified.sql
@@ -102,8 +102,8 @@ DECLARE
     results RECORD;
 BEGIN
     -- since for this admin op, we don't want to generate a history record for each delete!
-    ALTER TABLE ehr.event_context DISABLE TRIGGER ALL;
-    ALTER TABLE ehr.participation DISABLE TRIGGER ALL;
+    ALTER TABLE ehr.event_context DISABLE TRIGGER versioning_trigger;
+    ALTER TABLE ehr.participation DISABLE TRIGGER versioning_trigger;
 
     RETURN QUERY WITH
                      linked_events(id) AS ( -- get linked EVENT_CONTEXT entities -- 0..1
@@ -162,8 +162,8 @@ BEGIN
         END LOOP;
 
     -- restore disabled triggers
-    ALTER TABLE ehr.event_context ENABLE TRIGGER ALL;
-    ALTER TABLE ehr.participation ENABLE TRIGGER ALL;
+    ALTER TABLE ehr.event_context ENABLE TRIGGER versioning_trigger;
+    ALTER TABLE ehr.participation ENABLE TRIGGER versioning_trigger;
 
 END;
 $$ LANGUAGE plpgsql

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
@@ -128,8 +128,8 @@ public class AdminEhrController extends BaseController {
 
         ehrService.adminDeleteEhr(ehrUuid);
 
-        //purge party_identified following the delete (which deletes also composition, etc.)
-        ehrService.adminPurgePartyIdentified();
+        //delete orphan history records following EHR delete including unused party_identified
+        ehrService.adminDeleteOrphanHistory();
 
         return ResponseEntity.noContent().build();
     }

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
@@ -128,6 +128,9 @@ public class AdminEhrController extends BaseController {
 
         ehrService.adminDeleteEhr(ehrUuid);
 
+        //purge party_identified following the delete (which deletes also composition, etc.)
+        ehrService.adminPurgePartyIdentified();
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
@@ -37,6 +37,7 @@ import org.ehrbase.dao.access.interfaces.*;
 import org.ehrbase.dao.access.jooq.AttestationAccess;
 import org.ehrbase.dao.access.jooq.party.PersistedPartyProxy;
 import org.ehrbase.dao.access.jooq.party.PersistedPartyRef;
+import org.ehrbase.jooq.pg.Routines;
 import org.ehrbase.response.ehrscape.CompositionFormat;
 import org.ehrbase.response.ehrscape.EhrStatusDto;
 import org.ehrbase.response.ehrscape.StructuredString;
@@ -44,6 +45,7 @@ import org.ehrbase.response.ehrscape.StructuredStringFormat;
 import org.ehrbase.serialisation.jsonencoding.CanonicalJson;
 import org.jooq.DSLContext;
 import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -435,6 +437,13 @@ public class EhrServiceImp extends BaseServiceImp implements EhrService {
     public void adminPurgePartyIdentified() {
         getDataAccess().getContext().deleteFrom(PARTY_IDENTIFIED).where(partyUsage(PARTY_IDENTIFIED.ID).eq(0L)).execute();
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public void adminDeleteOrphanHistory() {
+        Routines.deleteOrphanHistory(getDataAccess().getContext().configuration());
+    }
+
 
     @Override
     public UUID getSubjectUuid(String ehrId) {

--- a/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
@@ -43,6 +43,8 @@ import org.ehrbase.response.ehrscape.StructuredString;
 import org.ehrbase.response.ehrscape.StructuredStringFormat;
 import org.ehrbase.serialisation.jsonencoding.CanonicalJson;
 import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +60,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.ehrbase.jooq.pg.Routines.partyUsage;
+import static org.ehrbase.jooq.pg.Tables.PARTY_IDENTIFIED;
 
 @Service(value = "ehrService")
 @Transactional()
@@ -423,6 +428,12 @@ public class EhrServiceImp extends BaseServiceImp implements EhrService {
     public void adminDeleteEhr(UUID ehrId) {
         I_EhrAccess ehrAccess = I_EhrAccess.retrieveInstance(getDataAccess(), ehrId);
         ehrAccess.adminDeleteEhr();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public void adminPurgePartyIdentified() {
+        getDataAccess().getContext().deleteFrom(PARTY_IDENTIFIED).where(partyUsage(PARTY_IDENTIFIED.ID).eq(0L)).execute();
     }
 
     @Override


### PR DESCRIPTION
## Changes

Fixes admin endpoint so that a delete EHR results in a clean state of the DB with full deletion of all related xyz_history entries, party_identified with no more references, identifiers are also deleted if the parent party_identified is deleted. 

## Related issue

This changes is required to allow a successful build of openEHR_SDK (see corresponding PR in this latter repository)

Fixes: https://github.com/ehrbase/project_management/issues/565


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
