### PR TITLE
Consider using 'ehrbase' as configuration prefix to not interfere with Spring-Boots Server-Properties

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -115,6 +115,16 @@
             <groupId>net.bull.javamelody</groupId>
             <artifactId>javamelody-spring-boot-starter</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/application/src/main/java/org/ehrbase/application/config/EhrbaseConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/EhrbaseConfiguration.java
@@ -17,29 +17,27 @@
  */
 package org.ehrbase.application.config;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
-@ConfigurationProperties(prefix = "server")
-public class ServerConfigImp implements org.ehrbase.api.definitions.ServerConfig {
+@ConfigurationProperties(prefix = "ehrbase")
+public class EhrbaseConfiguration implements org.ehrbase.api.definitions.ServerConfig, EnvironmentAware {
 
-    @Min(1025)
-    @Max(65536)
-    private int port;
-
+    private Environment environment;
     private String nodename = "local.ehrbase.org";
     private AqlConfig aqlConfig;
     private boolean disableStrictValidation = false;
 
     public int getPort() {
-        return port;
+        return this.environment.getProperty("server.port", Integer.class);
     }
 
+    @Deprecated
     public void setPort(int port) {
-        this.port = port;
+        throw new RuntimeException("Do not set the port ...");
     }
 
     public String getNodename() {
@@ -66,6 +64,11 @@ public class ServerConfigImp implements org.ehrbase.api.definitions.ServerConfig
 
     public void setAqlConfig(AqlConfig aqlConfig) {
         this.aqlConfig = aqlConfig;
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
     }
 
     public static class AqlConfig {

--- a/application/src/main/resources/application-cloud.yml
+++ b/application/src/main/resources/application-cloud.yml
@@ -14,6 +14,11 @@ security:
 
 server:
   port: 8080
+  servlet:
+    context-path: /ehrbase
+
+
+ehrbase:
   # Optional custom server nodename
   # nodename: 'local.test.org'
 
@@ -25,5 +30,3 @@ server:
     # how many embedded jsonb_array_elements(..) are acceptable? Recommended == 1
     iterationScanDepth: 1
 
-  servlet:
-    context-path: /ehrbase

--- a/application/src/main/resources/application-docker.yml
+++ b/application/src/main/resources/application-docker.yml
@@ -29,11 +29,12 @@ security:
 
 server:
   port: 8080
-  # Optional custom server nodename
-  # nodename: 'local.test.org'
   servlet:
     context-path: /ehrbase
 
+ehrbase:
+  # Optional custom server nodename
+  # nodename: 'local.test.org'
   aqlConfig:
     # if true, WHERE clause is using jsquery, false uses SQL only
     useJsQuery: false

--- a/application/src/main/resources/application-local.yml
+++ b/application/src/main/resources/application-local.yml
@@ -34,13 +34,15 @@ spring:
         default_schema: ehr
         hbm2ddl:
           auto: " "           
+
 server:
   port: 8080
-  # Optional custom server nodename
-  # nodename: 'local.test.org'
   servlet:
     context-path: /ehrbase
 
+ehrbase:
+  # Optional custom server nodename
+  # nodename: 'local.test.org'
   aqlConfig:
     # if true, WHERE clause is using jsquery, false uses SQL only
     useJsQuery: false

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -48,8 +48,10 @@ spring:
       resourceserver:
         jwt:
           issuer-uri:  # http://localhost:8081/auth/realms/ehrbase  # Example issuer URI - or set via env var
+
   profiles:
     active: local
+
   datasource:
     driver-class-name: org.postgresql.Driver
 
@@ -128,7 +130,7 @@ logging:
   pattern:
     console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr([%X]){faint} %clr(${PID}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx'
 
-server:
+ehrbase:
   # Optional custom server nodename
   # nodename: 'local.test.org'
 

--- a/application/src/test/java/org/ehrbase/application/config/EhrbaseConfigurationTest.java
+++ b/application/src/test/java/org/ehrbase/application/config/EhrbaseConfigurationTest.java
@@ -1,0 +1,25 @@
+package org.ehrbase.application.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest(classes = {EhrbaseConfiguration.class})
+public class EhrbaseConfigurationTest {
+
+  @Autowired
+  private EhrbaseConfiguration ehrbaseConfiguration;
+
+  // 'port' is defined in 'application-local.yml'
+  // 'local' profile is activated in 'application.yml'
+  @Test
+  void testConfiguration() {
+    int port = ehrbaseConfiguration.getPort();
+    assertEquals(8080, port);
+  }
+
+}


### PR DESCRIPTION
## Changes

- change the prefix for Ehrbase configuration properties from 'server' -> 'ehrbase'
- rename 'ServerConfigImp' to 'EhrbaseConfiguration'

## Related issue

- no related issues (afaik)

## Additional information and checks
The project should avoid to use configuration-prefix `server` [because it's already used by Spring-Boot itself](https://docs.spring.io/spring-boot/docs/2.7.6/reference/html/application-properties.html#appendix.application-properties.server).

That could lead to confusion about what configuration property belongs to what configuration-class.

Imo `ehrbase` matches very well for this project.
