### PR TITLE
Add plugin path to sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,7 +26,8 @@ sonar.sources=api/src/main/java/, \
   jooq-pq/src/main/java/, \
   rest-ehr-scape/src/main/java/, \
   rest-openehr/src/main/java/, \
-  service/src/main/java/
+  service/src/main/java/, \
+  plugin/src/main/java
 sonar.java.binaries=**/target/**
 sonar.exclusions=**/test/**
 sonar.coverage.exclusions=**/test/**


### PR DESCRIPTION
# Changes

Sonar project analysis is not going over the plugin path. Added it to the analysis.
