### PR TITLE
Externalizes context path for REST API

### DIFF
--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -101,9 +101,12 @@ cache:
 system:
   allow-template-overwrite: false
 
+openehr-api:
+  context-path: /rest/openehr
 admin-api:
   active: false
   allowDeleteAll: false
+  context-path: /rest/admin
 
 logging:
   level:

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminCompositionController.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 @Api(tags = {"Admin", "Composition"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminCompositionController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminContributionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminContributionController.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 @Api(tags = {"Admin", "Contribution"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminContributionController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminController.java
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Api(tags = {"Admin", "Heartbeat"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminController extends BaseController {
 
     @GetMapping(path = "/status")

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminDirectoryController.java
@@ -40,7 +40,7 @@ import java.util.UUID;
 @Api(tags = {"Admin", "Directory"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminDirectoryController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminEhrController.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 @Api(tags = {"Admin", "EHR"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminEhrController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminTemplateController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminTemplateController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.*;
 @Api(tags = {"Admin", "Template"})
 @ConditionalOnProperty(prefix = "admin-api", name = "active")
 @RestController
-@RequestMapping(path = "/rest/admin/template", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${admin-api.context-path:/rest/admin}/template", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class AdminTemplateController extends BaseController {
 
     TemplateService templateService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
@@ -78,7 +78,7 @@ import java.util.function.Supplier;
  */
 @Api(tags = "Composition")
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrCompositionController extends BaseController {
 
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrContributionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrContributionController.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 
 @Api(tags = "Contribution")
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrContributionController extends BaseController {
 
     private final ContributionService contributionService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryController.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 @Api(tags = "Stored Query")
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/definition/query", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/definition/query", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrDefinitionQueryController extends BaseController {
 
     final static Logger log = LoggerFactory.getLogger(OpenehrDefinitionQueryController.class);

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -71,7 +71,7 @@ import io.swagger.annotations.ResponseHeader;
  */
 @Api(tags = "Directory")
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr")
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr")
 public class OpenehrDirectoryController extends BaseController {
 
     private final FolderService folderService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrController.java
@@ -72,7 +72,7 @@ import java.util.function.Supplier;
  */
 @Api(tags = {"EHR"})
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrEhrController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrStatusController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrStatusController.java
@@ -50,7 +50,7 @@ import java.util.function.Supplier;
  */
 @Api(tags = {"EHR_STATUS"})
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr/{ehr_id}/ehr_status", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr/{ehr_id}/ehr_status", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrEhrStatusController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
@@ -60,7 +60,7 @@ import java.util.Set;
 
 @Api(tags = "Query")
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/query", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/query", produces = MediaType.APPLICATION_JSON_VALUE)
 public class OpenehrQueryController extends BaseController {
 
     final static Logger log = LoggerFactory.getLogger(OpenehrQueryController.class);

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
@@ -49,7 +49,7 @@ import java.util.function.Supplier;
  */
 @Api(tags = {"Template"})
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/definition/template", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/definition/template", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrTemplateController extends BaseController {
 
     private final TemplateService templateService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrVersionedCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrVersionedCompositionController.java
@@ -63,7 +63,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Api
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr/{ehr_id}/versioned_composition", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr/{ehr_id}/versioned_composition", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrVersionedCompositionController extends BaseController {
 
     private final EhrService ehrService;

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrVersionedEhrStatusController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrVersionedEhrStatusController.java
@@ -35,7 +35,7 @@ import java.util.UUID;
  */
 @Api
 @RestController
-@RequestMapping(path = "/rest/openehr/v1/ehr/{ehr_id}/versioned_ehr_status", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = "${openehr-api.context-path:/rest/openehr}/v1/ehr/{ehr_id}/versioned_ehr_status", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OpenehrVersionedEhrStatusController extends BaseController {
 
     private final EhrService ehrService;


### PR DESCRIPTION
## Changes
Externalize configuration of the context paths.

- New configuration property `admin-api.context-path` (default value: `/rest/admin`) to configure the path for the Admin API endpoints.
- New configuration property `openehr-api.context-path` (default value: `/rest/openehr`) to configure the path for the standard openEHR REST API endpoints.

## Related issue

Resolves #ehrbase/project_management#562

## Additional information and checks

- [ ] Pull request linked in changelog
