### PR TITLE
fix: provide tests folder into .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,7 @@ vulnerability_analysis.json
 application/.pgdata
 /plugin_dir/
 /plugin_config_dir/
+
+# Robot tests, as they are stored in external repository
+tests/
+*.robot


### PR DESCRIPTION
- Add tests/ folder to .gitignore file
- tests/ folder should be empty in EHRBase repo, as Robot scripts and their configuration is stored in another Github repo (integration-tests)