### PR TITLE
Use multiarch based postgres 13.4 image in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
             - COMPOSITION-tests-2
             - COMPOSITION-tests-3
             - COMPOSITION-tests-4
+            - COMPOSITION-tests-5
             - CONTRIBUTION-test
             - DIRECTORY-test
             - EHRSERVICE-test
@@ -279,6 +280,7 @@ workflows:
             - COMPOSITION-tests-2
             - COMPOSITION-tests-3
             - COMPOSITION-tests-4
+            - COMPOSITION-tests-5
             - CONTRIBUTION-test
             - DIRECTORY-test
             - EHRSERVICE-test
@@ -463,6 +465,7 @@ workflows:
             - COMPOSITION-tests-2
             - COMPOSITION-tests-3
             - COMPOSITION-tests-4
+            - COMPOSITION-tests-5
             - CONTRIBUTION-test
             - DIRECTORY-test
             - EHRSERVICE-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1505,7 +1505,7 @@ commands:
                         -e POSTGRES_USER=$POSTGRES_USER \
                         -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
                         -e DISABLE_SECURITY=true \
-                        -p 5432:5432 ehrbase/ehrbase-postgres:13.3
+                        -p 5432:5432 ehrbase/ehrbase-postgres:13.4
 
 
   setup-file-repo:
@@ -1842,13 +1842,14 @@ executors:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_HUB_PASSWORD
-      - image: ehrbase/ehrbase-postgres:13.3
+      - image: ehrbase/ehrbase-postgres:13.4
         auth:
           username: $DOCKER_USER
           password: $DOCKER_HUB_PASSWORD
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+          PGDATA: /tmp
 
   machine-ubuntu-1604:
     description: |

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -121,7 +121,7 @@ tasks:
                    -e POSTGRES_PASSWORD=postgres \
                    -e DISABLE_SECURITY \
                    -d -p 5432:5432 \
-                   ehrbase/ehrbase-postgres:13.3
+                   ehrbase/ehrbase-postgres:13.4
 
         echo ... DB server started.
 

--- a/tests/robot/_resources/libraries/dockerlib.py
+++ b/tests/robot/_resources/libraries/dockerlib.py
@@ -23,9 +23,9 @@ client = docker.from_env()
 
 def run_postgresql_container():
     """run a postgresql container in background with given envs"""
-    env = ["POSTGRES_USER=postgres", "POSTGRES_PASSWORD=postgres"]
+    env = ["POSTGRES_USER=postgres", "POSTGRES_PASSWORD=postgres", "PGDATA=/tmp"]
     container = client.containers.run(
-        "ehrbase/ehrbase-postgres:13.3",
+        "ehrbase/ehrbase-postgres:13.4",
         name="ehrdb",
         environment=env,
         ports={"5432/tcp": 5432},


### PR DESCRIPTION
## Changes

- I've built and deployed a multiarch ehrbase-postgres DB image which is based on postgres-13.4
- modified CI config and Robot test to use the new DB image

NOTE: there is an issue ( porbably caused by Moby's BuildKit (docker buildx) ) which requieres to set a custom PGDATA folder to successfully run a container based on this image, i.e.

```
docker run --name ehrdb \
           -e POSTGRES_PASSWORD=postgres \
           -e PGDATA=/tmp \
           -d -p 5432:5432 \
           ehrbase/ehrbase-postgres:13.4
```


