### PR TITLE
Replaces spring-boot-starter-data-jpa by spring-boot-starter-jdbc

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Changes

- Remove `spring-boot-starter-data-jpa` as EHRbase is not using JPA/Hibernate
- Add `spring-boot-starter-jdbc` to keep auto-configuration for the DataSource.

## Related issue

Closes ehrbase/project_management#591 (PEM-517)

