### PR TITLE
allow null value for health facility

### DIFF
--- a/service/src/main/java/org/ehrbase/aql/sql/binding/JoinBinder.java
+++ b/service/src/main/java/org/ehrbase/aql/sql/binding/JoinBinder.java
@@ -212,6 +212,7 @@ public class JoinBinder implements IJoinBinder {
         joinEventContext(selectQuery);
         Table<PartyIdentifiedRecord> facilityTable = facilityRef;
         selectQuery.addJoin(facilityTable,
+                JoinType.LEFT_OUTER_JOIN,
                 EVENT_CONTEXT.FACILITY
                         .eq(DSL.field(facilityTable.field(PARTY_IDENTIFIED.ID.getName(), UUID.class))));
         facilityJoined = true;


### PR DESCRIPTION
## Changes

Changed join quality to allow null values in the right member as NULL is valid for an optional health care facility attribute.

## Related issue

Fixes: CR #848 

## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
