### PR TITLE
Add default handler for Unsupported operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Changed `StoredQueryRepository` methods to only accept `StoredQueryQualifiedName` as arguments ([#1258](https://github.com/ehrbase/ehrbase/pull/1258))
 * Changed docker image and run integration test against it instead of the ehrbase.jar ([#1259](https://github.com/ehrbase/ehrbase/pull/1259))
  ### Fixed 
+* Delete Contribution now returns a 501 Not Implemented instead of 500 as it's not supported since 2.0.0 ([#1278](https://github.com/ehrbase/ehrbase/pull/1278))
 
 ## [2.0.0]
   Welcome to EHRbase 2.0.0. This major release contains a complete overhaul of the data structure and 

--- a/configuration/src/main/java/org/ehrbase/configuration/exception/DefaultExceptionHandler.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/exception/DefaultExceptionHandler.java
@@ -163,6 +163,13 @@ public class DefaultExceptionHandler {
         return handleExceptionInternal(ex, message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // 501 - not implemented
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<Object> handleUncaughtException(UnsupportedOperationException ex) {
+        var message = "The current operation is not supported by this server. Please contact your administrator.";
+        return handleExceptionInternal(ex, message, HttpStatus.NOT_IMPLEMENTED);
+    }
+
     private ResponseEntity<Object> handleExceptionInternal(Exception ex, String message, HttpStatusCode status) {
         return handleExceptionInternal(ex, message, status, HttpHeaders.EMPTY);
     }

--- a/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/controller/CompositionController.java
+++ b/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/controller/CompositionController.java
@@ -72,11 +72,11 @@ public class CompositionController extends BaseController {
 
     @PostMapping
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/ehr/{ehr_id}/composition](./index.html?urls.primaryName=1.%20openEHR%20API#/COMPOSITION/createComposition)",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<CompositionWriteRestResponseData> createComposition(
             @RequestParam(value = "format", defaultValue = "XML") CompositionFormat format,
             @RequestParam(value = "templateId", required = false) String templateId,
@@ -109,11 +109,11 @@ public class CompositionController extends BaseController {
 
     @GetMapping(path = "/{uid}")
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/ehr/{ehr_id}/composition/{versioned_object_uid}](./index.html?urls.primaryName=1.%20openEHR%20API#/COMPOSITION/getComposition)",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<CompositionResponseData> getComposition(
             @PathVariable("uid") String compositionUid,
             @RequestParam(value = "format", defaultValue = "XML") CompositionFormat format) {
@@ -157,11 +157,11 @@ public class CompositionController extends BaseController {
 
     @PutMapping(path = "/{uid}")
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/ehr/{ehr_id}/composition/{versioned_object_uid}](./index.html?urls.primaryName=1.%20openEHR%20API#/COMPOSITION/updateComposition)",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<ActionRestResponseData> update(
             @PathVariable("uid") String compositionUid,
             @RequestParam(value = "format", defaultValue = "XML") CompositionFormat format,
@@ -198,11 +198,11 @@ public class CompositionController extends BaseController {
 
     @DeleteMapping(path = "/{uid}")
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/ehr/{ehr_id}/composition/{versioned_object_uid}](./index.html?urls.primaryName=1.%20openEHR%20API#/COMPOSITION/deleteComposition)",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<ActionRestResponseData> delete(@PathVariable("uid") String compositionUid) {
 
         ObjectVersionId objectVersionId = getObjectVersionId(compositionUid);

--- a/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/controller/TemplateController.java
+++ b/rest-ehr-scape/src/main/java/org/ehrbase/rest/ehrscape/controller/TemplateController.java
@@ -64,11 +64,11 @@ public class TemplateController extends BaseController {
 
     @GetMapping(path = "/{templateId}/example")
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/definition/template/adl1.4/{template_id}/example](./index.html?urls.primaryName=1.%20openEHR%20API#/ADL%201.4%20TEMPLATE/getTemplateExample)",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<String> getTemplateExample(
             @PathVariable(value = "templateId") String templateId,
             @RequestParam(value = "format", defaultValue = "FLAT") CompositionFormat format) {
@@ -93,12 +93,12 @@ public class TemplateController extends BaseController {
 
     @GetMapping(path = "/{templateId}")
     @Operation(
-            summary = "Deprecated since 1.0.0 and marked for removal",
+            summary = "Deprecated since 2.0.0 and marked for removal",
             description =
                     "Replaced by [/rest/openehr/v1/definition/template/adl1.4/{template_id}/webtemplate](./index.html?urls.primaryName=1.%20openEHR%20API#/TEMPLATE/getWebTemplate). "
                             + "Note the replacement endpoint provides the Web-Template as it is, without wrapping it in a `webTemplate` property.",
             deprecated = true)
-    @Deprecated(since = "1.0.0", forRemoval = true)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public ResponseEntity<TemplateResponseData> getTemplate(@PathVariable(value = "templateId") String templateId) {
         TemplateResponseData responseData = new TemplateResponseData();
         responseData.setWebTemplate(new Filter().filter(templateService.findTemplate(templateId)));

--- a/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminContributionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/admin/AdminContributionController.java
@@ -21,6 +21,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.ehrbase.api.rest.HttpRestContext.EHR_ID;
 import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -114,22 +115,10 @@ public class AdminContributionController extends BaseController {
     }
 
     @DeleteMapping(path = "/{ehr_id}/contribution/{contribution_id}")
+    @Operation(summary = "Not supported since 2.0.0")
     @ApiResponses(
             value = {
-                @ApiResponse(
-                        responseCode = "200",
-                        description = "Contribution has been deleted successfully.",
-                        headers = {
-                            @Header(
-                                    name = CONTENT_TYPE,
-                                    description = RESP_CONTENT_TYPE_DESC,
-                                    schema = @Schema(implementation = MediaType.class))
-                        }),
-                @ApiResponse(responseCode = "401", description = "Client credentials invalid or have expired."),
-                @ApiResponse(
-                        responseCode = "403",
-                        description = "Client does not have permission to access since admin role is missing."),
-                @ApiResponse(responseCode = "404", description = "EHR or Contribution could not be found.")
+                @ApiResponse(responseCode = "501", description = "Contribution delete is not supported since 2.0.0."),
             })
     public ResponseEntity<AdminDeleteResponseData> deleteContribution(
             @Parameter(description = "Target EHR id to update contribution inside.", required = true)


### PR DESCRIPTION
# Changes

Admin Delete for contributions is not supported with EHRbase 2.0.0.
This PR takes care of nicely handling the UnsupportedOperationException.
