### PR TITLE
Perform git checkout for JUnit collect workflow

### DIFF
--- a/.github/workflows/collect-junit-results.yml
+++ b/.github/workflows/collect-junit-results.yml
@@ -35,6 +35,12 @@ jobs:
           merge-multiple: true
           path: ./
 
+      # checkout because dorny/test-reporter needs to read tracked files
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
       - name: Collect - JUnit Reports
         uses: dorny/test-reporter@v1
         # Dependabot has not enough rights to add the report to the run.


### PR DESCRIPTION
# Changes

Due to the fact that we trick out dorny/test-reporter by pre-downloading the reports and not using an artifact, it now need the whole github checkout to be present.

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 