### PR TITLE
Create dedicated ehrbase use to run the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
  ### Added
+- Create a `ehrbase` user to run the Docker container ([#1336](https://github.com/ehrbase/ehrbase/pull/1336))
  ### Changed 
 - Deprecate plugin aspects ([#1344](https://github.com/ehrbase/ehrbase/pull/1344))
  ### Fixed 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 # syntax=docker/dockerfile:1
 FROM eclipse-temurin:21-jre-alpine
+
+RUN addgroup -S ehrbase && adduser -S ehrbase -G ehrbase
+
 COPY /application/target/ehrbase.jar /app/ehrbase.jar
 
+RUN chown -R ehrbase:ehrbase /app
+USER ehrbase
+WORKDIR /app
+
 EXPOSE 8080
-ENTRYPOINT  [ "java", "-jar", "-Dspring.profiles.active=docker", "/app/ehrbase.jar"]
+
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/ehrbase.jar --spring.profiles.active=docker"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 #
 # Minimal setup for a running EHRbase. Contains the server component as well as the required postgres instance.
 #

--- a/tests/DockerfileTest
+++ b/tests/DockerfileTest
@@ -25,6 +25,8 @@ FROM ${EHRBASE_IMAGE}
 
 COPY --from=builder /build/*.jar /app/
 
+USER root
+
 ENV JACOCO_RESULT_PATH=/app/coverage/jacoco.exec
 
 ENTRYPOINT java -jar -Dspring.profiles.active=docker -javaagent:/app/jacoco-agent.jar=destfile=${JACOCO_RESULT_PATH},append=false,includes=org.ehrbase.* /app/ehrbase.jar

--- a/tests/docker-compose-int-test.yml
+++ b/tests/docker-compose-int-test.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 #
 # Extended setup for EHRbase for integration tests.
 #


### PR DESCRIPTION
# Changes

- Create a `ehrbase` dedicated non-root user to run the container.
- Suppress warning about deprecated `version` in Docker Compose files

# Related issue

Closes #1335 

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 