### PR TITLE
Build EHRbase Docker image when a new SDK SNAPSHOT is published

### DIFF
--- a/.github/workflows/build-multiarch-image-next.yml
+++ b/.github/workflows/build-multiarch-image-next.yml
@@ -8,51 +8,51 @@ on:
       - '**/*.md'
       - 'doc/**'
       - 'tests/**'
+  repository_dispatch:
+    types: [ build-ehrbase-next ]
 
 jobs:
   build-docker:
     runs-on: ubuntu-20.04
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1 
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Build and push (AMD64)
+
+      - name: Build and push (AMD64)
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/amd64
           push: true
           tags: ehrbase/ehrbase:next-amd64
-      -
-        name: Build and push (ARM64)
+
+      - name: Build and push (ARM64)
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/arm64
           push: true
           tags: ehrbase/ehrbase:next-arm64
-  
-      - 
-        name: Create and push MultiArch Manifest
+
+      - name: Create and push MultiArch Manifest
         run: |
           docker buildx imagetools create \
                  ehrbase/ehrbase:next-arm64 \
                  ehrbase/ehrbase:next-amd64 \
                  -t ehrbase/ehrbase:next
           docker pull ehrbase/ehrbase:next
-      -
-        name: Inspect MultiArch Manifest
-        run:  docker manifest inspect ehrbase/ehrbase:next
+
+      - name: Inspect MultiArch Manifest
+        run: docker manifest inspect ehrbase/ehrbase:next
 
 
 


### PR DESCRIPTION
## Changes

Build EHRbase Docker image (ehrbase:next) when a new openEHR SDK SNAPSHOT is published.

## Related issue

CDR-322
