### PR TITLE
Minor fixes and failing integration tests for ABAC

### DIFF
--- a/application/src/main/java/org/ehrbase/application/abac/CustomMethodSecurityExpressionRoot.java
+++ b/application/src/main/java/org/ehrbase/application/abac/CustomMethodSecurityExpressionRoot.java
@@ -295,7 +295,7 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot i
 
     // in all other cases just handle the one String "subject" variable
     // check if matches (to block accessing patient X with token from patient Y) OR null reference
-    if (tokenPatient.equals(subject) || subject != null) {
+    if (tokenPatient.equals(subject) || subject == null) {
       // matches OR EHR's external ref is null, so add our subject from token
       requestMap.put(PATIENT, tokenPatient);
     } else {

--- a/application/src/test/java/org/ehrbase/application/abac/FlywayTestConfiguration.java
+++ b/application/src/test/java/org/ehrbase/application/abac/FlywayTestConfiguration.java
@@ -1,0 +1,17 @@
+package org.ehrbase.application.abac;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayTestConfiguration {
+
+  @Bean
+  public FlywayMigrationStrategy clean() {
+    return flyway -> {
+      flyway.clean();
+      flyway.migrate();
+    };
+  }
+}

--- a/application/src/test/resources/application-test.yml
+++ b/application/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+abac:
+  enabled: true
+security:
+  auth-type: oauth
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9000/auth/realms/master

--- a/application/src/test/resources/composition.json
+++ b/application/src/test/resources/composition.json
@@ -1,0 +1,150 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/application/src/test/resources/contribution.json
+++ b/application/src/test/resources/contribution.json
@@ -1,0 +1,78 @@
+{
+  "_type": "CONTRIBUTION",
+  "versions": [
+    {
+      "_type": "ORIGINAL_VERSION",
+      "commit_audit": {
+        "_type": "AUDIT_DETAILS",
+        "system_id": "test-system-id",
+        "committer": {
+          "_type": "PARTY_IDENTIFIED",
+          "name": "<optional name of the committer>",
+          "external_ref": {
+            "id": {
+              "_type": "GENERIC_ID",
+              "value": "<OBJECT_ID>",
+              "scheme": "<ID SCHEME NAME>"
+            },
+            "namespace": "demographic",
+            "type": "PERSON"
+          }
+        },
+        "change_type": {
+          "value": "creation",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "249"
+          }
+        },
+        "description": {
+          "value": "<optional audit description>"
+        }
+      },
+      "data":
+      %s      ,
+      "lifecycle_state": {
+        "value": "complete",
+        "defining_code": {
+          "terminology_id": {
+            "value": "openehr"
+          },
+          "code_string": "532"
+        }
+      }
+    }
+  ],
+  "audit": {
+    "_type": "AUDIT_DETAILS",
+    "system_id": "test-system-id",
+    "committer": {
+      "_type": "PARTY_IDENTIFIED",
+      "name": "<optional name of the committer>",
+      "external_ref": {
+        "id": {
+          "_type": "GENERIC_ID",
+          "value": "<OBJECT_ID>",
+          "scheme": "<ID SCHEME NAME>"
+        },
+        "namespace": "demographic",
+        "type": "PERSON"
+      }
+    },
+    "change_type": {
+      "value": "creation",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "249"
+      }
+    },
+    "description": {
+      "value": "<optional audit description>"
+    }
+  }
+}
+

--- a/application/src/test/resources/ehr_status.json
+++ b/application/src/test/resources/ehr_status.json
@@ -1,0 +1,20 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "name": {
+    "value": "EHR Status"
+  },
+  "subject": {
+    "external_ref": {
+      "id": {
+        "_type": "GENERIC_ID",
+        "value": "%s",
+        "scheme": "id_scheme"
+      },
+      "namespace": "examples",
+      "type": "PERSON"
+    }
+  },
+  "is_queryable": true,
+  "is_modifiable": true
+}

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrController.java
@@ -38,6 +38,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -158,6 +159,7 @@ public class OpenehrEhrController extends BaseController implements EhrApiSpecif
      * Returns EHR by ID
      */
     @GetMapping(path = "/{ehr_id}")
+    @PreAuthorize("checkAbacPre(@openehrEhrController.EHR, @ehrService.getSubjectExtRef(#ehrIdString))")
     @Override
     public ResponseEntity<EhrResponseData> retrieveEhrById(@RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
                                                            @PathVariable(value = "ehr_id") String ehrIdString,
@@ -176,6 +178,7 @@ public class OpenehrEhrController extends BaseController implements EhrApiSpecif
      * Returns EHR by subject (id and namespace)
      */
     @GetMapping(params = {"subject_id", "subject_namespace"})
+    @PreAuthorize("checkAbacPre(@openehrEhrController.EHR, #subjectId)")
     @Override
     public ResponseEntity<EhrResponseData> retrieveEhrBySubject(@RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
                                                                 @RequestParam(value = "subject_id") String subjectId,

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
@@ -71,6 +71,7 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
     }
 
     @GetMapping("/aql{?q, offset, fetch, query_parameter}")
+    @PostAuthorize("checkAbacPostQuery(@queryServiceImp.getAuditResultMap())")
     @Override
     public ResponseEntity<QueryResponseData> getAdhocQuery(@RequestHeader(value = ACCEPT, required = false) String accept,
                                                            @RequestParam(value = "q") String query,


### PR DESCRIPTION
## Changes

<!-- Describe your changes in a short list -->
- Added integration tests to check if ABAC server is being called after every API call in c787bf7f5e82bef9eda1408c9bcef90d23097ce0
- Fixed the composition in the ABAC Integration test to commit (it was failing with 400)
- Fixed 500 internal server error when EHR does not have subject id with ABAC turned on in 6ede6f2
## Related issue
 #690

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->


## Additional information and checks

The following tests are currently failing:
- GET EHR: Does not call ABAC server. Probably not secured with ABAC.
- GET COMPOSITION (here of deleted composition): Does not call ABAC server (maybe works as expected?)
- GET QUERY: Does not call ABAC server. Probably not secured with ABAC.
- GET QUERY WITH MULTIPLE EHRs AND TEMPLATES (incl. posting those): Does not call ABAC server. Probably not secured with ABAC.

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
