### PR TITLE
fix: capture 404 not found in case of delete composition and template

### DIFF
--- a/tests/robot/COMPOSITION_TESTS/CREATE_COMPOSITION/B.6.s_create_composition_dv_parsable_open_constraint.robot
+++ b/tests/robot/COMPOSITION_TESTS/CREATE_COMPOSITION/B.6.s_create_composition_dv_parsable_open_constraint.robot
@@ -187,13 +187,21 @@ Delete Template Using API
     &{resp}=            REST.DELETE   ${admin_baseurl}/template/${template_id}
                         Set Suite Variable    ${deleteTemplateResponse}    ${resp}
                         Output Debug Info To Console
-                        Should Be Equal As Strings      ${resp.status}      200
-                        Delete All Sessions
+                        ${isDeleteTemplateFailed}     Run Keyword And Return Status
+                        ...     Should Be Equal As Strings      ${resp.status}      200
+                        IF      ${isDeleteTemplateFailed} == ${FALSE} and '${resp.status}' == '404'
+                            Log     Delete Template returned ${resp.status} code.   console=yes
+                        END
+                        #Delete All Sessions
 
 Delete Composition Using API
     IF      '${versioned_object_uid}' != '${None}'
         &{resp}         REST.DELETE    ${admin_baseurl}/ehr/${ehr_id}/composition/${versioned_object_uid}
-                        Run Keyword And Return Status   Integer    response status    204
+                        ${isDeleteCompositionFailed}     Run Keyword And Return Status
+                        ...     Integer    response status    204
                         Set Suite Variable    ${deleteCompositionResponse}    ${resp}
+                        IF      ${isDeleteCompositionFailed} == ${FALSE} and '${deleteCompositionResponse.status}' == '404'
+                            Log     Delete Composition returned ${deleteCompositionResponse.status} code.   console=yes
+                        END
                         Output Debug Info To Console
     END

--- a/tests/robot/COMPOSITION_TESTS/CREATE_COMPOSITION/B.6.t_create_composition_dv_multimedia_open_constraint.robot
+++ b/tests/robot/COMPOSITION_TESTS/CREATE_COMPOSITION/B.6.t_create_composition_dv_multimedia_open_constraint.robot
@@ -188,13 +188,21 @@ Delete Template Using API
     &{resp}=            REST.DELETE   ${admin_baseurl}/template/${template_id}
                         Set Suite Variable    ${deleteTemplateResponse}    ${resp}
                         Output Debug Info To Console
-                        Should Be Equal As Strings      ${resp.status}      200
-                        Delete All Sessions
+                        ${isDeleteTemplateFailed}     Run Keyword And Return Status
+                        ...     Should Be Equal As Strings      ${resp.status}      200
+                        IF      ${isDeleteTemplateFailed} == ${FALSE} and '${resp.status}' == '404'
+                            Log     Delete Template returned ${resp.status} code.   console=yes
+                        END
+                        #Delete All Sessions
 
 Delete Composition Using API
     IF      '${versioned_object_uid}' != '${None}'
         &{resp}         REST.DELETE    ${admin_baseurl}/ehr/${ehr_id}/composition/${versioned_object_uid}
-                        Run Keyword And Return Status   Integer    response status    204
+                        ${isDeleteCompositionFailed}     Run Keyword And Return Status
+                        ...     Integer    response status    204
                         Set Suite Variable    ${deleteCompositionResponse}    ${resp}
+                        IF      ${isDeleteCompositionFailed} == ${FALSE} and '${deleteCompositionResponse.status}' == '404'
+                            Log     Delete Composition returned ${deleteCompositionResponse.status} code.   console=yes
+                        END
                         Output Debug Info To Console
     END


### PR DESCRIPTION
## Changes

- capture 404 not found in case of delete composition and template
- skip to next keywords/test cases and log message in case of 404 was returned
