### PR TITLE
Add permissions for dorny/test-reporter and robot reporter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,6 +23,11 @@ jobs:
   build-maven:
     name: Build-Maven
     runs-on: ubuntu-latest
+    # required by the dorny/test-reporter@v1 to be able to write status updates
+    # see https://github.com/dorny/test-reporter/pull/174
+    permissions:
+      statuses: write
+      checks: write
     outputs:
       # Map the step outputs to job outputs
       ehrbase-version: ${{ steps.get_version.outputs.ehrbase-version }}
@@ -258,6 +263,10 @@ jobs:
       integration-test-run
     ]
     runs-on: ubuntu-latest
+    # allow to write comments to the issue
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Download - Robot results
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# Changes

Looks like, the test reporter does not have enough permission to create the junit/robot reports for a PR, that is not created by an ehrbase org member. See -> https://github.com/ehrbase/ehrbase/pull/1303

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 