### PR TITLE
Let spring decide which prometheus version is used

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,6 @@
 
     <!-- jooq -->
     <postgresql.version>42.7.3</postgresql.version>
-    <prometheus.version>1.13.1</prometheus.version>
 
     <!-- spring -->
     <spring-boot.version>3.2.5</spring-boot.version>
@@ -309,11 +308,6 @@
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
         <version>${git-commit-id-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>${prometheus.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>

--- a/configuration/src/test/java/org/ehrbase/configuration/config/security/ManagementSecurityConfigurationIT.java
+++ b/configuration/src/test/java/org/ehrbase/configuration/config/security/ManagementSecurityConfigurationIT.java
@@ -56,6 +56,7 @@ public class ManagementSecurityConfigurationIT {
                 "management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers",
                 "management.endpoint.info.enabled=true",
                 "management.endpoint.metrics.enabled=true",
+                "management.endpoint.prometheus.enabled=true",
                 "management.endpoint.loggers.enabled=true",
                 "management.endpoint.health.enabled=true",
                 "management.health.db.enabled=false", // turn off db health checks for tests


### PR DESCRIPTION
# Changes

Prometheus to 1.13 broke actuator endpoint -> see https://github.com/micrometer-metrics/micrometer/issues/5103

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 