### PR TITLE
changed behavior for conflicting identified parties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - fixed SQL encoding whenever template is unresolved (https://github.com/ehrbase/ehrbase/pull/723)
+- modified handling of conflicting identified parties (https://github.com/ehrbase/ehrbase/issues/710)
 
 ## [0.18.3]
 


### PR DESCRIPTION
## Changes

Changed the behavior when committing an identified party as in integration test https://github.com/ehrbase/openEHR_SDK/blob/feature/sync/710_party_conflicts/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/ParticipationTestIT.java

Previously, if unresolved in the DB, party was substituted with a party having the same name and ExternalRef ID if any...

## Related issue

Fixes: https://github.com/ehrbase/ehrbase/issues/710

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
