### PR TITLE
Fix/cdr 413

### DIFF
--- a/tests/robot/COMPOSITION_TESTS/GET_VERSIONED_COMPOSITION/C.6__B)_Get_Versioned_COMPOSITION_Revision_History.robot
+++ b/tests/robot/COMPOSITION_TESTS/GET_VERSIONED_COMPOSITION/C.6__B)_Get_Versioned_COMPOSITION_Revision_History.robot
@@ -70,6 +70,7 @@ Force Tags      COMPOSITION_get_versioned
 
 
 3. Get Correct Ordered Revision History of Versioned Composition Of Existing EHR With Two Composition Versions (JSON)
+    [Tags]      not-ready
     [Documentation]     Testing with two versions like above, but checking the response more thoroughly.
 
     create EHR and commit a composition for versioned composition tests

--- a/tests/robot/COMPOSITION_TESTS/GET_VERSIONED_COMPOSITION/C.6__B)_Get_Versioned_COMPOSITION_Revision_History.robot
+++ b/tests/robot/COMPOSITION_TESTS/GET_VERSIONED_COMPOSITION/C.6__B)_Get_Versioned_COMPOSITION_Revision_History.robot
@@ -48,8 +48,10 @@ Force Tags      COMPOSITION_get_versioned
     Should Be Equal As Strings    ${version_uid}    ${item1.version_id.value}
 
 
-2. Get Revision History of Versioned Composition Of Existing EHR With Two Composition Versions (JSON)
+2. Get Revision History Of Versioned Composition Of Existing EHR With Two Composition Versions (JSON)
     [Documentation]    Testing with two versions, so the result should list two history entries.
+    ...     Checks if versions are listed in desc order -> Latest modified first.
+    ...     Doc: https://specifications.openehr.org/releases/RM/latest/common.html#_revision_history_class
 
     create EHR and commit a composition for versioned composition tests
 
@@ -75,13 +77,13 @@ Force Tags      COMPOSITION_get_versioned
     update a composition for versioned composition tests
 
     get revision history of versioned composition of EHR by UID    ${versioned_object_uid}
-    Should Be Equal As Strings    ${response.status}    200
+    Status Should Be    200
     ${length} =    Get Length    ${response.body} 	
     Should Be Equal As Integers 	${length} 	2
 
     # comment: Attention: the following code is depending on the order of the array!
     ${item1} =    Get From List    ${response.body}    0
-    Should Be Equal As Strings    ${version_uid}    ${item1.version_id.value}
+    Should Be Equal As Strings    ${version_uid[0:-1]}2    ${item1.version_id.value}
     # comment: check if change type is "creation"
     ${audit1} =    Get From List    ${item1.audits}    0
     Should Be Equal As Strings    creation    ${audit1.change_type.value}
@@ -89,7 +91,7 @@ Force Tags      COMPOSITION_get_versioned
     ${timestamp1} = 	Convert Date    ${audit1.time_committed.value}    result_format=%Y-%m-%dT%H:%M:%S.%f
 
     ${item2} =    Get From List    ${response.body}    1
-    Should Be Equal As Strings    ${version_uid[0:-1]}2    ${item2.version_id.value}
+    Should Be Equal As Strings    ${version_uid[0:-1]}1    ${item2.version_id.value}
     # comment: check if change type is "modification"
     ${audit2} =    Get From List    ${item2.audits}    0
     Should Be Equal As Strings    modification    ${audit2.change_type.value}
@@ -102,6 +104,7 @@ Force Tags      COMPOSITION_get_versioned
 
     # comment: Idea here: newer/higher timestamp - older/lesser timestamp = number larger than 0 IF correct
     Should Be True 	${timediff} > 0
+    [Teardown]      TRACE JIRA ISSUE    CDR-413
 
 
 4. Get Revision History of Versioned Composition Of Non-Existing EHR (JSON)

--- a/tests/robot/_resources/keywords/composition_keywords.robot
+++ b/tests/robot/_resources/keywords/composition_keywords.robot
@@ -837,6 +837,7 @@ get revision history of versioned composition of EHR by UID
     &{resp}=            REST.GET    ${baseurl}/ehr/${ehr_id}/versioned_composition/${uid}/revision_history
                         ...         headers={"Accept": "application/json"}
                         Set Test Variable    ${response}    ${resp}
+                        Log     ${response}
 
 
 get version of versioned composition of EHR by UID and time


### PR DESCRIPTION
## Changes

- Test Case: Get Correct Ordered Revision History of Versioned Composition Of Existing EHR With Two Composition Versions (JSON)
- Add checks for revision history order (most-recent-first order)

## Related issue

- https://jira.vitagroup.ag/browse/CDR-413


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
