### PR TITLE
CDR-690 folder fixes + cleanup

### DIFF
--- a/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
@@ -21,7 +21,11 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.InvalidApiParameterException;
@@ -301,24 +305,20 @@ public abstract class BaseController {
         return contentType;
     }
 
-    protected Optional<OffsetDateTime> getVersionAtTimeParam() {
-        Map<String, String> queryParams = ServletUriComponentsBuilder.fromCurrentRequest()
-                .build()
-                .getQueryParams()
-                .toSingleValueMap();
-
-        String versionAtTime = queryParams.get("version_at_time");
-        if (StringUtils.isBlank(versionAtTime)) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(OffsetDateTime.parse(UriUtils.decode(versionAtTime, StandardCharsets.UTF_8)));
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException(
-                    "Value '" + versionAtTime + "' is not valid for version_at_time parameter. "
-                            + "Value must be in the extended ISO 8601 format.",
-                    e);
-        }
+    protected static Optional<OffsetDateTime> decodeVersionAtTime(String versionAtTimeParam) {
+        return Optional.ofNullable(versionAtTimeParam)
+                .filter(StringUtils::isNotBlank)
+                .map(s -> UriUtils.decode(s, StandardCharsets.UTF_8))
+                .map(s -> {
+                    try {
+                        return OffsetDateTime.parse(s);
+                    } catch (DateTimeParseException e) {
+                        throw new IllegalArgumentException(
+                                "Value '%s' is not valid for version_at_time parameter. "
+                                        + "Value must be in the extended ISO 8601 format."
+                                                .formatted(versionAtTimeParam),
+                                e);
+                    }
+                });
     }
 }

--- a/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
@@ -18,7 +18,6 @@
 package org.ehrbase.rest;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
@@ -308,15 +307,15 @@ public abstract class BaseController {
     protected static Optional<OffsetDateTime> decodeVersionAtTime(String versionAtTimeParam) {
         return Optional.ofNullable(versionAtTimeParam)
                 .filter(StringUtils::isNotBlank)
-                .map(s -> UriUtils.decode(s, StandardCharsets.UTF_8))
+                // revert application/x-www-form-urlencoded
+                .map(s -> s.replace(' ', '+'))
                 .map(s -> {
                     try {
                         return OffsetDateTime.parse(s);
                     } catch (DateTimeParseException e) {
                         throw new IllegalArgumentException(
-                                "Value '%s' is not valid for version_at_time parameter. "
-                                        + "Value must be in the extended ISO 8601 format."
-                                                .formatted(versionAtTimeParam),
+                                "Value '%s' is not valid for version_at_time parameter. Value must be in the extended ISO 8601 format."
+                                        .formatted(versionAtTimeParam),
                                 e);
                     }
                 });

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
@@ -374,14 +374,13 @@ public class OpenehrCompositionController extends BaseController implements Comp
         int version = extractVersionFromVersionUid(versionedObjectUid);
         if (version == 0) {
             // case GET {versioned_object_uid}{?version_at_time}
-            Optional<OffsetDateTime> temporal = getVersionAtTimeParam();
-            if (versionAtTime != null && temporal.isPresent()) {
+            Optional<OffsetDateTime> temporal = decodeVersionAtTime(versionAtTime);
+            if (temporal.isPresent()) {
                 // when optional request parameter was provided, retrieve version according to given time
-
-                Optional<Integer> versionFromTimestamp = Optional.ofNullable(compositionService.getVersionByTimestamp(
-                        compositionUid, temporal.get().toLocalDateTime()));
-                version = versionFromTimestamp.orElseThrow(() -> new ObjectNotFoundException(
-                        COMPOSITION, "No composition version matching the timestamp condition"));
+                version = temporal.map(OffsetDateTime::toLocalDateTime)
+                        .map(t -> compositionService.getVersionByTimestamp(compositionUid, t))
+                        .orElseThrow(() -> new ObjectNotFoundException(
+                                COMPOSITION, "No composition version matching the timestamp condition"));
             } // else continue with fallback: latest version
         }
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -148,11 +148,11 @@ public class OpenehrDirectoryController extends BaseController implements Direct
     @GetMapping(path = "/{ehr_id}/directory/{version_uid}")
     public ResponseEntity<DirectoryResponseData> getFolderInDirectory(
             @PathVariable(name = "ehr_id") UUID ehrId,
-            @PathVariable(name = "version_uid") ObjectVersionId rawVersionUid,
+            @PathVariable(name = "version_uid") ObjectVersionId versionUid,
             @RequestParam(name = "path", required = false) String path,
             @RequestHeader(name = HttpHeaders.ACCEPT, defaultValue = MediaType.APPLICATION_JSON_VALUE) String accept) {
 
-        ObjectVersionId versionUid = parseAndValidateVersionUid(rawVersionUid.getValue());
+        validateVersionUid(versionUid.getValue());
 
         // Check if EHR for the folder exists
         ehrService.checkEhrExists(ehrId);
@@ -172,9 +172,9 @@ public class OpenehrDirectoryController extends BaseController implements Direct
         return createDirectoryResponse(HttpMethod.GET, RETURN_REPRESENTATION, accept, foundFolder.get(), ehrId);
     }
 
-    private ObjectVersionId parseAndValidateVersionUid(String versionUidStr) {
+    private void validateVersionUid(String versionUidStr) {
         if (StringUtils.isEmpty(versionUidStr)) {
-            return null;
+            throw new InvalidApiParameterException("a valid  must be provided");
         }
 
         ObjectVersionId versionUid = new ObjectVersionId(versionUidStr);
@@ -186,7 +186,6 @@ public class OpenehrDirectoryController extends BaseController implements Direct
         } catch (UnsupportedOperationException e) {
             throw new InvalidApiParameterException(e.getMessage(), e);
         }
-        return versionUid;
     }
 
     @EhrbaseAuthorization(permission = EhrbasePermission.EHRBASE_DIRECTORY_READ)

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -33,7 +33,6 @@ import org.ehrbase.api.authorization.EhrbasePermission;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
 import org.ehrbase.api.service.DirectoryService;
-import org.ehrbase.api.service.EhrService;
 import org.ehrbase.response.openehr.DirectoryResponseData;
 import org.ehrbase.rest.BaseController;
 import org.ehrbase.rest.openehr.specification.DirectoryApiSpecification;
@@ -69,11 +68,8 @@ public class OpenehrDirectoryController extends BaseController implements Direct
 
     private final DirectoryService directoryService;
 
-    private final EhrService ehrService;
-
-    public OpenehrDirectoryController(DirectoryService directoryService, EhrService ehrService) {
+    public OpenehrDirectoryController(DirectoryService directoryService) {
         this.directoryService = directoryService;
-        this.ehrService = ehrService;
     }
 
     /**

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -156,6 +156,10 @@ public class OpenehrDirectoryController extends BaseController implements Direct
 
         assertValidPath(path);
 
+        if (versionUid != null && versionUid.isBranch()) {
+            throw new InvalidApiParameterException("Version branching is not supported");
+        }
+
         // Get the folder entry from database
         Optional<Folder> foundFolder = directoryService.get(ehrId, versionUid, path);
         if (foundFolder.isEmpty()) {
@@ -185,7 +189,7 @@ public class OpenehrDirectoryController extends BaseController implements Direct
 
         final Optional<Folder> foundFolder;
         // Get the folder entry from database
-        Optional<OffsetDateTime> temporal = getVersionAtTimeParam();
+        Optional<OffsetDateTime> temporal = decodeVersionAtTime(versionAtTime);
 
         if (temporal.isPresent()) {
             foundFolder = directoryService.getByTime(ehrId, temporal.get(), path);

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -154,9 +154,6 @@ public class OpenehrDirectoryController extends BaseController implements Direct
 
         validateVersionUid(versionUid.getValue());
 
-        // Check if EHR for the folder exists
-        ehrService.checkEhrExists(ehrId);
-
         assertValidPath(path);
 
         // Get the folder entry from database

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -148,7 +148,7 @@ public class OpenehrDirectoryController extends BaseController implements Direct
             @RequestParam(name = "path", required = false) String path,
             @RequestHeader(name = HttpHeaders.ACCEPT, defaultValue = MediaType.APPLICATION_JSON_VALUE) String accept) {
 
-        validateVersionUid(versionUid.getValue());
+        validateVersionUid(versionUid);
 
         assertValidPath(path);
 
@@ -158,19 +158,18 @@ public class OpenehrDirectoryController extends BaseController implements Direct
             throw new ObjectNotFoundException(
                     "DIRECTORY",
                     String.format(
-                            "Folder with id %s and path %s does not exist.",
-                            versionUid.toString(), path != null ? path : "/"));
+                            "Folder with id %s and path %s does not exist.", versionUid, path != null ? path : "/"));
         }
 
         return createDirectoryResponse(HttpMethod.GET, RETURN_REPRESENTATION, accept, foundFolder.get(), ehrId);
     }
 
-    private void validateVersionUid(String versionUidStr) {
+    private void validateVersionUid(ObjectVersionId versionUid) {
+        String versionUidStr = versionUid.getValue();
         if (StringUtils.isEmpty(versionUidStr)) {
             throw new InvalidApiParameterException("a valid  must be provided");
         }
 
-        ObjectVersionId versionUid = new ObjectVersionId(versionUidStr);
         try {
             versionUid.getCreatingSystemId();
             if (versionUid.isBranch()) {

--- a/service/src/main/java/org/ehrbase/service/DirectoryServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/DirectoryServiceImp.java
@@ -94,17 +94,13 @@ public class DirectoryServiceImp extends BaseServiceImp implements InternalDirec
 
     @Override
     public Optional<Folder> getByTime(UUID ehrId, OffsetDateTime time, @Nullable String path) {
+        List<EhrFolderRecord> ehrFolderRecords =
+                ehrFolderRepository.fromHistory(ehrFolderRepository.getByTime(ehrId, time));
 
-        List<EhrFolderRecord> ehrFolderRecords;
-
-        ehrFolderRecords = ehrFolderRepository.fromHistory(ehrFolderRepository.getByTime(ehrId, time));
-
-        if (!ehrFolderRecords.isEmpty()) {
-            return findByPath(ehrFolderRepository.from(ehrFolderRecords), StringUtils.split(path, '/'));
-        } else {
-
+        if (ehrFolderRecords.isEmpty()) {
             return Optional.empty();
         }
+        return findByPath(ehrFolderRepository.from(ehrFolderRecords), StringUtils.split(path, '/'));
     }
 
     private Optional<Folder> findByPath(Folder root, String[] path) {

--- a/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/EhrServiceImp.java
@@ -477,7 +477,7 @@ public class EhrServiceImp extends BaseServiceImp implements EhrService {
     @Override
     public void adminDeleteEhr(UUID ehrId) {
 
-        ehrFolderRepository.adminDelete(ehrId);
+        ehrFolderRepository.adminDelete(ehrId, null);
         I_EhrAccess ehrAccess = I_EhrAccess.retrieveInstance(getDataAccess(), ehrId);
         ehrAccess.adminDeleteEhr();
     }


### PR DESCRIPTION
-simplified handling of version_at_time parameter
-introduced term 'head' for non-history ("active") folders -fail cleanly when branched versions are provided
-explicitly handle ehrFoldersIdx in Repository
-more readable union queries
-fix: same sysPeriod values in all folders of a version -fix: coordinate sysPeriod values between versions -fix: sysPeriod: min. 1 microsecond between upper and lower


# Changes

> Describe your changes in a short and concise list.

# Related issue

> Reference related issues, and use one of the [closing keywords, e.g. closes or fixes](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link the corresponding issue, if any.

# Additional information 

> Provide additional information for this change, if needed.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 