### PR TITLE
fix: removing non required trigger on audit details table

### DIFF
--- a/base/db-setup/migrate_to_cloud_db_setup.sql
+++ b/base/db-setup/migrate_to_cloud_db_setup.sql
@@ -24,12 +24,6 @@ EXECUTE PROCEDURE ext.versioning('sys_period', 'ehr.folder_items_history', 'true
 
 CREATE TRIGGER versioning_trigger
   BEFORE INSERT OR UPDATE OR DELETE
-  ON ehr.audit_details
-  FOR EACH ROW
-EXECUTE PROCEDURE ext.versioning('sys_period', 'ehr.audit_details_history', true);
-
-CREATE TRIGGER versioning_trigger
-  BEFORE INSERT OR UPDATE OR DELETE
   ON ehr.status
   FOR EACH ROW
 EXECUTE PROCEDURE ext.versioning('sys_period', 'ehr.status_history', true);


### PR DESCRIPTION
## Changes

Updating the `migrate_to_cloud_db_setup.sql` script to so that it doesn't create a `versioning_trigger` on the `ehr.audit_details` table. There is not a history table (`ehr.audit_details_history`) so it appears like the trigger here is incorrect. 

## Related issue

There's no related issue. We had run the script which resulted in us having a trigger on the `audit_details` table that was causing us an error when we tried to create an EHR as the trigger couldn't write to the non-existent `ehr.audit_details_history` table.


## Additional information and checks

I'm not sure we need to include anything in the changelog here. The change is just to avoid anyone else running the migration script and being affected by the same issue.
