### PR TITLE
Cdr 15 maven central

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,15 +39,15 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>response-dto</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>web-template</artifactId>
         </dependency>
         <dependency>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -97,7 +97,7 @@
             <artifactId>api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>
@@ -137,7 +137,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>test-data</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jooq-pq/pom.xml
+++ b/jooq-pq/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,9 @@
         <skipIntegrationTests>true</skipIntegrationTests>
         <include.tests>**/*Test.java</include.tests>
         <test.profile>unit</test.profile>
+
+        <surefireArgLine/>
+        <failsafeArgLine/>
     </properties>
 
     <build>
@@ -540,37 +543,37 @@
 
             <!-- sdk -->
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>response-dto</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>opt-1.4</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>serialisation</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>terminology</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>validation</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>web-template</artifactId>
                 <version>${ehrbase.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
                 <artifactId>test-data</artifactId>
                 <version>${ehrbase.sdk.version}</version>
                 <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <keycloak.version>4.0.0.Final</keycloak.version>
         <springdoc-openapi.version>1.5.11</springdoc-openapi.version>
         <postgressql.version>42.2.18</postgressql.version>
-        <ehrbase.sdk.version>41b4db1</ehrbase.sdk.version>
+        <ehrbase.sdk.version>1.6.0-SNAPSHOT</ehrbase.sdk.version>
         <flyway.version>7.11.3</flyway.version>
         <joda.version>2.10.6</joda.version>
         <jacoco.version>0.8.6</jacoco.version>
@@ -680,6 +680,16 @@
     </dependencyManagement>
 
     <repositories>
+        <repository>
+            <id>ossrh-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>
@@ -65,7 +65,7 @@
             <artifactId>archie</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>opt-1.4</artifactId>
         </dependency>
         <dependency>
@@ -73,11 +73,11 @@
             <artifactId>jooq-pg</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>web-template</artifactId>
         </dependency>
         <dependency>
@@ -147,7 +147,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
             <artifactId>test-data</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Changes

Switch to openEHR SDK dependencies published on Maven Central using groupID: `org.ehrbase.openehr.sdk`
