### PR TITLE
CDR-647 remove old participations on event_context update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1757,6 +1757,7 @@ commands:
             cd ~/projects    # NOTE: This is where the target folder w/ artifacts were persisted to in previous step.
             java -javaagent:/home/circleci/jacoco/lib/jacocoagent.jar=output=tcpserver,address=127.0.0.1 \
                  -jar application/target/application-${EHRbase_VERSION}.jar --cache.enabled=true --plugin-manager.enable=true --plugin-manager.plugin-dir='tests/test_plugin' --plugin-manager.plugin-config-dir='tests/test_plugin_config_dir'> log &
+            sleep 15s
             grep -m 1 "Started EhrBase in" <(tail -f log)
             cd ~/projects/openEHR_SDK
             jps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1755,9 +1755,9 @@ commands:
             EHRbase_VERSION=$(xmlstarlet sel -t -m "/_:project/_:version" -v .   pom.xml )
             echo ${EHRbase_VERSION}
             cd ~/projects    # NOTE: This is where the target folder w/ artifacts were persisted to in previous step.
+            echo "" > log
             java -javaagent:/home/circleci/jacoco/lib/jacocoagent.jar=output=tcpserver,address=127.0.0.1 \
-                 -jar application/target/application-${EHRbase_VERSION}.jar --cache.enabled=true --plugin-manager.enable=true --plugin-manager.plugin-dir='tests/test_plugin' --plugin-manager.plugin-config-dir='tests/test_plugin_config_dir'> log &
-            sleep 15s
+                 -jar application/target/application-${EHRbase_VERSION}.jar --cache.enabled=true --plugin-manager.enable=true --plugin-manager.plugin-dir='tests/test_plugin' --plugin-manager.plugin-config-dir='tests/test_plugin_config_dir'>> log &
             grep -m 1 "Started EhrBase in" <(tail -f log)
             cd ~/projects/openEHR_SDK
             jps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - use caffeine cache instead of ehcache as ehcache has unnecessary blocking([#1007](https://github.com/ehrbase/ehrbase/pull/1007))
 - remove unnecessary DB queries([#1007](https://github.com/ehrbase/ehrbase/pull/1007))
  ### Fixed 
+- maintain a correct history of participations([#1016](https://github.com/ehrbase/ehrbase/pull/1016))
 
 ## [0.23.0]
  ### Added

--- a/base/src/main/resources/db/migration/V76__move_deleted_participations_to_history.sql
+++ b/base/src/main/resources/db/migration/V76__move_deleted_participations_to_history.sql
@@ -1,0 +1,48 @@
+/*
+ * Modifications copyright (C) 2019 Vitasystems GmbH and Hannover Medical School.
+
+ * This file is part of Project EHRbase
+
+ * Copyright (c) 2015 Christian Chevalley
+ * This file is part of Project Ethercis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ALTER TABLE ehr.participation DISABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.participation_history DISABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.event_context DISABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.event_context_history DISABLE ROW LEVEL SECURITY;
+-- delete all participations that do not match any currently active event context -> trigger will move them to history
+DELETE FROM ehr.participation p1
+       WHERE NOT EXISTS (SELECT ec.id
+                         FROM ehr.event_context ec
+                         WHERE p1.event_context=ec.id AND p1.sys_transaction = ec.sys_transaction);
+
+-- remove all participation's from history that do not have an associated event_context_history row
+/* This is the case if i.e. a plugin was used to rollback a composition to a previous version,
+ leaving orphans in the participation_history table after moving them there from the participation table */
+DELETE FROM ehr.participation_history ph
+       WHERE NOT EXISTS(SELECT ech.id
+                        FROM ehr.event_context_history ech
+                        WHERE ech.id=ph.event_context AND ech.sys_transaction=ph.sys_transaction);
+
+-- set the correct sys_period for all participation_history rows
+UPDATE ehr.participation_history ph
+SET sys_period = (SELECT ech.sys_period
+                  FROM ehr.event_context_history ech
+                  WHERE ech.id=ph.event_context AND ech.sys_transaction=ph.sys_transaction);
+
+ALTER TABLE ehr.participation ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.participation_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.event_context ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ehr.event_context_history ENABLE ROW LEVEL SECURITY;

--- a/service/src/main/java/org/ehrbase/dao/access/jooq/ContextAccess.java
+++ b/service/src/main/java/org/ehrbase/dao/access/jooq/ContextAccess.java
@@ -52,6 +52,7 @@ import org.ehrbase.dao.access.support.DataAccess;
 import org.ehrbase.dao.access.util.TransactionTime;
 import org.ehrbase.jooq.pg.tables.records.EventContextHistoryRecord;
 import org.ehrbase.jooq.pg.tables.records.EventContextRecord;
+import org.ehrbase.jooq.pg.tables.records.ParticipationHistoryRecord;
 import org.ehrbase.jooq.pg.tables.records.ParticipationRecord;
 import org.ehrbase.jooq.pg.tables.records.PartyIdentifiedRecord;
 import org.ehrbase.serialisation.dbencoding.RawJson;
@@ -176,19 +177,13 @@ public class ContextAccess extends DataAccess implements I_ContextAccess {
                     // retrieve performer
                     PartyProxy performer = new PersistedPartyProxy(domainAccess).retrieve(historyRecord.getPerformer());
 
-                    DvInterval<DvDateTime> startTime = null;
-                    if (historyRecord.getTimeLower() != null) { // start time null value is allowed for participation
-                        startTime = new DvInterval<>(
-                                new RecordedDvDateTime()
-                                        .decodeDvDateTime(historyRecord.getTimeLower(), historyRecord.getTimeLowerTz()),
-                                new RecordedDvDateTime()
-                                        .decodeDvDateTime(
-                                                historyRecord.getTimeUpper(), historyRecord.getTimeUpperTz()));
-                    }
-                    DvCodedText mode = null;
+                    DvInterval<DvDateTime> startTime = getStartTimeInterval(historyRecord);
+                    DvCodedText mode;
                     if (historyRecord.getMode() != null) {
                         mode = (DvCodedText)
                                 new RecordedDvCodedText().fromDB(historyRecord, PARTICIPATION_HISTORY.MODE);
+                    } else {
+                        mode = null;
                     }
 
                     Participation participation = new Participation(
@@ -509,22 +504,12 @@ public class ContextAccess extends DataAccess implements I_ContextAccess {
                     // retrieve performer
                     PartyProxy performer = new PersistedPartyProxy(this).retrieve(participationRecord.getPerformer());
 
-                    DvInterval<DvDateTime> startTime = null;
-                    if (participationRecord.getTimeLower()
-                            != null) { // start time null value is allowed for participation
-                        startTime = new DvInterval<>(
-                                new RecordedDvDateTime()
-                                        .decodeDvDateTime(
-                                                participationRecord.getTimeLower(),
-                                                participationRecord.getTimeLowerTz()),
-                                new RecordedDvDateTime()
-                                        .decodeDvDateTime(
-                                                participationRecord.getTimeUpper(),
-                                                participationRecord.getTimeUpperTz()));
-                    }
-                    DvCodedText mode = null;
+                    DvInterval<DvDateTime> startTime = getStartTimeInterval(participationRecord);
+                    DvCodedText mode;
                     if (participationRecord.getMode() != null) {
                         mode = (DvCodedText) new RecordedDvCodedText().fromDB(participationRecord, PARTICIPATION.MODE);
+                    } else {
+                        mode = null;
                     }
 
                     Participation participation = new Participation(
@@ -555,6 +540,32 @@ public class ContextAccess extends DataAccess implements I_ContextAccess {
                 eventContextRecord.getLocation(),
                 concept,
                 otherContext);
+    }
+
+    private static DvInterval<DvDateTime> getStartTimeInterval(ParticipationHistoryRecord historyRecord) {
+        if (historyRecord.getTimeLower() != null) { // start time null value is allowed for participation
+            return new DvInterval<>(
+                    new RecordedDvDateTime()
+                            .decodeDvDateTime(historyRecord.getTimeLower(), historyRecord.getTimeLowerTz()),
+                    new RecordedDvDateTime()
+                            .decodeDvDateTime(historyRecord.getTimeUpper(), historyRecord.getTimeUpperTz()));
+        } else {
+            return null;
+        }
+    }
+
+    private static DvInterval<DvDateTime> getStartTimeInterval(ParticipationRecord participationRecord) {
+        if (participationRecord.getTimeLower() != null) {
+            // start time null value is allowed for participation
+            return new DvInterval<>(
+                    new RecordedDvDateTime()
+                            .decodeDvDateTime(participationRecord.getTimeLower(), participationRecord.getTimeLowerTz()),
+                    new RecordedDvDateTime()
+                            .decodeDvDateTime(
+                                    participationRecord.getTimeUpper(), participationRecord.getTimeUpperTz()));
+        } else {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Changes

<!-- Describe your changes in a short list -->

- replace old participations on updating an event_context for correct representation in all composition versions

## Related issue

<!-- Use one of the closing keywords like "Closes" or "Fixes" to link the corresponding issue (see https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for help) -->


## Additional information and checks

<!-- If there are more checks or data to be provided, put it here -->

- [x] Pull request linked in changelog
