### PR TITLE
Ensure unit tests are running with fixed locale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <skipTests>true</skipTests>
+          <!-- Ensure tests have a stable local to prevent localized XML parsing error messages -->
+          <systemPropertyVariables>
+            <user.language>en</user.language>
+            <user.region>US</user.region>
+          </systemPropertyVariables>
           <!-- SETS THE VM ARGUMENT LINE USED WHEN UNIT TESTS ARE RUN. -->
           <argLine>${surefireArgLine}</argLine>
         </configuration>


### PR DESCRIPTION
# Changes

Ensure unit tests are running with fixed locale.

This prevents the internal apache xml implementation to provide localized errors messages.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 