### PR TITLE
Feature/cdr 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 ### Fixed
+- fixed SQL encoding whenever template is unresolved (https://github.com/ehrbase/ehrbase/pull/723)
 
 ## [0.18.3]
 

--- a/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/QueryProcessor.java
@@ -35,6 +35,7 @@ import org.ehrbase.aql.sql.queryimpl.attribute.JoinSetup;
 import org.ehrbase.dao.access.interfaces.I_DomainAccess;
 import org.ehrbase.service.IntrospectService;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 

--- a/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/LocatableItem.java
@@ -32,7 +32,7 @@ public class LocatableItem {
 
     private final CompositionAttributeQuery compositionAttributeQuery;
     private final JsonbEntryQuery jsonbEntryQuery;
-    private IQueryImpl.Clause clause;
+    private final IQueryImpl.Clause clause;
 
     public LocatableItem(CompositionAttributeQuery compositionAttributeQuery, JsonbEntryQuery jsonbEntryQuery, IQueryImpl.Clause clause) {
         this.compositionAttributeQuery = compositionAttributeQuery;
@@ -45,8 +45,10 @@ public class LocatableItem {
 
         multiFields = jsonbEntryQuery.makeField(templateId, variableDefinition.getIdentifier(), variableDefinition, clause);
 
-        if (multiFields == null)
+        if (multiFields == null) {
+            compositionAttributeQuery.setUseEntry(true);
             return MultiFields.asNull(variableDefinition, templateId, clause);
+        }
 
         return multiFields;
     }


### PR DESCRIPTION
## Changes
Make sure that table `entry` is used in the FROM clause whenever the template is not resolved (that is resulting in "null" field).

## Related issue

fixes: https://jira.vitagroup.ag/browse/CDR-18


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
