### PR TITLE
automated multi arch docker build via Github Actions

### DIFF
--- a/.github/workflows/build-multiarch-image-latest.yml
+++ b/.github/workflows/build-multiarch-image-latest.yml
@@ -28,7 +28,7 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ehrbase/buildx:latest-amd64
+          tags: ehrbase/ehrbase:latest-amd64
       -
         name: Build and push (ARM64)
         uses: docker/build-push-action@v2
@@ -36,19 +36,19 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: ehrbase/buildx:latest-arm64
+          tags: ehrbase/ehrbase:latest-arm64
   
       - 
         name: Create and push MultiArch Manifest
         run: |
           docker buildx imagetools create \
-                 ehrbase/buildx:latest-arm64 \
-                 ehrbase/buildx:latest-amd64 \
-                 -t ehrbase/buildx:latest
-          docker pull ehrbase/buildx:latest
+                 ehrbase/ehrbase:latest-arm64 \
+                 ehrbase/ehrbase:latest-amd64 \
+                 -t ehrbase/ehrbase:latest
+          docker pull ehrbase/ehrbase:latest
       -
         name: Inspect MultiArch Manifest
-        run:  docker manifest inspect ehrbase/buildx:latest
+        run:  docker manifest inspect ehrbase/ehrbase:latest
 
 
 
@@ -68,12 +68,12 @@ jobs:
 #
 # builds image for specific platform
 # and pushes it to docker-hub
-# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
-# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/ehrbase:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/ehrbase:next-amd .
 #
 # creates multiarch manifest from given images
 # and pushes it to docker-hub
-# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+# > docker buildx imagetools create ehrbase/ehrbase:next-arm ehrbase/ehrbase:next-amd -t ehrbase/ehrbase:next
 #
 # inspects created mulitarch image
-# > docker manifest inspect ehrbase/buildx:next
+# > docker manifest inspect ehrbase/ehrbase:next

--- a/.github/workflows/build-multiarch-image-latest.yml
+++ b/.github/workflows/build-multiarch-image-latest.yml
@@ -1,0 +1,79 @@
+name: Build & Deploy Docker Image (latest)
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push (AMD64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ehrbase/buildx:latest-amd64
+      -
+        name: Build and push (ARM64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ehrbase/buildx:latest-arm64
+  
+      - 
+        name: Create and push MultiArch Manifest
+        run: |
+          docker buildx imagetools create \
+                 ehrbase/buildx:latest-arm64 \
+                 ehrbase/buildx:latest-amd64 \
+                 -t ehrbase/buildx:latest
+          docker pull ehrbase/buildx:latest
+      -
+        name: Inspect MultiArch Manifest
+        run:  docker manifest inspect ehrbase/buildx:latest
+
+
+
+
+
+# STEPS FOR LOCAL REPRODUCTION
+# ============================
+# provides build runtimes for addition platforms
+# > docker run --privileged --rm tonistiigi/binfmt --install all
+#
+# creates a 'docker-container' driver
+# which allows building for multiple platforms 
+# > docker buildx create --use --name mybuild
+#
+# shows build Driver and available target platforms
+# > docker buildx inspect mybuild
+#
+# builds image for specific platform
+# and pushes it to docker-hub
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+#
+# creates multiarch manifest from given images
+# and pushes it to docker-hub
+# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+#
+# inspects created mulitarch image
+# > docker manifest inspect ehrbase/buildx:next

--- a/.github/workflows/build-multiarch-image-next.yml
+++ b/.github/workflows/build-multiarch-image-next.yml
@@ -28,7 +28,7 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ehrbase/buildx:next-amd64
+          tags: ehrbase/ehrbase:next-amd64
       -
         name: Build and push (ARM64)
         uses: docker/build-push-action@v2
@@ -36,19 +36,19 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: ehrbase/buildx:next-arm64
+          tags: ehrbase/ehrbase:next-arm64
   
       - 
         name: Create and push MultiArch Manifest
         run: |
           docker buildx imagetools create \
-                 ehrbase/buildx:next-arm64 \
-                 ehrbase/buildx:next-amd64 \
-                 -t ehrbase/buildx:next
-          docker pull ehrbase/buildx:next
+                 ehrbase/ehrbase:next-arm64 \
+                 ehrbase/ehrbase:next-amd64 \
+                 -t ehrbase/ehrbase:next
+          docker pull ehrbase/ehrbase:next
       -
         name: Inspect MultiArch Manifest
-        run:  docker manifest inspect ehrbase/buildx:next
+        run:  docker manifest inspect ehrbase/ehrbase:next
 
 
 
@@ -68,12 +68,12 @@ jobs:
 #
 # builds image for specific platform
 # and pushes it to docker-hub
-# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
-# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/ehrbase:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/ehrbase:next-amd .
 #
 # creates multiarch manifest from given images
 # and pushes it to docker-hub
-# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+# > docker buildx imagetools create ehrbase/ehrbase:next-arm ehrbase/ehrbase:next-amd -t ehrbase/ehrbase:next
 #
 # inspects created mulitarch image
-# > docker manifest inspect ehrbase/buildx:next
+# > docker manifest inspect ehrbase/ehrbase:next

--- a/.github/workflows/build-multiarch-image-next.yml
+++ b/.github/workflows/build-multiarch-image-next.yml
@@ -1,0 +1,79 @@
+name: Build & Deploy Docker Image (next)
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push (AMD64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ehrbase/buildx:next-amd64
+      -
+        name: Build and push (ARM64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ehrbase/buildx:next-arm64
+  
+      - 
+        name: Create and push MultiArch Manifest
+        run: |
+          docker buildx imagetools create \
+                 ehrbase/buildx:next-arm64 \
+                 ehrbase/buildx:next-amd64 \
+                 -t ehrbase/buildx:next
+          docker pull ehrbase/buildx:next
+      -
+        name: Inspect MultiArch Manifest
+        run:  docker manifest inspect ehrbase/buildx:next
+
+
+
+
+
+# STEPS FOR LOCAL REPRODUCTION
+# ============================
+# provides build runtimes for addition platforms
+# > docker run --privileged --rm tonistiigi/binfmt --install all
+#
+# creates a 'docker-container' driver
+# which allows building for multiple platforms 
+# > docker buildx create --use --name mybuild
+#
+# shows build Driver and available target platforms
+# > docker buildx inspect mybuild
+#
+# builds image for specific platform
+# and pushes it to docker-hub
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+#
+# creates multiarch manifest from given images
+# and pushes it to docker-hub
+# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+#
+# inspects created mulitarch image
+# > docker manifest inspect ehrbase/buildx:next

--- a/.github/workflows/build-multiarch-image-tag.yml
+++ b/.github/workflows/build-multiarch-image-tag.yml
@@ -1,0 +1,89 @@
+name: Build & Deploy Docker Image (latest)
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Create TAG ENV from version of release Branch
+        run: |
+          echo $GITHUB_REF
+          echo "${GITHUB_REF#refs/heads/}"
+          BRANCH=$(echo "${GITHUB_REF#refs/heads/}")
+          TAG="$(echo $BRANCH | awk -F'/v' '{print $2;}')"
+          echo $TAG
+          echo "TAG=$TAG" >> $GITHUB_ENV
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push (AMD64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ehrbase/buildx:tag-amd64
+      -
+        name: Build and push (ARM64)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ehrbase/buildx:tag-arm64
+      - 
+        name: Create and push MultiArch Manifest
+        run: |
+          #BRANCH=$(echo "${GITHUB_REF#refs/heads/}")
+          #TAG="$(echo $BRANCH | awk -F'/v' '{print $2;}')"
+          docker buildx imagetools create \
+                 ehrbase/buildx:tag-arm64 \
+                 ehrbase/buildx:tag-amd64 \
+                 -t ehrbase/buildx:${{ env.TAG }}
+          docker pull ehrbase/buildx:${{ env.TAG }}
+      -
+        name: Inspect MultiArch Manifest
+        run:  docker manifest inspect ehrbase/buildx:${{ env.TAG }}
+
+
+
+
+
+# STEPS FOR LOCAL REPRODUCTION
+# ============================
+# provides build runtimes for addition platforms
+# > docker run --privileged --rm tonistiigi/binfmt --install all
+#
+# creates a 'docker-container' driver
+# which allows building for multiple platforms 
+# > docker buildx create --use --name mybuild
+#
+# shows build Driver and available target platforms
+# > docker buildx inspect mybuild
+#
+# builds image for specific platform
+# and pushes it to docker-hub
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+#
+# creates multiarch manifest from given images
+# and pushes it to docker-hub
+# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+#
+# inspects created mulitarch image
+# > docker manifest inspect ehrbase/buildx:next

--- a/.github/workflows/build-multiarch-image-tag.yml
+++ b/.github/workflows/build-multiarch-image-tag.yml
@@ -37,7 +37,7 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ehrbase/buildx:tag-amd64
+          tags: ehrbase/ehrbase:tag-amd64
       -
         name: Build and push (ARM64)
         uses: docker/build-push-action@v2
@@ -45,20 +45,20 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: ehrbase/buildx:tag-arm64
+          tags: ehrbase/ehrbase:tag-arm64
       - 
         name: Create and push MultiArch Manifest
         run: |
           #BRANCH=$(echo "${GITHUB_REF#refs/heads/}")
           #TAG="$(echo $BRANCH | awk -F'/v' '{print $2;}')"
           docker buildx imagetools create \
-                 ehrbase/buildx:tag-arm64 \
-                 ehrbase/buildx:tag-amd64 \
-                 -t ehrbase/buildx:${{ env.TAG }}
-          docker pull ehrbase/buildx:${{ env.TAG }}
+                 ehrbase/ehrbase:tag-arm64 \
+                 ehrbase/ehrbase:tag-amd64 \
+                 -t ehrbase/ehrbase:${{ env.TAG }}
+          docker pull ehrbase/ehrbase:${{ env.TAG }}
       -
         name: Inspect MultiArch Manifest
-        run:  docker manifest inspect ehrbase/buildx:${{ env.TAG }}
+        run:  docker manifest inspect ehrbase/ehrbase:${{ env.TAG }}
 
 
 
@@ -78,12 +78,12 @@ jobs:
 #
 # builds image for specific platform
 # and pushes it to docker-hub
-# > docker buildx build --push --platform=linux/arm64 -t ehrbase/buildx:next-arm .
-# > docker buildx build --push --platform=linux/amd64 -t ehrbase/buildx:next-amd .
+# > docker buildx build --push --platform=linux/arm64 -t ehrbase/ehrbase:next-arm .
+# > docker buildx build --push --platform=linux/amd64 -t ehrbase/ehrbase:next-amd .
 #
 # creates multiarch manifest from given images
 # and pushes it to docker-hub
-# > docker buildx imagetools create ehrbase/buildx:next-arm ehrbase/buildx:next-amd -t ehrbase/buildx:next
+# > docker buildx imagetools create ehrbase/ehrbase:next-arm ehrbase/ehrbase:next-amd -t ehrbase/ehrbase:next
 #
 # inspects created mulitarch image
-# > docker manifest inspect ehrbase/buildx:next
+# > docker manifest inspect ehrbase/ehrbase:next


### PR DESCRIPTION
## Changes

- modified Dockerfile to allow multiarch build
- added Github Action workflows to build docker images with the tags 'next', 'latest' and 'release-version'

Initial implementation and tests done in a [playground repo](https://github.com/testautomation/ehrbase).
Check [Github Action builds](https://github.com/testautomation/ehrbase/actions) and experimental [DockerHub results](https://hub.docker.com/repository/docker/ehrbase/buildx) for details.

## Related issue

resolves https://github.com/ehrbase/ehrbase/issues/567


## Additional information and checks

- [ ] Pull request linked in changelog
