### PR TITLE
CDR-1379 Prevent sonar run for dependabot git actor

### DIFF
--- a/.github/workflows/build-and-test-postgres.yml
+++ b/.github/workflows/build-and-test-postgres.yml
@@ -36,13 +36,15 @@ jobs:
         run: mvn spotless:check
 
       - name: Maven - Verify and Package
-        run: mvn -B -U -Dmaven.test.failure.ignore=true verify package
+        run: mvn --batch-mode -U -Dmaven.test.failure.ignore=true verify package
 
       - name: Sonar - Analyze
+        # Dependabot has no access to the SONAR_TOKEN secret, so we need to skip sonar.
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn -B sonar:sonar \
+          mvn --batch-mode sonar:sonar \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.organization=ehrbase \
             -Dsonar.projectKey=ehrbase_ehrbase \
@@ -191,7 +193,7 @@ jobs:
   integration-test-results:
     name: Robot-Collect
     if: ${{ always() }}
-    needs: [ integration-test-run ]
+    needs: [ build, integration-test-run ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Changes

Prevent sonar anylize and publish in case the git actor is dependabot. The reason for this is that the bot does not have access to the secrets -> [GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [x] Code has been reviewed 