### PR TITLE
perf: add index to improve find EHR by subject-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - use bom for dependence management  ([#820](https://github.com/ehrbase/ehrbase/pull/820))
 - add  Release action  ([#831](https://github.com/ehrbase/ehrbase/pull/831)
 - Added hooks for the plugin system ([#816](https://github.com/ehrbase/ehrbase/pull/816))
+- Added index to `party_identified` to improve performance of find EHR by subject-id ([857](https://github.com/ehrbase/ehrbase/pull/857)))
 
 ### Changed
 - Upgrade to Spring boot 2.5.12

--- a/base/src/main/resources/db/migration/V70__add_index_to_party_identified.sql
+++ b/base/src/main/resources/db/migration/V70__add_index_to_party_identified.sql
@@ -1,0 +1,1 @@
+CREATE INDEX party_identified_namespace_value_idx ON party_identified(party_ref_namespace, party_ref_value);


### PR DESCRIPTION
## Changes

- Added a new Flyway migration to create a new index on the `party_identified` table to improve the performance of finding EHRs by subject--id

## Related issue

#856


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [x] Pull request linked in changelog
