### PR TITLE
reduce the join depth as required

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -148,12 +148,14 @@ public class QueryProcessor extends TemplateMetaData {
 
                 SelectQuery select = queryStep.getSelectQuery();
 
-                select.addFrom(ENTRY);
-
                 if (!queryStep.getTemplateId().equalsIgnoreCase(NIL_TEMPLATE))
                     joinSetup.setUseEntry(true);
 
-                select = new JoinBinder(domainAccess, select).addJoinClause(joinSetup);
+                JoinBinder joinBinder = new JoinBinder(domainAccess, joinSetup);
+
+                select.addFrom(joinBinder.initialFrom());
+
+                select = joinBinder.addJoinClause(select);
 
                 select = setLateralJoins(queryStep.getLateralJoins(), select);
 

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/ehr/ehrstatus/SimpleEhrStatusAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/ehr/ehrstatus/SimpleEhrStatusAttribute.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Vitasystems GmbH and Christian Chevalley (Hannover Medical School).
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.aql.sql.queryimpl.attribute.ehr.ehrstatus;
+
+import org.ehrbase.aql.sql.binding.JoinBinder;
+import org.ehrbase.aql.sql.queryimpl.attribute.FieldResolutionContext;
+import org.ehrbase.aql.sql.queryimpl.attribute.IRMObjectAttribute;
+import org.ehrbase.aql.sql.queryimpl.attribute.JoinSetup;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.DSL;
+
+import static org.ehrbase.jooq.pg.Tables.STATUS;
+
+@SuppressWarnings({"java:S3740","java:S1452"})
+public class SimpleEhrStatusAttribute extends EhrStatusAttribute {
+
+    protected Field tableField;
+
+    public SimpleEhrStatusAttribute(FieldResolutionContext fieldContext, JoinSetup joinSetup) {
+        super(fieldContext, joinSetup);
+    }
+
+    @Override
+    public Field<?> sqlField() {
+        return as(DSL.field(tableField));
+    }
+
+    @Override
+    public IRMObjectAttribute forTableField(TableField tableField) {
+        this.tableField = tableField;
+        if (tableField.getTable().equals(STATUS)) {
+            joinSetup.setJoinEhrStatus(true);
+            this.tableField = JoinBinder.statusRecordTable.field(tableField.getName());
+        }
+        return this;
+    }
+}

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/ehr/ehrstatus/StatusResolver.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/ehr/ehrstatus/StatusResolver.java
@@ -22,10 +22,10 @@ import org.ehrbase.aql.sql.queryimpl.attribute.AttributeResolver;
 import org.ehrbase.aql.sql.queryimpl.attribute.FieldResolutionContext;
 import org.ehrbase.aql.sql.queryimpl.attribute.JoinSetup;
 import org.ehrbase.aql.sql.queryimpl.attribute.ehr.ehrstatus.subject.SubjectResolver;
-import org.ehrbase.aql.sql.queryimpl.attribute.eventcontext.SimpleEventContextAttribute;
 import org.jooq.Field;
 
 import static org.ehrbase.jooq.pg.Tables.STATUS;
+
 @SuppressWarnings({"java:S3740","java:S1452"})
 public class StatusResolver extends AttributeResolver
 {
@@ -44,9 +44,9 @@ public class StatusResolver extends AttributeResolver
             } else if (path.isEmpty()) {
                 return new EhrStatusJson(fieldResolutionContext, joinSetup).sqlField();
             } else if (path.equals("is_queryable")){
-                return new SimpleEventContextAttribute(fieldResolutionContext, joinSetup).forTableField(STATUS.IS_QUERYABLE).sqlField();
+                return new SimpleEhrStatusAttribute(fieldResolutionContext, joinSetup).forTableField(STATUS.IS_QUERYABLE).sqlField();
             } else if (path.equals("is_modifiable")){
-                return new SimpleEventContextAttribute(fieldResolutionContext, joinSetup).forTableField(STATUS.IS_MODIFIABLE).sqlField();
+                return new SimpleEhrStatusAttribute(fieldResolutionContext, joinSetup).forTableField(STATUS.IS_MODIFIABLE).sqlField();
             } else
                 return new EhrStatusJson(fieldResolutionContext, joinSetup).forJsonPath(path).sqlField();
         }


### PR DESCRIPTION
## Changes


This change adjust the actual JOIN statements depending on whether it's COMPOSITION attributes based or EHR attributes only.
F.e the join initially is:
```
from "ehr"."entry"
    right outer join "ehr"."composition" as "composition_join"
      on "composition_join"."id" = "ehr"."entry"."composition_id"
    right outer join "ehr"."ehr" as "ehr_join"
      on "ehr_join"."id" = "composition_join"."ehr_id"
    join "ehr"."status" as "status_join"
      on "status_join"."ehr_id" = "ehr_join"."id"
    join "ehr"."party_identified" as "subject_ref"
      on "subject_ref"."id" = "status_join"."party"
```
With this change:
```
from "ehr"."ehr" as "ehr_join"
    join "ehr"."status" as "status_join"
      on "status_join"."ehr_id" = "ehr_join"."id"
    join "ehr"."party_identified" as "subject_ref"
      on "subject_ref"."id" = "status_join"."party"
```
In large datasets this reduces the seq scan timing significantly.


## Related issue

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
