### PR TITLE
Adds missing foreign key and fixes constraint reference when delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Missing details in response returned by Directory REST API (see: https://github.com/ehrbase/ehrbase/pull/605)
-
+- Add foreign key between `folder` and `ehr` tables (see: https://github.com/ehrbase/ehrbase/pull/616)
 
 ## [0.17.2]
 

--- a/base/src/main/resources/db/migration/V63__add_missing_ehr_folder_fk.sql
+++ b/base/src/main/resources/db/migration/V63__add_missing_ehr_folder_fk.sql
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2021 Vitasystems GmbH.
+ *
+ *  This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and  limitations under the License.
+ *
+ */
+
+ALTER TABLE ehr.ehr
+    ADD CONSTRAINT ehr_directory_fkey
+        FOREIGN KEY (directory)
+            REFERENCES ehr.folder(id);
+
+CREATE UNIQUE INDEX ehr_folder_idx ON ehr.ehr(directory);

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -419,8 +419,9 @@ public class OpenehrDirectoryController extends BaseController {
         // Check version conflicts and throw precondition failed exception if not
         checkDirectoryVersionConflicts(folderId, ehrId);
 
-        this.folderService.delete(ehrId, folderId);
         this.ehrService.removeDirectory(ehrId);
+        this.folderService.delete(ehrId, folderId);
+
         return createDirectoryResponse(HttpMethod.DELETE, null, accept, null, ehrId);
     }
 


### PR DESCRIPTION
## Changes

- Adds the missing foreign key constraints betwenn `ehr` and `folder` tables.
- Removes folder reference before deleting folder associated to an EHR

## Related issue

Resolves ehrbase/project_management#318

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
