### PR TITLE
Fixes issue with start time without timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix conversion between `DvDateTime` and `Timestamp` (see https://github.com/ehrbase/ehrbase/pull/634)
 - Fix FLAT format does not return the archetype data if the archetype_id contains the letters "and"
 - Datetime inconsistent handling (see https://github.com/ehrbase/ehrbase/pull/649)
+- Fix issue using DV_DATE_TIME without time-zone (see https://github.com/ehrbase/ehrbase/pull/658)
 
 ## [0.17.2]
 

--- a/base/src/main/resources/db/migration/V65__fix_dv_date_time_function.sql
+++ b/base/src/main/resources/db/migration/V65__fix_dv_date_time_function.sql
@@ -1,0 +1,28 @@
+-- Removes 'Z' when timezone is NULL
+
+CREATE OR REPLACE FUNCTION ehr.js_dv_date_time(TIMESTAMP, TEXT)
+    RETURNS JSON AS
+$$
+DECLARE
+date_time ALIAS FOR $1;
+    time_zone ALIAS FOR $2;
+BEGIN
+
+    IF (date_time IS NULL)
+    THEN
+        RETURN NULL;
+END IF;
+
+    IF (time_zone IS NULL)
+    THEN
+        time_zone := '';
+END IF;
+
+RETURN
+    json_build_object(
+            '_type', 'DV_DATE_TIME',
+            'value',to_char(date_time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"'||time_zone||'"')
+        );
+END
+$$
+LANGUAGE plpgsql;

--- a/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/TemporalWithTimeZone.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/queryimpl/attribute/TemporalWithTimeZone.java
@@ -41,7 +41,7 @@ public class TemporalWithTimeZone extends SimpleEventContextAttribute {
         //                "ehr.js_dv_date_time("+tableField+"::timestamptz, COALESCE("+timeZoneField+"::text,'UTC'))::json #>>'{value}'")
         return as(field(
                 jsonpathItemAsText(
-                        jsDvDateTime(tableField, timeZoneField.coalesce(DSL.val("UTC"))).cast(JSONB.class),
+                        jsDvDateTime(tableField, timeZoneField).cast(JSONB.class),
                         jsonpathParameters("value")
                 )
         ));

--- a/service/src/main/java/org/ehrbase/service/RecordedDvDateTime.java
+++ b/service/src/main/java/org/ehrbase/service/RecordedDvDateTime.java
@@ -1,14 +1,13 @@
 package org.ehrbase.service;
 
-import com.nedap.archie.datetime.DateTimeFormatters;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
 
 public class RecordedDvDateTime {
 
@@ -26,12 +25,13 @@ public class RecordedDvDateTime {
         return Timestamp.valueOf(LocalDateTime.from(temporal));
     }
 
-    public String zoneId() {
+    public Optional<String> zoneId() {
         TemporalAccessor accessor = dateTime.getValue();
         if (accessor instanceof OffsetDateTime) {
-            return ((OffsetDateTime) accessor).getOffset().getId();
+            ZoneOffset offset = ((OffsetDateTime) accessor).getOffset();
+            return Optional.of(offset.getId());
         } else {
-            return OffsetDateTime.now().getOffset().getId();
+            return Optional.empty();
         }
     }
 
@@ -47,8 +47,13 @@ public class RecordedDvDateTime {
         if (timestamp == null) {
             return null;
         }
-        ZoneId zoneId = timezone != null ? ZoneId.of(timezone) : ZoneId.systemDefault();
-        ZonedDateTime zonedDateTime = timestamp.toLocalDateTime().atZone(zoneId);
-        return new DvDateTime(DateTimeFormatters.ISO_8601_DATE_TIME.format(zonedDateTime));
+
+        TemporalAccessor temporal;
+        if (timezone != null) {
+            temporal = timestamp.toLocalDateTime().atOffset(ZoneOffset.of(timezone));
+        } else {
+            temporal = timestamp.toLocalDateTime();
+        }
+        return new DvDateTime(temporal);
     }
 }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/attribute/TemporalWithTimeZoneTest.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/attribute/TemporalWithTimeZoneTest.java
@@ -58,10 +58,7 @@ public class TemporalWithTimeZoneTest extends TestAqlBase {
                 .isEqualToIgnoringWhitespace(
                     "select jsonb_extract_path_text(cast(\"ehr\".\"js_dv_date_time\"(\n" +
                             "  \"ehr\".\"event_context\".\"start_time\", \n" +
-                            "  coalesce(\n" +
-                            "    event_context.START_TIME_TZID, \n" +
-                            "    'UTC'\n" +
-                            "  )\n" +
+                            "  event_context.START_TIME_TZID\n" +
                             ") as jsonb),'value') \"/test\""
                 );
     }

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/UC42Test.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/UC42Test.java
@@ -46,10 +46,7 @@ public class UC42Test extends UC42 {
                         "  'local'\n" +
                         ") as jsonb),'uid','value') as \"NewerComposition\" where cast(jsonb_extract_path_text(cast(\"ehr\".\"js_dv_date_time\"(\n" +
                         "  \"ehr\".\"event_context\".\"start_time\", \n" +
-                        "  coalesce(\n" +
-                        "    event_context.START_TIME_TZID, \n" +
-                        "    'UTC'\n" +
-                        "  )\n" +
+                        "    event_context.START_TIME_TZID\n" +
                         ") as jsonb),'value') as varchar) > cast('2020-01-01' as varchar)) as \"COLUMN\") as \"ARRAY\" on ? where (\"ehr\".\"entry\".\"template_id\" = ? and ARRAY.COLUMN is not null and ARRAY.COLUMN is not null and ARRAY.COLUMN is not null)) union (select ARRAY.COLUMN as \"Diagnose\", ARRAY.COLUMN as \"MabuseComposition\", ARRAY.COLUMN as \"NewerComposition\" from \"ehr\".\"entry\" right outer join \"ehr\".\"composition\" as \"composition_join\" on \"composition_join\".\"id\" = \"ehr\".\"entry\".\"composition_id\" join \"ehr\".\"event_context\" on \"ehr\".\"event_context\".\"composition_id\" = \"ehr\".\"entry\".\"composition_id\" join \"ehr\".\"party_identified\" as \"composer_ref\" on \"composition_join\".\"composer\" = \"composer_ref\".\"id\" left outer join lateral (select (select jsonb_extract_path_text(cast(\"ehr\".\"js_composition\"(\n" +
                         "  cast(composition_join.id as uuid), \n" +
                         "  'local'\n" +
@@ -66,10 +63,7 @@ public class UC42Test extends UC42 {
                         "  'local'\n" +
                         ") as jsonb),'uid','value') as \"NewerComposition\" where cast(jsonb_extract_path_text(cast(\"ehr\".\"js_dv_date_time\"(\n" +
                         "  \"ehr\".\"event_context\".\"start_time\", \n" +
-                        "  coalesce(\n" +
-                        "    event_context.START_TIME_TZID, \n" +
-                        "    'UTC'\n" +
-                        "  )\n" +
+                        "    event_context.START_TIME_TZID \n" +
                         ") as jsonb),'value') as varchar) > cast('2020-01-01' as varchar)) as \"COLUMN\") as \"ARRAY\" on ? where (\"ehr\".\"entry\".\"template_id\" = ? and ARRAY.COLUMN is not null and ARRAY.COLUMN is not null and ARRAY.COLUMN is not null))";
     }
 

--- a/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/UC4Test.java
+++ b/service/src/test/java/org/ehrbase/aql/sql/queryimpl/translator/testcase/pg10/pgsql/UC4Test.java
@@ -31,10 +31,7 @@ public class UC4Test extends UC4 {
         this.expectedSqlExpression =
                 "select \"\".\"/composer/name\", \"\".\"/context/start_time/value\" from (select \"composer_ref\".\"name\" as \"/composer/name\", jsonb_extract_path_text(cast(\"ehr\".\"js_dv_date_time\"(\n" +
                         "  \"ehr\".\"event_context\".\"start_time\", \n" +
-                        "  coalesce(\n" +
-                        "    event_context.START_TIME_TZID, \n" +
-                        "    'UTC'\n" +
-                        "  )\n" +
+                        "    event_context.START_TIME_TZID\n" +
                         ") as jsonb),'value') as \"/context/start_time/value\"" +
                         " from \"ehr\".\"entry\" " +
                         "join \"ehr\".\"event_context\" on \"ehr\".\"event_context\".\"composition_id\" = \"ehr\".\"entry\".\"composition_id\"" +

--- a/service/src/test/java/org/ehrbase/service/RecordedDvDateTimeTest.java
+++ b/service/src/test/java/org/ehrbase/service/RecordedDvDateTimeTest.java
@@ -1,6 +1,7 @@
 package org.ehrbase.service;
 
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
+import org.apache.tomcat.jni.Local;
 import org.junit.Test;
 
 import java.sql.Timestamp;
@@ -26,7 +27,7 @@ public class RecordedDvDateTimeTest {
 
     @Test
     public void testDecodeDvDateTime() {
-        ZoneId zoneId = ZoneId.of("America/Los_Angeles");
+        ZoneOffset zoneId = ZoneOffset.of("-06:00");
         Instant now = Instant.now();
 
         DvDateTime dateTime;
@@ -35,7 +36,7 @@ public class RecordedDvDateTimeTest {
         assertEquals(OffsetDateTime.ofInstant(now, zoneId), dateTime.getValue());
 
         dateTime = new RecordedDvDateTime().decodeDvDateTime(Timestamp.from(now), null);
-        assertEquals(OffsetDateTime.ofInstant(now, ZoneId.systemDefault()), dateTime.getValue());
+        assertEquals(LocalDateTime.ofInstant(now, ZoneId.systemDefault()), dateTime.getValue());
 
         dateTime = new RecordedDvDateTime().decodeDvDateTime(Timestamp.from(now), zoneId.getId());
         assertNotEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), dateTime.getValue());


### PR DESCRIPTION
## Changes

Fixes the discrepancy using DV_DATE_TIME without timezone between submitted composition and returned values (Get composition/AQL query).

## Related issue

Fixes PEM-455


## Additional information and checks

- [x] Pull request linked in changelog
