### PR TITLE
Export of the connection variables to the DB that are in the pom to a properties file

### DIFF
--- a/abc.properties
+++ b/abc.properties
@@ -1,0 +1,5 @@
+jdbc.url=localhost
+jdbc.port=5432
+jdbc.db=ehrbase
+jdbc.user=ehrbase
+jdbc.pass=ehrbase

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -76,6 +76,30 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -145,6 +145,28 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -43,4 +43,28 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jooq-pq/pom.xml
+++ b/jooq-pq/pom.xml
@@ -62,6 +62,28 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-maven-plugin</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -56,5 +56,29 @@
             <artifactId>response-dto</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,38 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <license-header.dir>./</license-header.dir>
         <!-- PostgreSQL Database Properties -->
-        <database.host>localhost</database.host>
-        <database.port>5432</database.port>
-        <database.user>ehrbase</database.user>
-        <database.pass>ehrbase</database.pass>
-        <database.name>ehrbase</database.name>
+        <database.host>${jdbc.url}</database.host>
+        <database.port>${jdbc.port}</database.port>
+        <database.user>${jdbc.user}</database.user>
+        <database.pass>${jdbc.pass}</database.pass>
+        <database.name>${jdbc.db}</database.name>
         <test.profile>unit</test.profile>
     </properties>
 
-
     <build>
         <plugins>
+            <!-- Añado el pluging necesario para las variables de propiedades-->
+            <!-- Cada hijo tiene esto con la ruta cogida desde el padre-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/rest-ehr-scape/pom.xml
+++ b/rest-ehr-scape/pom.xml
@@ -64,4 +64,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/rest-openehr/pom.xml
+++ b/rest-openehr/pom.xml
@@ -64,4 +64,28 @@
             <version>4.0.0</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -168,6 +168,28 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -77,6 +77,27 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <files>
+                        <file>${project.parent.basedir}/abc.properties</file>
+                    </files>
+                    <outputFile/>
+                    <properties/>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
Export of the connection variables to the DB that are in the pom to a properties file to only have to modify them there and in case of deployment in kubernetes to be able to use secrets

## Changes

<!-- Describe your changes in a short list -->

1- Create a abc.properties in the main folder with the bbdd variables
2- In the main pom I change the DB connection variables with the variables I have in my abc.properties file.
3- I add the plugin org.codehaus.mojo indicating the directory where the abc.properties file is located.
4- I add this plugin to each child pom only indicating that the path is set by the parent pom.

## Related issue

In this way it is possible to avoid hardcoding the connection to the DB in order to be able to migrate it to kubernetes with secrets in the future. 
Besides, it only allows you to change the .properties data and everything is updated.


## Additional information and checks
This is also very advantageous if you run ehrbase in a pipeline. Normally database data is treated with secrets and only if you have the secrets file you can run the product in the pipeline.

Solution oriented to DevOps philosophy, use of kubernetes and for possible hot deployments. 

<!-- If there are more checks or data to be provided, put it here -->

- [ ] Pull request linked in changelog
