### PR TITLE
Enabled swagger ui working with Spring Boot 3

### DIFF
--- a/application/src/main/java/org/ehrbase/application/config/SwaggerConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/SwaggerConfiguration.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
@@ -52,7 +52,6 @@ import org.springframework.security.web.SecurityFilterChain;
  * @author Jake Smolka
  * @since 1.0.0
  */
-@Deprecated
 @Configuration
 @EnableWebSecurity
 @ConditionalOnProperty(prefix = "security", name = "auth-type", havingValue = "oauth")

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -120,7 +120,7 @@
         <postgresql.version>42.5.3</postgresql.version>
         <prometheus.version>1.11.3</prometheus.version>
         <spring-boot.version>3.1.1</spring-boot.version>
-        <springdoc-openapi.version>1.6.6</springdoc-openapi.version>
+        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
         <!-- not used erhbase but needed for the version plugin -->
         <log4j.version>2.20.0</log4j.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
@@ -325,7 +325,7 @@
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-ui</artifactId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc-openapi.version}</version>
             </dependency>
             <dependency>

--- a/rest-ehr-scape/pom.xml
+++ b/rest-ehr-scape/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>

--- a/rest-openehr/pom.xml
+++ b/rest-openehr/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>


### PR DESCRIPTION
# Changes

- Update Swagger UI dependency to work with Spring Boot 3
- Remove deprecate from Oauth Security Configuration