### PR TITLE
fix missing alias substitution

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/binding/CompositionAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/CompositionAttribute.java
@@ -42,7 +42,8 @@ public class CompositionAttribute {
 
         if (variableDefinition.getPath() != null && variableDefinition.getPath().startsWith("content")) {
             qualifiedAqlFields = jsonbEntryQuery.makeField(templateId, identifier, variableDefinition, clause);
-            qualifiedAqlFields.setUseEntryTable(true);
+            if (qualifiedAqlFields != null)
+                qualifiedAqlFields.setUseEntryTable(true);
         } else {
             qualifiedAqlFields = compositionAttributeQuery.makeField(templateId, identifier, variableDefinition, clause);
         }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/ContextualAttribute.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/ContextualAttribute.java
@@ -52,8 +52,12 @@ public class ContextualAttribute {
             for (Iterator<QualifiedAqlField> qualifiedAqlFieldIterator = fields.iterator(); qualifiedAqlFieldIterator.hasNext();) {
                 QualifiedAqlField field = qualifiedAqlFieldIterator.next();
                 variableDefinition.setPath(originalPath);
-                if (originalPath != null)
-                    field.setField(field.getSQLField().as("/" + originalPath));
+                if (originalPath != null) {
+                    if (variableDefinition.getAlias() != null)
+                        field.setField(field.getSQLField().as(variableDefinition.getAlias()));
+                    else
+                        field.setField(field.getSQLField().as("/" + originalPath));
+                }
                 else
                     field.setField(field.getSQLField().as(variableDefinition.getIdentifier()));
             }

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/SelectBinder.java
@@ -104,7 +104,7 @@ public class SelectBinder extends TemplateMetaData implements ISelectBinder {
 
                 multiFields = expressionField.toSql(className, templateId, identifier, SELECT);
 
-                if (multiFields.isEmpty()) { //the field cannot be resolved with containment (f.e. empty DB)
+                if (multiFields == null || multiFields.isEmpty()) { //the field cannot be resolved with containment (f.e. empty DB)
                     continue;
                 }
 
@@ -135,7 +135,7 @@ public class SelectBinder extends TemplateMetaData implements ISelectBinder {
             if (new SetReturningFunction(selectQuery.toString()).isUsed()){
                 String alias = sqlField.getName();
                 MultiFields unaliasedFields = new ExpressionField(variableDefinition, jsonbEntryQuery, compositionAttributeQuery).toSql(className, templateId, variableDefinition.getIdentifier(), IQueryImpl.Clause.WHERE);
-                //TODO: evaluate for multiple paths in a single template!
+
                 TaggedStringBuilder taggedStringBuilder = new TaggedStringBuilder();
                 taggedStringBuilder.append(unaliasedFields.getLastQualifiedField().getSQLField().toString());
                 new LateralJoins().create(templateId, taggedStringBuilder, variableDefinition, SELECT);


### PR DESCRIPTION
## Changes
This fixes an absent aliasing for items in /context/other_context[at0001] as the aliasing was not properly propagated to the resultset definition.

## Related issue

fixes: https://github.com/ehrbase/ehrbase/issues/688


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
