### PR TITLE
Adjust permission for dorney test-reporter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,10 +23,10 @@ jobs:
   build-maven:
     name: Build-Maven
     runs-on: ubuntu-latest
-    # required by the dorny/test-reporter@v1 to be able to write status updates
-    # see https://github.com/dorny/test-reporter/pull/174
+    # Allows dorny/test-reporter to collect results for pull request triggered from a forked repository.
     permissions:
-      statuses: write
+      contents: read
+      actions: read
       checks: write
     outputs:
       # Map the step outputs to job outputs


### PR DESCRIPTION
# Changes

Grant read on contents and actions for the dorney test-report action. This allows workflows triggered for PRs  from forked repositories to collect test results. 

Currently failing -> https://github.com/ehrbase/ehrbase/pull/1303.

Permissions overview:

actions:read -> https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions

contents:read -> https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 