### PR TITLE
Add explicit ant matcher wrappers in the auth security configs

### DIFF
--- a/application/src/main/java/org/ehrbase/application/config/security/BasicAuthSecurityConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/security/BasicAuthSecurityConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
  * {@link Configuration} for Basic authentication.
@@ -75,8 +76,10 @@ public class BasicAuthSecurityConfiguration {
         http.addFilterBefore(new SecurityFilter(), BasicAuthenticationFilter.class);
 
         http.cors(withDefaults())
-                .csrf(c -> c.ignoringRequestMatchers("/rest/**"))
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/rest/admin/**", "/management/**")
+                .csrf(c -> c.ignoringRequestMatchers(AntPathRequestMatcher.antMatcher("/rest/**")))
+                .authorizeHttpRequests(auth -> auth.requestMatchers(
+                                AntPathRequestMatcher.antMatcher("/rest/admin/**"),
+                                AntPathRequestMatcher.antMatcher("/management/**"))
                         .hasRole(ADMIN)
                         .anyRequest()
                         .hasAnyRole(ADMIN, SecurityProperties.USER))

--- a/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
@@ -100,10 +100,11 @@ public class OAuth2SecurityConfiguration {
         http.cors(withDefaults())
                 .authorizeHttpRequests(auth -> {
                     AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry registry =
-                            auth.requestMatchers(AntPathRequestMatcher.antMatcher("/rest/admin/**")).hasRole(adminRole);
+                            auth.requestMatchers(AntPathRequestMatcher.antMatcher("/rest/admin/**"))
+                                    .hasRole(adminRole);
 
-                    var managementAuthorizedUrl =
-                            registry.requestMatchers(AntPathRequestMatcher.antMatcher(this.managementWebEndpointProperties.getBasePath() + "/**"));
+                    var managementAuthorizedUrl = registry.requestMatchers(AntPathRequestMatcher.antMatcher(
+                            this.managementWebEndpointProperties.getBasePath() + "/**"));
 
                     switch (managementEndpointsAccessType) {
                         case ADMIN_ONLY ->

--- a/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
+++ b/application/src/main/java/org/ehrbase/application/config/security/OAuth2SecurityConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
  * {@link Configuration} for OAuth2 authentication.
@@ -99,10 +100,10 @@ public class OAuth2SecurityConfiguration {
         http.cors(withDefaults())
                 .authorizeHttpRequests(auth -> {
                     AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry registry =
-                            auth.requestMatchers("/rest/admin/**").hasRole(adminRole);
+                            auth.requestMatchers(AntPathRequestMatcher.antMatcher("/rest/admin/**")).hasRole(adminRole);
 
                     var managementAuthorizedUrl =
-                            registry.requestMatchers(this.managementWebEndpointProperties.getBasePath() + "/**");
+                            registry.requestMatchers(AntPathRequestMatcher.antMatcher(this.managementWebEndpointProperties.getBasePath() + "/**"));
 
                     switch (managementEndpointsAccessType) {
                         case ADMIN_ONLY ->


### PR DESCRIPTION
# Changes

Add explicit ant matcher wrapper around ant expressions in the Basic and OAuth2 Security Configs.

# Additional info

```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration': Unsatisfied dependency expressed through method 'setFilterChains' parameter 0: Error creating bean with name 'filterChain' defined in class path resource [org/ehrbase/application/config/security/BasicAuthSecurityConfiguration.class]: Failed to instantiate [org.springframework.security.web.SecurityFilterChain]: Factory method 'filterChain' threw exception with message: This method cannot decide whether these patterns are Spring MVC patterns or not. If this endpoint is a Spring MVC endpoint, please use requestMatchers(MvcRequestMatcher); otherwise, please use requestMatchers(AntPathRequestMatcher).
2023-11-01T07:49:22.662357234Z 
2023-11-01T07:49:22.662360670Z This is because there is more than one mappable servlet in your servlet context: {org.springframework.web.servlet.DispatcherServlet=[/]}.
2023-11-01T07:49:22.662364749Z 
2023-11-01T07:49:22.662367988Z For each MvcRequestMatcher, call MvcRequestMatcher#setServletPath to indicate the servlet path.
2023-11-01T07:49:22.662371595Z 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.resolveMethodArguments(AutowiredAnnotationBeanPostProcessor.java:825)
2023-11-01T07:49:22.662375859Z 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:778)
2023-11-01T07:49:22.662380088Z 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:145)
2023-11-01T07:49:22.662383692Z 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:483)
2023-11-01T07:49:22.662387588Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1416)
2023-11-01T07:49:22.662391462Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:597)
2023-11-01T07:49:22.662396949Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520)
2023-11-01T07:49:22.662400732Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326)
2023-11-01T07:49:22.662404453Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
2023-11-01T07:49:22.662408435Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:324)
2023-11-01T07:49:22.662412051Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200)
2023-11-01T07:49:22.662415799Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:973)
2023-11-01T07:49:22.662430189Z 	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:942)
2023-11-01T07:49:22.662434013Z 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:608)
2023-11-01T07:49:22.662437971Z 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146)
2023-11-01T07:49:22.662441580Z 	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:734)
2023-11-01T07:49:22.662445286Z 	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:436)
2023-11-01T07:49:22.662448753Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:312)
2023-11-01T07:49:22.662453106Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1306)
2023-11-01T07:49:22.662456641Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1295)
2023-11-01T07:49:22.662460334Z 	at org.ehrbase.application.EhrBase.main(EhrBase.java:44)
2023-11-01T07:49:22.662463899Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-11-01T07:49:22.662467648Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
2023-11-01T07:49:22.662471049Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
2023-11-01T07:49:22.662474579Z 	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
2023-11-01T07:49:22.662478369Z 	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
2023-11-01T07:49:22.662482118Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:95)
2023-11-01T07:49:22.662486725Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
2023-11-01T07:49:22.662490267Z 	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65)
```

