### PR TITLE
Use Docker image ehrbase/ehrbase-postgres:13.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       ehrbase-db:
-        image: ehrbase/ehrbase-postgres:latest
+        image: ehrbase/ehrbase-postgres:13.4
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
## Changes

Use correct Docker image for the database: `ehrbase/ehrbase-postgres:13.4`
