### PR TITLE
Change from GITHUB_TOKEN to PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -286,7 +286,7 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: joonvena/robotframework-reporter-action@v2.4
         with:
-          gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          gh_access_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           report_path: ./tests/report
           show_passed_tests: false
 


### PR DESCRIPTION
# Changes

Use PERSONAL_ACCESS_TOKEN for reporting the Robot Report