### PR TITLE
Fixes default ASC direction for ORDER BY clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove unused Operational Template cache ([#759](https://github.com/ehrbase/ehrbase/pull/759)).
 - Allow update/adding/removal of feeder_audit/links on Composition ([#773](https://github.com/ehrbase/ehrbase/pull/773))
+- Add default ASC direction to ORDER BY clause in AQL ([#780](https://github.com/ehrbase/ehrbase/pull/780)).
 
 ## [0.19.0]
 

--- a/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
+++ b/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
@@ -54,7 +54,7 @@ orderBySeq
         : orderByExpr (COMMA orderBySeq)?;
 //      | orderByExpr COMMA orderBySeq ;
 
-orderByExpr : identifiedPath (DESCENDING|ASCENDING|DESC|ASC);
+orderByExpr : identifiedPath (DESCENDING|ASCENDING|DESC|ASC)?;
 //      | identifiedPath DESCENDING
 //      | identifiedPath ASCENDING
 //      | identifiedPath DESC

--- a/service/src/main/java/org/ehrbase/aql/compiler/QueryCompilerPass2.java
+++ b/service/src/main/java/org/ehrbase/aql/compiler/QueryCompilerPass2.java
@@ -384,10 +384,10 @@ public class QueryCompilerPass2 extends AqlBaseListener {
               new VariableDefinition(path, null, identifier, false));
         }
 
-        if (context1.ASC() != null || context1.ASCENDING() != null) {
-          orderAttribute.setDirection(OrderAttribute.OrderDirection.ASC);
-        } else if (context1.DESC() != null || context1.DESCENDING() != null) {
+        if (context1.DESC() != null || context1.DESCENDING() != null) {
           orderAttribute.setDirection(OrderAttribute.OrderDirection.DESC);
+        } else {
+          orderAttribute.setDirection(OrderAttribute.OrderDirection.ASC);
         }
         orderAttributes.push(orderAttribute);
       }

--- a/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass2Test.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass2Test.java
@@ -197,6 +197,24 @@ public class QueryCompilerPass2Test {
             I_VariableDefinition expected = I_VariableDefinitionHelper.build(null, "date_created", null, false, false, false);
             I_VariableDefinitionHelper.checkEqualWithoutFuncParameters(orderAttribute.getVariableDefinition(), expected);
         }
+
+        // with default direction
+        {
+            QueryCompilerPass2 cut = new QueryCompilerPass2();
+            String aql = "select a/uid/value as uid, a/composer/name as author, a/context/start_time/value as date_created " +
+                    "from EHR e  contains COMPOSITION a[openEHR-EHR-COMPOSITION.health_summary.v1] " +
+                    "order by date_created";
+            ParseTree tree = QueryHelper.setupParseTree(aql);
+            walker.walk(cut, tree);
+
+            List<OrderAttribute> orderAttributes = cut.getOrderAttributes();
+            Assertions.assertThat(orderAttributes).size().isEqualTo(1);
+
+            OrderAttribute orderAttribute = orderAttributes.get(0);
+            assertThat(orderAttribute.getDirection()).isEqualTo(OrderAttribute.OrderDirection.ASC);
+            I_VariableDefinition expected = I_VariableDefinitionHelper.build(null, "date_created", null, false, false, false);
+            I_VariableDefinitionHelper.checkEqualWithoutFuncParameters(orderAttribute.getVariableDefinition(), expected);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Changes

Add default sort direction (ASC) to ORDER BY clause.

## Related issue

Fixes #689 

## Additional information and checks

- [x] Pull request linked in changelog
