### PR TITLE
[CDR-1471] Align template controller with latest spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  ### Added
 - Create a `ehrbase` user to run the Docker container ([#1336](https://github.com/ehrbase/ehrbase/pull/1336))
  ### Changed 
-- Deprecate plugin aspects ([#1344](https://github.com/ehrbase/ehrbase/pull/1344))
+* Deprecate plugin aspects ([#1344](https://github.com/ehrbase/ehrbase/pull/1344))
+* Add simplified JSON-based “web template” format support for GET Template ADL 1.4 using header `Accept: application/openehr.wt+json` ([1334](https://github.com/ehrbase/ehrbase/pull/1334))
  ### Fixed 
 
 ## [2.4.0]

--- a/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
@@ -17,7 +17,6 @@
  */
 package org.ehrbase.rest;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -25,9 +24,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.*;
-import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
-import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.NotAcceptableException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
@@ -37,8 +35,7 @@ import org.ehrbase.rest.openehr.format.OpenEHRMediaType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
@@ -65,32 +62,15 @@ public abstract class BaseController {
     public static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE;
     public static final String ACCEPT = HttpHeaders.ACCEPT;
     public static final String REQ_CONTENT_TYPE = "Client may request content format";
-    public static final String REQ_CONTENT_TYPE_BODY = "Format of transferred body";
     public static final String REQ_ACCEPT = "Client should specify expected format";
     // response headers
     public static final String RESP_CONTENT_TYPE_DESC = "Format of response";
-    // Audit
-    public static final String REST_OPERATION = "RestOperation";
 
     public static final String LOCATION = HttpHeaders.LOCATION;
     public static final String ETAG = HttpHeaders.ETAG;
     public static final String LAST_MODIFIED = HttpHeaders.LAST_MODIFIED;
 
     public static final String IF_MATCH = HttpHeaders.IF_MATCH;
-    public static final String IF_NONE_MATCH = HttpHeaders.IF_NONE_MATCH;
-    // Configuration of swagger-ui description fields
-    // request headers
-    public static final String REQ_OPENEHR_VERSION = "Optional custom request header for versioning";
-    public static final String REQ_OPENEHR_AUDIT = "Optional custom request header for auditing";
-    public static final String REQ_PREFER = "May be used by clients for resource representation negotiation";
-    public static final String RESP_LOCATION_DESC = "Location of resource";
-    public static final String RESP_ETAG_DESC = "Entity tag for resource";
-    public static final String RESP_LAST_MODIFIED_DESC = "Time of last modification of resource";
-    // common response description fields
-    public static final String RESP_NOT_ACCEPTABLE_DESC =
-            "Not Acceptable - Service can not fulfill requested format via accept header.";
-    public static final String RESP_UNSUPPORTED_MEDIA_DESC =
-            "Unsupported Media Type - request's content-type not supported.";
 
     // constants of all API resources
     public static final String EHR = "ehr";
@@ -107,23 +87,6 @@ public abstract class BaseController {
     public static final String API_CONTEXT_PATH_WITH_VERSION = API_CONTEXT_PATH + "/v1";
     public static final String ADMIN_API_CONTEXT_PATH = "${admin-api.context-path:/rest/admin}";
 
-    public Map<String, Map<String, String>> add2MetaMap(
-            Map<String, Map<String, String>> metaMap, String key, String value) {
-        Map<String, String> contentMap;
-
-        if (metaMap == null) {
-            metaMap = new HashMap<>();
-            contentMap = new HashMap<>();
-            metaMap.put("meta", contentMap);
-        } else {
-            contentMap = metaMap.get("meta");
-        }
-
-        contentMap.put(key, value);
-        return metaMap;
-    }
-
-    @VisibleForTesting
     public String getContextPath() {
         return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
     }
@@ -140,7 +103,7 @@ public abstract class BaseController {
      */
     protected URI createLocationUri(String... pathSegments) {
         return UriComponentsBuilder.fromHttpUrl(getContextPath())
-                .path(this.encodePath(apiContextPathWithVersion))
+                .path(UriUtils.encodePath(apiContextPathWithVersion, "UTF-8"))
                 .pathSegment(pathSegments)
                 .build()
                 .toUri();
@@ -220,10 +183,9 @@ public abstract class BaseController {
             final MediaType mediaType = resolveContentType(
                     contentType,
                     MediaType.APPLICATION_JSON,
-                    mediaType1 -> mediaType1.isCompatibleWith(MediaType.APPLICATION_JSON)
-                            || mediaType1.isCompatibleWith(MediaType.APPLICATION_XML)
-                            || mediaType1.isCompatibleWith(OpenEHRMediaType.APPLICATION_WT_FLAT_SCHEMA_JSON)
-                            || mediaType1.isCompatibleWith(OpenEHRMediaType.APPLICATION_WT_STRUCTURED_SCHEMA_JSON));
+                    MediaType.APPLICATION_XML,
+                    OpenEHRMediaType.APPLICATION_WT_FLAT_SCHEMA_JSON,
+                    OpenEHRMediaType.APPLICATION_WT_STRUCTURED_SCHEMA_JSON);
 
             representation =
                     CompositionRepresentation.selectFromMediaTypeWithFormat(mediaType, parsedFormat.orElse(null));
@@ -236,24 +198,10 @@ public abstract class BaseController {
     }
 
     /**
-     * Convenience helper to encode path strings to URI-safe strings
-     *
-     * @param path input
-     * @return URI-safe escaped string
-     * @throws InternalServerException when encoding failed
-     */
-    public String encodePath(String path) {
-
-        path = UriUtils.encodePath(path, "UTF-8");
-
-        return path;
-    }
-
-    /**
      * Extracts the UUID base from a versioned UID. Or, if
      *
-     * @param versionUid
-     * @return
+     * @param versionUid  raw versionUid in format <code>[UUID]::[VERSION]</code>
+     * @return uuid <code>[UUID]</code> part
      */
     protected UUID extractVersionedObjectUidFromVersionUid(String versionUid) {
         if (!versionUid.contains("::")) {
@@ -265,69 +213,46 @@ public abstract class BaseController {
     protected Optional<Integer> extractVersionFromVersionUid(String versionUid) {
         // extract the version from string of format "$UUID::$SYSTEM::$VERSION"
         // via making a substring starting at last occurrence of "::" + 2
-        int lastOccourence = versionUid.lastIndexOf("::");
-        if (lastOccourence > 0 && versionUid.indexOf("::") != lastOccourence) {
-            return Optional.of(Integer.parseInt(versionUid.substring(lastOccourence + 2)));
+        int lastOccurrence = versionUid.lastIndexOf("::");
+        if (lastOccurrence > 0 && versionUid.indexOf("::") != lastOccurrence) {
+            return Optional.of(Integer.parseInt(versionUid.substring(lastOccurrence + 2)));
         }
 
         return Optional.empty();
     }
 
     /**
-     * Add attribute to the current request.
-     *
-     * @param attributeName
-     * @param value
-     */
-    protected void enrichRequestAttribute(String attributeName, Object value) {
-        RequestContextHolder.currentRequestAttributes()
-                .setAttribute(attributeName, value, RequestAttributes.SCOPE_REQUEST);
-    }
-
-    /**
-     * Resolves the Content-Type based on Accept header.
+     * Resolves the Content-Type based on Accept header. Validates if the given <code>acceptHeader</code> in
+     * either <code>application/json</code> or <code>application/xml</code>.
+     * In case <code>acceptHeader</code> is given <code>application/json</code> will be selected as a default.
      *
      * @param acceptHeader Accept header value
      * @return Content-Type of the response
      */
     protected MediaType resolveContentType(String acceptHeader) {
-        return resolveContentType(acceptHeader, MediaType.APPLICATION_JSON);
-    }
-
-    /**
-     * Resolves the Content-Type based on Accept header.
-     *
-     * @param acceptHeader     Accept header value
-     * @param defaultMediaType Default Content-Type
-     * @return Content-Type of the response
-     */
-    protected MediaType resolveContentType(String acceptHeader, MediaType defaultMediaType) {
-        return resolveContentType(
-                acceptHeader,
-                defaultMediaType,
-                mediaType -> mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)
-                        || mediaType.isCompatibleWith(MediaType.APPLICATION_XML));
+        return resolveContentType(acceptHeader, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML);
     }
 
     /**
      * Resolves the Content-Type based on Accept header using the supported predicate.
      *
-     * @param acceptHeader     Accept header value
-     * @param defaultMediaType Default Content-Type
-     * @param isSupported      Filter the supported Content-Types
+     * @param acceptHeader        Accept header value
+     * @param defaultMediaType    Default Content-Type
+     * @param supportedMediaTypes supported Content-Types
      * @return Content-Type of the response
      */
     protected MediaType resolveContentType(
-            String acceptHeader, MediaType defaultMediaType, Predicate<MediaType> isSupported) {
+            String acceptHeader, MediaType defaultMediaType, MediaType... supportedMediaTypes) {
 
         List<MediaType> mediaTypes = MediaType.parseMediaTypes(acceptHeader);
         if (mediaTypes.isEmpty()) {
             return defaultMediaType;
         }
 
-        MediaType.sortBySpecificityAndQuality(mediaTypes);
+        MimeTypeUtils.sortBySpecificity(mediaTypes);
         MediaType contentType = mediaTypes.stream()
-                .filter(isSupported)
+                .filter(type -> Stream.concat(Stream.of(defaultMediaType), Arrays.stream(supportedMediaTypes))
+                        .anyMatch(type::isCompatibleWith))
                 .findFirst()
                 .orElseThrow(() -> new InvalidApiParameterException("Wrong Content-Type header in request"));
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -225,7 +225,7 @@ public class OpenehrDirectoryController extends BaseController implements Direct
         DirectoryResponseData body;
 
         if (prefer != null && prefer.equals(RETURN_REPRESENTATION)) {
-            headers.setContentType(resolveContentType(accept, MediaType.APPLICATION_XML));
+            headers.setContentType(resolveContentType(accept));
             body = buildResponse(folderDto);
             successStatus = getSuccessStatus(method);
         } else {

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
@@ -22,21 +22,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Supplier;
 import org.apache.xmlbeans.XmlException;
 import org.ehrbase.api.definitions.OperationalTemplateFormat;
-import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.NotAcceptableException;
 import org.ehrbase.api.service.CompositionService;
 import org.ehrbase.api.service.TemplateService;
 import org.ehrbase.openehr.sdk.response.dto.TemplateResponseData;
-import org.ehrbase.openehr.sdk.response.dto.TemplatesResponseData;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.CompositionDto;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.TemplateMetaDataDto;
 import org.ehrbase.openehr.sdk.webtemplate.model.WebTemplate;
@@ -44,7 +38,6 @@ import org.ehrbase.rest.BaseController;
 import org.ehrbase.rest.openehr.format.CompositionRepresentation;
 import org.ehrbase.rest.openehr.format.OpenEHRMediaType;
 import org.ehrbase.rest.openehr.specification.TemplateApiSpecification;
-import org.ehrbase.rest.util.InternalResponse;
 import org.openehr.schemas.v1.TemplateDocument;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -61,15 +54,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriUtils;
 
 /**
  * Controller for /template resource as part of the Definitions sub-API of the openEHR REST API
  */
 @ConditionalOnMissingBean(name = "primaryopenehrtemplatecontroller")
 @RestController
-@RequestMapping(
-        path = BaseController.API_CONTEXT_PATH_WITH_VERSION + "/definition/template",
-        produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+@RequestMapping(path = BaseController.API_CONTEXT_PATH_WITH_VERSION + "/definition/template")
 public class OpenehrTemplateController extends BaseController implements TemplateApiSpecification {
 
     protected static final String ADL_1_4 = "adl1.4";
@@ -88,116 +80,97 @@ public class OpenehrTemplateController extends BaseController implements Templat
     */
     @PostMapping(
             path = "/adl1.4",
+            consumes = {MediaType.APPLICATION_XML_VALUE},
             produces = {MediaType.APPLICATION_XML_VALUE})
     @ResponseStatus(value = HttpStatus.CREATED)
-    public ResponseEntity createTemplateClassic(
-            @RequestHeader(value = "openEHR-VERSION", required = false) String openehrVersion, // TODO, see EHR-267
-            @RequestHeader(value = "openEHR-AUDIT_DETAILS", required = false)
-                    String openehrAuditDetails, // TODO, see EHR-267
-            @RequestHeader(value = CONTENT_TYPE) String contentType,
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+    public ResponseEntity<String> createTemplateClassic(
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
+            @RequestHeader(value = HttpHeaders.CONTENT_TYPE) String contentType,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @RequestHeader(value = PREFER, required = false) String prefer,
             @RequestBody String template) {
 
-        // TODO: only XML at the moment
-        if (!MediaType.parseMediaType(contentType).isCompatibleWith(MediaType.APPLICATION_XML)) {
-            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Only XML is supported at the moment");
-        }
+        // ensure the response media type is supported
+        MediaType mediaType = resolveContentType(accept, MediaType.APPLICATION_XML);
 
-        TemplateDocument document;
-        try {
-            document =
-                    TemplateDocument.Factory.parse(new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8)));
+        // create template
+        String templateId;
+        try (var input = new ByteArrayInputStream(template.getBytes(StandardCharsets.UTF_8))) {
+            TemplateDocument document = TemplateDocument.Factory.parse(input);
+            templateId = templateService.create(document.getTemplate());
         } catch (XmlException | IOException e) {
             throw new InvalidApiParameterException(e.getMessage());
         }
 
-        String templateId = templateService.create(document.getTemplate());
+        // initialize HTTP 201 Created body builder
+        ResponseEntity.BodyBuilder bodyBuilder = templateResponseBuilder(HttpStatus.CREATED, templateId, mediaType);
 
-        URI uri = createLocationUri(DEFINITION, TEMPLATE, ADL_1_4, templateId);
-
-        List<String> headerList = Arrays.asList(
-                LOCATION,
-                ETAG,
-                LAST_MODIFIED); // whatever is required by REST spec - CONTENT_TYPE only needed for 201, so handled
-        // separately
-
-        Optional<InternalResponse<TemplateResponseData>>
-                respData; // variable to overload with more specific object if requested
-
-        if (Optional.ofNullable(prefer)
-                .map(i -> i.equals(RETURN_REPRESENTATION))
-                .orElse(false)) { // null safe way to test prefer header
-            respData = buildTemplateResponseData(templateId, accept, uri, headerList, TemplateResponseData::new);
-        } else { // "minimal" is default fallback
-            respData = buildTemplateResponseData(templateId, accept, uri, headerList, () -> null);
+        // return either representation body or only the created response
+        if (RETURN_REPRESENTATION.equals(prefer)) {
+            OperationalTemplateFormat format = operationalTemplateFormatForMediaType(mediaType);
+            String responseTemplate = templateService.findOperationalTemplate(templateId, format);
+            return bodyBuilder.body(responseTemplate);
+        } else {
+            return bodyBuilder.build();
         }
-
-        // TODO remove 204?
-        // returns 201 with body + headers, 204 only with headers or 500 error depending on what processing above yields
-        return respData.map(i -> Optional.ofNullable(i.getResponseData())
-                        .map(j -> ResponseEntity.created(uri)
-                                .headers(i.getHeaders())
-                                .body(j.get()))
-                        // when the body is empty
-                        .orElse(ResponseEntity.noContent()
-                                .headers(i.getHeaders())
-                                .build()))
-                // when no response could be created at all
-                .orElse(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
     }
 
     // Note: based on latest-branch of 1.1.0 release of openEHR REST API, because this endpoint was changed
     // significantly
-    @GetMapping("/adl1.4")
-    public ResponseEntity getTemplatesClassic(
-            @RequestHeader(value = "openEHR-VERSION", required = false) String openehrVersion, // TODO, see EHR-267
-            @RequestHeader(value = "openEHR-AUDIT_DETAILS", required = false)
-                    String openehrAuditDetails, // TODO, see EHR-267
+    @GetMapping(
+            value = "/adl1.4",
+            produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    public ResponseEntity<List<TemplateMetaDataDto>> getTemplatesClassic(
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
             @RequestHeader(value = ACCEPT, required = false) String accept) {
 
         URI uri = createLocationUri(DEFINITION, TEMPLATE, ADL_1_4);
+        MediaType mediaType = resolveContentType(accept, MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML);
 
-        List<String> headerList =
-                Collections.emptyList(); // whatever is required by REST spec - CONTENT_TYPE only needed for 201, so
-        // handled
-        // separately
-
-        Optional<InternalResponse<TemplatesResponseData>> respData =
-                buildTemplateResponseData("", accept, uri, headerList, TemplatesResponseData::new);
+        List<TemplateMetaDataDto> templates = templateService.getAllTemplates();
 
         // returns 200 with all templates OR error
-        return respData.map(i -> ResponseEntity.ok()
-                        .headers(i.getHeaders())
-                        .body(i.getResponseData().get()))
-                .orElse(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+        return ResponseEntity.ok().location(uri).contentType(mediaType).body(templates);
     }
 
     // Note: based on latest-branch of 1.1.0 release of openEHR REST API, because this endpoint was changed
     // significantly
-    @GetMapping("/adl1.4/{template_id}")
-    public ResponseEntity getTemplateClassic(
-            @RequestHeader(value = "openEHR-VERSION", required = false) String openehrVersion, // TODO, see EHR-267
-            @RequestHeader(value = "openEHR-AUDIT_DETAILS", required = false)
-                    String openehrAuditDetails, // TODO, see EHR-267
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+    @GetMapping(
+            value = "/adl1.4/{template_id}",
+            // TODO ITS-REST/Release-1.0.3 produces also "text/plain" but what format should this be
+            produces = {
+                MediaType.APPLICATION_XML_VALUE,
+                MediaType.APPLICATION_JSON_VALUE,
+                OpenEHRMediaType.APPLICATION_WT_JSON_VALUE
+            })
+    public ResponseEntity<Object> getTemplateClassic(
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @PathVariable(value = "template_id") String templateId) {
 
-        URI uri = createLocationUri(DEFINITION, ADL_1_4, templateId);
+        // parse and set accepted format. with XML as fallback for empty header and error for unsupported header
+        MediaType mediaType = resolveContentType(
+                accept, MediaType.APPLICATION_XML, OpenEHRMediaType.APPLICATION_WT_JSON, MediaType.APPLICATION_JSON);
 
-        List<String> headerList = Arrays.asList(
-                LOCATION,
-                ETAG,
-                LAST_MODIFIED); // whatever is required by REST spec - CONTENT_TYPE only needed for 201, so handled
-        // separately
+        // resolve template
+        OperationalTemplateFormat format = operationalTemplateFormatForMediaType(mediaType);
 
-        Optional<InternalResponse<TemplateResponseData>> respData =
-                buildTemplateResponseData(templateId, accept, uri, headerList, TemplateResponseData::new);
+        ResponseEntity.BodyBuilder bodyBuilder = templateResponseBuilder(HttpStatus.OK, templateId, mediaType);
 
-        return respData.map(i -> ResponseEntity.ok()
-                        .headers(i.getHeaders())
-                        .body(i.getResponseData().get()))
-                .orElse(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+        // return the original XML based OPT format (if called with the Accept: application/xml request header),
+        if (mediaType.isCompatibleWith(MediaType.APPLICATION_XML)) {
+            String operationalTemplate = templateService.findOperationalTemplate(templateId, format);
+            return bodyBuilder.body(operationalTemplate);
+        }
+        // return simplified JSON-based “web template” format (if called with the Accept: application/json or
+        // application/openehr.wt+json request header)
+        else {
+            final WebTemplate webTemplate = templateService.findTemplate(templateId);
+            return bodyBuilder.body(webTemplate);
+        }
     }
 
     @GetMapping(
@@ -209,177 +182,122 @@ public class OpenehrTemplateController extends BaseController implements Templat
                 OpenEHRMediaType.APPLICATION_WT_FLAT_SCHEMA_JSON_VALUE
             })
     public ResponseEntity<String> getTemplateExample(
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @PathVariable(value = "template_id") String templateId,
             @RequestParam(value = "format", required = false) String format) {
 
         CompositionRepresentation representation = extractCompositionRepresentation(accept, format);
         Composition composition = templateService.buildExample(templateId);
+        CompositionDto compositionDto = new CompositionDto(composition, templateId, null, null);
 
         return ResponseEntity.ok()
+                .location(createLocationUri(DEFINITION, TEMPLATE, ADL_1_4, templateId, "example"))
                 .contentType(representation.mediaType)
                 .body(compositionService
-                        .serialize(new CompositionDto(composition, templateId, null, null), representation.format)
+                        .serialize(compositionDto, representation.format)
                         .getValue());
     }
 
     @GetMapping(
             path = "/adl1.4/{template_id}/webtemplate",
             produces = {MediaType.APPLICATION_JSON_VALUE, OpenEHRMediaType.APPLICATION_WT_JSON_VALUE})
+    @SuppressWarnings({"removal", "UastIncorrectHttpHeaderInspection"})
     public ResponseEntity<WebTemplate> getWebTemplate(
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @PathVariable(value = "template_id") String templateId) {
 
-        final MediaType mediaType = resolveContentType(
-                accept,
-                OpenEHRMediaType.APPLICATION_WT_JSON,
-                m -> m.isCompatibleWith(OpenEHRMediaType.APPLICATION_WT_JSON)
-                        || m.isCompatibleWith(MediaType.APPLICATION_JSON));
+        final MediaType mediaType =
+                resolveContentType(accept, OpenEHRMediaType.APPLICATION_WT_JSON, MediaType.APPLICATION_JSON);
         final WebTemplate webTemplate = templateService.findTemplate(templateId);
 
-        return ResponseEntity.ok().contentType(mediaType).body(webTemplate);
+        // @format:off
+        final String linkPrefix = "%s/%s".formatted(getContextPath(), "swagger-ui/index.html?urls.primaryName=1.%20openEHR%20API#");
+
+        return ResponseEntity.ok()
+                .location(createLocationUri(DEFINITION, TEMPLATE, ADL_1_4, templateId, "webtemplate"))
+                .contentType(mediaType)
+                .header("Deprecated", "Mon, 03 Jun 2024 00:00:00 GMT")
+                // .headers("Sunset", "Tue, 31 Dec 2024 00:00:00 GMT"); <- could be used until we know it ;)
+                .header("Link", String.join(", ", List.of(
+                    "<%s/%s>; rel=\"deprecation\"; type=\"text/html\"".formatted(linkPrefix, UriUtils.encode("TEMPLATE/getWebTemplate", StandardCharsets.US_ASCII)),
+                    "<%s/%s>; rel=\"successor-version\"".formatted(linkPrefix, UriUtils.encode("ADL 1.4 TEMPLATE/getTemplateClassic", StandardCharsets.US_ASCII))
+                )))
+                .body(webTemplate);
+        // @format:on
     }
 
     /*
        ADL 2
-       TODO WIP state only implements endpoints from outer server side, everything else is a stub. Also with a lot of duplication at the moment, which should be reduced when implementing functionality.
+       TODO WIP state only implements endpoints from outer server side, everything else is not implemented.
     */
-    @PostMapping("/adl2")
+    @PostMapping(
+            value = "/adl2",
+            consumes = {MediaType.TEXT_PLAIN_VALUE},
+            produces = {MediaType.TEXT_PLAIN_VALUE})
     @ResponseStatus(value = HttpStatus.CREATED)
     public ResponseEntity<TemplateResponseData> createTemplateNew(
-            @RequestHeader(value = "openEHR-VERSION", required = false) String openehrVersion, // TODO, see EHR-267
-            @RequestHeader(value = "openEHR-AUDIT_DETAILS", required = false)
-                    String openehrAuditDetails, // TODO, see EHR-267
-            @RequestHeader(value = CONTENT_TYPE, required = false) String contentType,
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
+            @RequestHeader(value = HttpHeaders.CONTENT_TYPE, required = false) String contentType,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @RequestHeader(value = PREFER, required = false) String prefer,
             @RequestParam(value = "version", required = false) String version,
             @RequestBody String template) {
 
-        // TODO implement handler - whole code below is only a stub yet
-
-        TemplateResponseData data = new TemplateResponseData(); // empty for now
-
-        URI url = URI.create("todo");
-        // TODO - continuing stub but list of headers most likely the correct list of necessary ones
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setLocation(url);
-        headers.setETag("\"something...\"");
-        headers.setLastModified(1234565778);
-
-        return Optional.ofNullable(data)
-                .map(i -> new ResponseEntity<>(i, headers, HttpStatus.CREATED))
-                .orElse(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    // TODO possible changes pending, keep an eye on: https://github.com/openEHR/specifications-ITS-REST/issues/85
+    @GetMapping(
+            value = "/adl2",
+            produces = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<TemplateResponseData> getTemplatesNew(
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept) {
+
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
 
     // Note: based on latest-branch of 1.1.0 release of openEHR REST API, because this endpoint was changed
     // significantly
     // also, this endpoint combines what is listed as two endpoints:
     // https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-adl-2-template-get
-    @GetMapping("/adl2/{template_id}/{version_pattern}")
+    @GetMapping(
+            value = "/adl2/{template_id}/{version_pattern}",
+            produces = {MediaType.TEXT_PLAIN_VALUE})
     public ResponseEntity<TemplateResponseData> getTemplateNew(
-            @RequestHeader(value = "openEHR-VERSION", required = false) String openehrVersion, // TODO, see EHR-267
-            @RequestHeader(value = "openEHR-AUDIT_DETAILS", required = false)
-                    String openehrAuditDetails, // TODO, see EHR-267
-            @RequestHeader(value = ACCEPT, required = false) String accept,
+            @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
+            @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
+            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @PathVariable(value = "template_id", required = false) String templateId,
             @PathVariable(value = "version_pattern", required = false) String versionPattern) {
 
-        // TODO implement handler - whole code below is only a stub yet
-
-        // TODO how to do that with multiple templates?
-        TemplateResponseData data = new TemplateResponseData(); // empty for now
-
-        URI url = URI.create("todo");
-        // TODO - continuing stub but list of headers most likely the correct list of necessary ones
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setLocation(url);
-        headers.setETag("\"something...\"");
-        headers.setLastModified(1234565778);
-
-        return Optional.ofNullable(data)
-                .map(i -> new ResponseEntity<>(i, headers, HttpStatus.CREATED))
-                .orElse(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    /**
-     * Builds response data for template endpoints. As specified there are two kinds of returns, with one or all templates.
-     * Hence factory can work with TemplateResponseData or TemplatesResponseData.
-     *
-     * @param templateId ID of the template, can be empty ("") when all templates are requested
-     * @param accept     Format the response should be delivered in, as given by request
-     * @param uri        Location of resource
-     * @param headerList List of headers to be set for response
-     * @param factory    Works with TemplateResponseData or TemplatesResponseData
-     * @param <T>        Type of response body
-     * @return
-     */
-    private <T> Optional<InternalResponse<T>> buildTemplateResponseData(
-            String templateId, String accept, URI uri, List<String> headerList, Supplier<T> factory) {
-        // create either TemplateResponseData or null (means no body, only headers incl. link to resource), via lambda
-        // request
-        T oneOrAllTemplates = factory.get();
+    private ResponseEntity.BodyBuilder templateResponseBuilder(
+            HttpStatus status, String templateId, MediaType mediaType) {
 
-        // do minimal scope steps
-        // create and supplement headers with data depending on which headers are requested
-        HttpHeaders respHeaders = new HttpHeaders();
-        for (String header : headerList) {
-            switch (header) {
-                case LOCATION:
-                    respHeaders.setLocation(uri);
-                    break;
-                case ETAG:
-                    respHeaders.setETag("\"" + templateId + "\"");
-                    break;
-                case LAST_MODIFIED:
-                    // TODO should be VERSION.commit_audit.time_committed.value which is not implemented yet - mock for
-                    // now
-                    respHeaders.setLastModified(123124442);
-                    break;
-                default:
-                    // Ignore header
-            }
-        }
+        URI uri = createLocationUri(DEFINITION, TEMPLATE, ADL_1_4, templateId);
 
-        // parse and set accepted format. with XML as fallback for empty header and error for non supported header
-        MediaType mediaType = resolveContentType(accept, MediaType.APPLICATION_XML);
-        OperationalTemplateFormat format;
+        // initialize HTTP 201 Created body builder
+        return ResponseEntity.status(status)
+                .location(uri)
+                .contentType(mediaType)
+                .eTag("\"%s\"".formatted(templateId))
+                // TODO should be VERSION.commit_audit.time_committed.value which is not implemented yet - mock for now
+                .lastModified(123124442);
+    }
+
+    private static OperationalTemplateFormat operationalTemplateFormatForMediaType(MediaType mediaType) {
         if (mediaType.isCompatibleWith(MediaType.APPLICATION_XML)) {
-            format = OperationalTemplateFormat.XML;
-        } else if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
-            format = OperationalTemplateFormat.JSON;
+            return OperationalTemplateFormat.XML;
+        } else if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)
+                || mediaType.isCompatibleWith(OpenEHRMediaType.APPLICATION_WT_JSON)) {
+            return OperationalTemplateFormat.JSON;
         } else {
-            throw new NotAcceptableException("Currently only xml (or empty for fallback) is allowed");
+            throw new NotAcceptableException(
+                    "Operation templates are only available in XML based OPT or simplified JSON-based web template format");
         }
-
-        // is null when request wants only metadata returned, so skips provisioning of body if null
-        if (oneOrAllTemplates != null) {
-            if (oneOrAllTemplates.getClass().equals(TemplateResponseData.class)) { // get only one template
-                // when this "if" is true the following casting can be executed and data manipulated by reference
-                // (handled by temporary variable)
-                TemplateResponseData objByReference = (TemplateResponseData) oneOrAllTemplates;
-
-                // TODO very simple now, needs more sophisticated templateService
-                String template = templateService.findOperationalTemplate(templateId, format);
-                objByReference.set(template);
-
-                // finally set last header // TODO only XML for now
-                respHeaders.setContentType(MediaType.APPLICATION_XML);
-
-            } else if (oneOrAllTemplates.getClass().equals(TemplatesResponseData.class)) { // get all templates
-                TemplatesResponseData objByReference = (TemplatesResponseData) oneOrAllTemplates;
-
-                List<TemplateMetaDataDto> templates = templateService.getAllTemplates();
-                objByReference.set(templates);
-            } else
-                throw new InternalServerException(
-                        "Building template response data failed"); // i.e. wrong usage of buildTemplateResponseData()
-        }
-
-        return Optional.of(new InternalResponse<>(oneOrAllTemplates, respHeaders));
     }
 }

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrTemplateController.java
@@ -86,13 +86,8 @@ public class OpenehrTemplateController extends BaseController implements Templat
     public ResponseEntity<String> createTemplateClassic(
             @RequestHeader(value = OPENEHR_VERSION, required = false) String openehrVersion,
             @RequestHeader(value = OPENEHR_AUDIT_DETAILS, required = false) String openehrAuditDetails,
-            @RequestHeader(value = HttpHeaders.CONTENT_TYPE) String contentType,
-            @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String accept,
             @RequestHeader(value = PREFER, required = false) String prefer,
             @RequestBody String template) {
-
-        // ensure the response media type is supported
-        MediaType mediaType = resolveContentType(accept, MediaType.APPLICATION_XML);
 
         // create template
         String templateId;
@@ -104,12 +99,13 @@ public class OpenehrTemplateController extends BaseController implements Templat
         }
 
         // initialize HTTP 201 Created body builder
-        ResponseEntity.BodyBuilder bodyBuilder = templateResponseBuilder(HttpStatus.CREATED, templateId, mediaType);
+        ResponseEntity.BodyBuilder bodyBuilder =
+                templateResponseBuilder(HttpStatus.CREATED, templateId, MediaType.APPLICATION_XML);
 
         // return either representation body or only the created response
         if (RETURN_REPRESENTATION.equals(prefer)) {
-            OperationalTemplateFormat format = operationalTemplateFormatForMediaType(mediaType);
-            String responseTemplate = templateService.findOperationalTemplate(templateId, format);
+            String responseTemplate =
+                    templateService.findOperationalTemplate(templateId, OperationalTemplateFormat.XML);
             return bodyBuilder.body(responseTemplate);
         } else {
             return bodyBuilder.build();
@@ -131,7 +127,7 @@ public class OpenehrTemplateController extends BaseController implements Templat
 
         List<TemplateMetaDataDto> templates = templateService.getAllTemplates();
 
-        // returns 200 with all templates OR error
+        // returns 200 with all templates
         return ResponseEntity.ok().location(uri).contentType(mediaType).body(templates);
     }
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/format/CompositionRepresentation.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/format/CompositionRepresentation.java
@@ -43,13 +43,13 @@ public enum CompositionRepresentation {
      * A structured <code>JSON</code> (<code>structSDT</code>) representation of a composition
      */
     // FlatFormat.STRUCTURED application/openehr.structSDT+json
-    JSON_STRUCTURED(MediaType.APPLICATION_JSON, CompositionFormat.STRUCTURED),
+    JSON_STRUCTURED(OpenEHRMediaType.APPLICATION_WT_STRUCTURED_SCHEMA_JSON, CompositionFormat.STRUCTURED),
 
     /**
      * A flat <code>JSON</code> (<code>simSDT</code>) representation of a composition
      */
     // FlatFormat.SIM_SDT application/openehr.simSDT+json
-    JSON_FLAT(MediaType.APPLICATION_JSON, CompositionFormat.FLAT);
+    JSON_FLAT(OpenEHRMediaType.APPLICATION_WT_FLAT_SCHEMA_JSON, CompositionFormat.FLAT);
 
     /**
      * The actual format of the composition

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/TemplateApiSpecification.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/TemplateApiSpecification.java
@@ -38,12 +38,7 @@ public interface TemplateApiSpecification {
                             url =
                                     "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL1.4/operation/definition_template_adl1.4_upload"))
     ResponseEntity<String> createTemplateClassic(
-            String openehrVersion,
-            String openehrAuditDetails,
-            String contentType,
-            String accept,
-            String prefer,
-            String template);
+            String openehrVersion, String openehrAuditDetails, String prefer, String template);
 
     @Operation(
             tags = "ADL 1.4 TEMPLATE",

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/TemplateApiSpecification.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/TemplateApiSpecification.java
@@ -21,7 +21,9 @@ import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import org.ehrbase.openehr.sdk.response.dto.TemplateResponseData;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.TemplateMetaDataDto;
 import org.ehrbase.openehr.sdk.webtemplate.model.WebTemplate;
 import org.springframework.http.ResponseEntity;
 
@@ -34,8 +36,8 @@ public interface TemplateApiSpecification {
             externalDocs =
                     @ExternalDocumentation(
                             url =
-                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-adl-1.4-template-post"))
-    ResponseEntity createTemplateClassic(
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL1.4/operation/definition_template_adl1.4_upload"))
+    ResponseEntity<String> createTemplateClassic(
             String openehrVersion,
             String openehrAuditDetails,
             String contentType,
@@ -49,8 +51,9 @@ public interface TemplateApiSpecification {
             externalDocs =
                     @ExternalDocumentation(
                             url =
-                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-adl-1.4-template-get"))
-    ResponseEntity getTemplatesClassic(String openehrVersion, String openehrAuditDetails, String accept);
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL1.4/operation/definition_template_adl1.4_list"))
+    ResponseEntity<List<TemplateMetaDataDto>> getTemplatesClassic(
+            String openehrVersion, String openehrAuditDetails, String accept);
 
     @Operation(
             tags = "ADL 1.4 TEMPLATE",
@@ -58,8 +61,8 @@ public interface TemplateApiSpecification {
             externalDocs =
                     @ExternalDocumentation(
                             url =
-                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-adl-1.4-template-get-1"))
-    ResponseEntity getTemplateClassic(
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL1.4/operation/definition_template_adl1.4_get"))
+    ResponseEntity<Object> getTemplateClassic(
             String openehrVersion, String openehrAuditDetails, String accept, String templateId);
 
     @Operation(tags = "ADL 1.4 TEMPLATE", summary = "Get an example composition for the specified template")
@@ -80,7 +83,7 @@ public interface TemplateApiSpecification {
             externalDocs =
                     @ExternalDocumentation(
                             url =
-                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-adl-2-template-post"))
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL2/operation/definition_template_adl2_upload"))
     ResponseEntity<TemplateResponseData> createTemplateNew(
             String openehrVersion,
             String openehrAuditDetails,
@@ -92,6 +95,16 @@ public interface TemplateApiSpecification {
 
     @Operation(
             tags = "ADL 2 TEMPLATE",
+            summary = "List templates",
+            externalDocs =
+                    @ExternalDocumentation(
+                            url =
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/ADL2/operation/definition_template_adl2_get"))
+    ResponseEntity<TemplateResponseData> getTemplatesNew(
+            String openehrVersion, String openehrAuditDetails, String accept);
+
+    @Operation(
+            tags = "ADL 2 TEMPLATE",
             summary = "Get template",
             externalDocs =
                     @ExternalDocumentation(
@@ -100,6 +113,12 @@ public interface TemplateApiSpecification {
     ResponseEntity<TemplateResponseData> getTemplateNew(
             String openehrVersion, String openehrAuditDetails, String accept, String templateId, String versionPattern);
 
-    @Operation(tags = "TEMPLATE", summary = "Get a webtemplate for the specified template")
+    @Operation(
+            tags = "TEMPLATE",
+            summary = "Deprecated since 2.2.0 and marked for removal",
+            description =
+                    "Replaced by [/rest/openehr/v1/definition/template/adl1.4/{template_id}](./index.html?urls.primaryName=1.%20openEHR%20API#/ADL%201.4%20TEMPLATE/getTemplateClassic)",
+            deprecated = true)
+    @Deprecated(since = "2.2.0", forRemoval = true)
     ResponseEntity<WebTemplate> getWebTemplate(String accept, String templateId);
 }

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrTemplateControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrTemplateControllerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.rest.openehr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.nedap.archie.rm.composition.Composition;
+import java.util.List;
+import java.util.Optional;
+import org.ehrbase.api.exception.InvalidApiParameterException;
+import org.ehrbase.api.service.CompositionService;
+import org.ehrbase.api.service.TemplateService;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.StructuredString;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.StructuredStringFormat;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.TemplateMetaDataDto;
+import org.ehrbase.openehr.sdk.webtemplate.model.WebTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+class OpenehrTemplateControllerTest {
+
+    private static final String CONTEXT_PATH = "https://template.test/ehrbase/rest";
+    private static final String SAMPLE_OPT =
+            """
+    <?xml version="1.0" encoding="utf-8"?>
+    <template xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.openehr.org/v1">
+        <test></test>
+    </template>
+    """;
+    private static final WebTemplate SAMPLE_WEB_TEMPLATE = new WebTemplate();
+    private static final String SAMPLE_ID = "test-template";
+
+    private final TemplateService mockTemplateService = mock();
+
+    private final CompositionService mockCompositionService = mock();
+
+    private final OpenehrTemplateController spyController =
+            spy(new OpenehrTemplateController(mockTemplateService, mockCompositionService));
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(mockTemplateService, mockCompositionService, spyController);
+        doReturn(CONTEXT_PATH).when(spyController).getContextPath();
+    }
+
+    private OpenehrTemplateController controller() {
+        doReturn(SAMPLE_ID).when(mockTemplateService).create(any());
+        doReturn(SAMPLE_OPT).when(mockTemplateService).findOperationalTemplate(any(), any());
+        doReturn(SAMPLE_WEB_TEMPLATE).when(mockTemplateService).findTemplate(SAMPLE_ID);
+        return spyController;
+    }
+
+    @ParameterizedTest
+    @CsvSource({"application/json", "application/xml"})
+    void getTemplatesADL1_4(String accept) {
+
+        TemplateMetaDataDto metaDataDto = new TemplateMetaDataDto();
+        metaDataDto.setTemplateId(SAMPLE_ID);
+
+        doReturn(List.of(metaDataDto)).when(mockTemplateService).getAllTemplates();
+
+        var response = controller().getTemplatesClassic("1.0.3", null, accept);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()).containsEntry(HttpHeaders.CONTENT_TYPE, List.of(accept));
+        assertThat(response.getHeaders())
+                .containsEntry(HttpHeaders.LOCATION, List.of(CONTEXT_PATH + "/definition/template/adl1.4"));
+        assertThat(response.getBody()).isEqualTo(List.of(metaDataDto));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+                ||
+                application/xml||return=minimal
+                application/xml|application/xml|
+                application/xml|application/xml|return=representation
+            """,
+            delimiterString = "|")
+    void createTemplateADL1_4(String contentType, String accept, String prefer) {
+
+        var response = controller().createTemplateClassic("1.0.3", null, contentType, accept, prefer, SAMPLE_OPT);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.CONTENT_TYPE,
+                        List.of(Optional.ofNullable(accept).orElse("application/xml")));
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.LOCATION, List.of(CONTEXT_PATH + "/definition/template/adl1.4/" + SAMPLE_ID));
+
+        if ("return=representation".equals(prefer)) {
+            assertThat(response.getBody()).isEqualTo(SAMPLE_OPT);
+        } else {
+            assertThat(response.getBody()).isNull();
+        }
+    }
+
+    @Test
+    void createTemplateADL1_4_foo() {
+
+        OpenehrTemplateController controller = controller();
+        assertThatThrownBy(() ->
+                        controller.createTemplateClassic("1.0.3", null, "application/xml", null, null, "not a xml"))
+                .isInstanceOf(InvalidApiParameterException.class)
+                .hasMessage("error: Content is not allowed in prolog.");
+    }
+
+    @Test
+    void getTemplateADL1_4_OPT() {
+
+        ResponseEntity<?> response =
+                controller().getTemplateClassic("1.0.3", null, MediaType.APPLICATION_XML_VALUE, SAMPLE_ID);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()).containsEntry(HttpHeaders.CONTENT_TYPE, List.of("application/xml"));
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.LOCATION, List.of(CONTEXT_PATH + "/definition/template/adl1.4/" + SAMPLE_ID));
+        assertThat(response.getBody()).isInstanceOf(String.class).isEqualTo(SAMPLE_OPT);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"application/json", "application/openehr.wt+json"})
+    void getTemplateADL1_4_WebTemplate(String accept) {
+
+        ResponseEntity<?> response = controller().getTemplateClassic("1.0.3", null, accept, SAMPLE_ID);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()).containsEntry(HttpHeaders.CONTENT_TYPE, List.of(accept));
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.LOCATION, List.of(CONTEXT_PATH + "/definition/template/adl1.4/" + SAMPLE_ID));
+        assertThat(response.getBody()).isInstanceOf(WebTemplate.class).isEqualTo(SAMPLE_WEB_TEMPLATE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "application/xml",
+        "application/json",
+        "application/openehr.wt.structured.schema+json",
+        "application/openehr.wt.flat.schema+json"
+    })
+    void getTemplateExample(String accept) {
+
+        Composition composition = new Composition();
+        StructuredString structuredString = new StructuredString("\"string\"", StructuredStringFormat.JSON);
+
+        doReturn(composition).when(mockTemplateService).buildExample(SAMPLE_ID);
+        doReturn(structuredString).when(mockCompositionService).serialize(any(), any());
+
+        ResponseEntity<?> response = controller().getTemplateExample(accept, SAMPLE_ID, null);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()).containsEntry(HttpHeaders.CONTENT_TYPE, List.of(accept));
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.LOCATION,
+                        List.of(CONTEXT_PATH + "/definition/template/adl1.4/" + SAMPLE_ID + "/example"));
+        assertThat(response.getBody()).isEqualTo("\"string\"");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"application/json", "application/openehr.wt+json"})
+    void getWebTemplate(String accept) {
+
+        ResponseEntity<?> response = controller().getWebTemplate(accept, SAMPLE_ID);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()).containsEntry(HttpHeaders.CONTENT_TYPE, List.of(accept));
+        assertThat(response.getHeaders())
+                .containsEntry(
+                        HttpHeaders.LOCATION,
+                        List.of(CONTEXT_PATH + "/definition/template/adl1.4/" + SAMPLE_ID + "/webtemplate"));
+        assertThat(response.getHeaders()).containsKey("Deprecated");
+        assertThat(response.getHeaders()).containsKey("Link");
+        assertThat(response.getBody()).isInstanceOf(WebTemplate.class).isEqualTo(SAMPLE_WEB_TEMPLATE);
+    }
+
+    @Test
+    void templateADL2NotImplemented() {
+
+        OpenehrTemplateController controller = controller();
+        assertThat(controller.getTemplatesNew(null, null, null).getStatusCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        assertThat(controller
+                        .createTemplateNew(null, null, null, null, null, null, null)
+                        .getStatusCode())
+                .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        assertThat(controller.getTemplatesNew(null, null, null).getStatusCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+    }
+}

--- a/service/src/main/java/org/ehrbase/service/TemplateServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/TemplateServiceImp.java
@@ -32,6 +32,7 @@ import org.apache.xmlbeans.XmlOptions;
 import org.ehrbase.api.definitions.OperationalTemplateFormat;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.exception.InvalidApiParameterException;
+import org.ehrbase.api.exception.NotAcceptableException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
 import org.ehrbase.api.knowledge.TemplateMetaData;
 import org.ehrbase.api.service.TemplateService;
@@ -127,7 +128,7 @@ public class TemplateServiceImp implements TemplateService {
     public String findOperationalTemplate(String templateId, OperationalTemplateFormat format)
             throws ObjectNotFoundException, InvalidApiParameterException, InternalServerException {
         if (format != OperationalTemplateFormat.XML) {
-            throw new InvalidApiParameterException("Requested operational template type not supported");
+            throw new NotAcceptableException("Requested operational template type not supported");
         }
 
         Optional<OPERATIONALTEMPLATE> existingTemplate =


### PR DESCRIPTION
# Changes

* Correct supported content types
  * ADL 1.4 POST Content-Type and Accept only `application/xml`
  * ADL 1.4 GET  Accept `application/xml`, `application/json`, `application/openehr.wt+json`
* Deprecate `/adl1.4/{template_id}/webtemplate`  because it's now supported using ADL 1.4 GET
* Ensure HTTP `406` is returned in case the requested ADL 1.4 Template is not a valid XML 
* Refactor response handling
* Removed dead code from `BaseController`

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [ ] No new Sonar issues introduced -> some TODOs need to be accepted again because some logic was moved around
- [x] Changelog is updated
- [ ] Code has been reviewed 