### PR TITLE
Support for ORDER BY and LIMIT clauses in any order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add Plugins system ([#772](https://github.com/ehrbase/ehrbase/pull/772)
-  , [#779](https://github.com/ehrbase/ehrbase/pull/779) ).
+- Add Plugins system ([#772](https://github.com/ehrbase/ehrbase/pull/772),
+  [#779](https://github.com/ehrbase/ehrbase/pull/779)).
+- AQL: support `ORDER BY` and `LIMIT [OFFSET]` clauses in any order ([#782](https://github.com/ehrbase/openEHR_SDK/pull/782)).
 
 ### Changed
 

--- a/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
+++ b/service/src/main/antlr4/org/ehrbase/aql/parser/Aql.g4
@@ -18,7 +18,7 @@ grammar Aql;
 
 query   :   queryExpr ;
 
-queryExpr : select from (where)? (limit)? (offset)? (orderBy)? EOF ;
+queryExpr : select from (where)? (orderBy (limit offset?)? | (limit offset?) orderBy?)? EOF ;
 
 select
         : SELECT selectExpr

--- a/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass2Test.java
+++ b/service/src/test/java/org/ehrbase/aql/compiler/QueryCompilerPass2Test.java
@@ -18,18 +18,17 @@
 
 package org.ehrbase.aql.compiler;
 
-import org.ehrbase.aql.definition.I_VariableDefinition;
-import org.ehrbase.aql.definition.I_VariableDefinitionHelper;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.assertj.core.api.Assertions;
+import org.ehrbase.aql.definition.I_VariableDefinition;
+import org.ehrbase.aql.definition.I_VariableDefinitionHelper;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.PREDICATE;
 
 public class QueryCompilerPass2Test {
 
@@ -261,7 +260,7 @@ public class QueryCompilerPass2Test {
         {
             QueryCompilerPass2 cut = new QueryCompilerPass2();
             String aql = "select e/ehr_id/value " +
-                    "from EHR e OFFSET 6 ";
+                    "from EHR e LIMIT 5 OFFSET 6 ";
             ParseTree tree = QueryHelper.setupParseTree(aql);
             walker.walk(cut, tree);
             Integer actual = cut.getOffsetAttribute();
@@ -288,7 +287,7 @@ public class QueryCompilerPass2Test {
 
     @Test
     @Ignore("in progress")
-    public void testCompositionNodeWithPredicate(){
+    public void testCompositionNodeWithPredicate() {
         ParseTreeWalker walker = new ParseTreeWalker();
         QueryCompilerPass2 cut = new QueryCompilerPass2();
         String aql = "SELECT\n" +
@@ -302,5 +301,52 @@ public class QueryCompilerPass2Test {
         walker.walk(cut, tree);
         Integer actual = cut.getOffsetAttribute();
         assertThat(actual).isEqualTo(6);
+    }
+
+    @Test
+    public void limitAndOrderByAnyOrder() {
+        var walker = new ParseTreeWalker();
+        var compiler = new QueryCompilerPass2();
+
+        String aql;
+        ParseTree tree;
+
+        aql = "select e/ehr_id/value from EHR e LIMIT 5 OFFSET 6";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getLimitAttribute()).isEqualTo(5);
+        assertThat(compiler.getOffsetAttribute()).isEqualTo(6);
+        assertThat(compiler.getOffsetAttribute()).isEqualTo(6);
+
+        aql = "select e/ehr_id/value from EHR e ORDER BY e/ehr_id/value DESC";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getOrderAttributes().get(0).getDirection()).isEqualTo(OrderAttribute.OrderDirection.DESC);
+
+        aql = "select e/ehr_id/value from EHR e LIMIT 5 ORDER BY e/ehr_id/value DESC";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getLimitAttribute()).isEqualTo(5);
+        assertThat(compiler.getOrderAttributes().get(0).getDirection()).isEqualTo(OrderAttribute.OrderDirection.DESC);
+
+        aql = "select e/ehr_id/value from EHR e ORDER BY e/ehr_id/value DESC LIMIT 5";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getLimitAttribute()).isEqualTo(5);
+        assertThat(compiler.getOrderAttributes().get(0).getDirection()).isEqualTo(OrderAttribute.OrderDirection.DESC);
+
+        aql = "select e/ehr_id/value from EHR e LIMIT 5 OFFSET 6 ORDER BY e/ehr_id/value DESC";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getLimitAttribute()).isEqualTo(5);
+        assertThat(compiler.getOffsetAttribute()).isEqualTo(6);
+        assertThat(compiler.getOrderAttributes().get(0).getDirection()).isEqualTo(OrderAttribute.OrderDirection.DESC);
+
+        aql = "select e/ehr_id/value from EHR e ORDER BY e/ehr_id/value DESC LIMIT 5 OFFSET 6";
+        tree = QueryHelper.setupParseTree(aql);
+        walker.walk(compiler, tree);
+        assertThat(compiler.getLimitAttribute()).isEqualTo(5);
+        assertThat(compiler.getOffsetAttribute()).isEqualTo(6);
+        assertThat(compiler.getOrderAttributes().get(0).getDirection()).isEqualTo(OrderAttribute.OrderDirection.DESC);
     }
 }


### PR DESCRIPTION
## Changes

Add support for ORDER BY and LIMIT clauses in any order

## Related issue

- Fixes #774 
- CDR-315


## Additional information and checks

- [x] Pull request linked in changelog
