### PR TITLE
 CDR-1532 Add EHRbase CLI to support pre migrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 
 # Allow files and directories
-!/application/target/ehrbase.jar
+!application/target/ehrbase.jar
+!tests/docker-int-test-entrypoint.sh
 !pom.xml
 !**/pom.xml

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 
 # Allow files and directories
 !application/target/ehrbase.jar
+!docker-entrypoint.sh
 !tests/docker-int-test-entrypoint.sh
 !pom.xml
 !**/pom.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -125,8 +125,9 @@ jobs:
             --build-arg EHRBASE_IMAGE=ehrbase/ehrbase:build \
             --file tests/DockerfileTest .
 
-      - name: Docker - Save Test Image
-        run: docker save --output ${{ runner.temp }}/ehrbase-test.tar ehrbase/ehrbase:test
+      - name: Docker - Save Images
+        run: |
+          docker save --output ${{ runner.temp }}/ehrbase-test.tar ehrbase/ehrbase:test
 
       - name: Upload - Test Image
         uses: actions/upload-artifact@v4
@@ -139,7 +140,7 @@ jobs:
   #
   # Uses the ehrbase docker image from [build] to run the robot integrations against it.
   #
-  integration-test-run:
+  integration-test-server:
     runs-on: ubuntu-latest
     needs: [
       docker-test-image
@@ -277,13 +278,13 @@ jobs:
           if-no-files-found: error
 
   #
-  # Collect all Robot result from [integration-test-run] and generated the final report.
+  # Collect all Robot result from [integration-test-server] and generated the final report.
   #
-  integration-test-collect:
+  robot-collect:
     name: Robot-Collect
     if: ${{ always() }}
     needs: [
-      integration-test-run
+      integration-test-server
     ]
     runs-on: ubuntu-latest
     # allow to write comments to the issue
@@ -318,13 +319,13 @@ jobs:
           rm -rf ./tests/report | true
 
   #
-  # Collect all Robot result from [integration-test-run] and generated the final report.
+  # Collect all Robot result from [integration-test-server] and generated the final report.
   #
   coverage-collect:
     name: Jacoco-Collect
     if: ${{ always() }}
     needs: [
-      integration-test-run
+      integration-test-server
     ]
     runs-on: ubuntu-latest
     steps:
@@ -383,6 +384,20 @@ jobs:
           path: ./tests/coverage/jacoco-report-final
 
   #
+  # Uses the ehrbase docker image from [build] to run the robot integrations against it.
+  #
+  integration-test-cli:
+    name: IT
+    uses: ./.github/workflows/job-integration-test-cli.yml
+    secrets: inherit
+    needs: [
+      docker-test-image
+    ]
+    with:
+      ehrbase-image-tag: ehrbase/ehrbase:test
+      ehrbase-image-artifact: ehrbase-image-test
+
+  #
   # Build and push docker image
   #
   docker-build-push:
@@ -393,7 +408,8 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [
       build-maven, # needed to obtain ehrbase-version from
-      integration-test-run
+      integration-test-server,
+      integration-test-cli
     ]
     with:
       ehrbase-version: ${{ needs.build-maven.outputs.ehrbase-version }}
@@ -410,7 +426,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [
       build-maven, # only to have them in the same UI group as docker-build-push
-      integration-test-run
+      integration-test-server
     ]
 
   #
@@ -421,7 +437,7 @@ jobs:
     if: ${{ always() }}
     needs: [
       coverage-collect,
-      integration-test-collect,
+      robot-collect,
       docker-build-push,
       maven-publish
     ]
@@ -433,7 +449,7 @@ jobs:
           name: |
             java-class-files
             ehrbase-jar
-            ehrbase-image-test
+            ehrbase-image-*
             robot-result-*
             jacoco-coverage-*
           failOnError: false

--- a/.github/workflows/job-integration-test-cli.yml
+++ b/.github/workflows/job-integration-test-cli.yml
@@ -1,0 +1,40 @@
+name: "Integration Test - EHRbase CLI"
+
+on:
+  workflow_call:
+    inputs:
+      ehrbase-image-tag:
+        type: string
+        description: 'Docker image tag name'
+        required: true
+      ehrbase-image-artifact:
+        type: string
+        description: 'Archived ehrbase docker image artifact name'
+        required: true
+
+jobs:
+  #
+  # Runs simple CLI integration tests against the EHRbase image
+  #
+  integration-test-cli:
+    name: EHRbase CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download - Image
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.ehrbase-image-artifact }}
+          path: ${{ runner.temp }}
+
+      # Docker load login
+      - name: Docker - Load Image
+        run: docker load --input ${{ runner.temp }}/ehrbase-test.tar
+
+      # Docker run test
+      - name: Docker - Test cli help
+        run:  docker run -i --rm ${{ inputs.ehrbase-image-tag }} cli help
+
+      # Docker run test
+      - name: Docker - Test cli database help
+        run:  docker run -i --rm ${{ inputs.ehrbase-image-tag }} cli database help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
  ### Added
 * Experimental ItemTag REST endpoints for EHR_STATUS and COMPOSITION (configs: `ehrbase.rest.experimental.tags.*`) ([1343](https://github.com/ehrbase/ehrbase/pull/1343))
+* CLI runner with support for flyway pre-migrations ([1387](https://github.com/ehrbase/ehrbase/pull/1387))
  ### Changed 
  ### Fixed 
 * Require EHR_STATUS `is_queryable` and `is_modifiable` to be present ([#1377](https://github.com/ehrbase/ehrbase/pull/1377)) 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR /app
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/ehrbase.jar --spring.profiles.active=docker"]
+ENTRYPOINT ["java", "-jar", "/app/ehrbase.jar", "--spring.profiles.active=docker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,17 @@ FROM eclipse-temurin:21-jre-alpine
 
 RUN addgroup -S ehrbase && adduser -S ehrbase -G ehrbase
 
-COPY /application/target/ehrbase.jar /app/ehrbase.jar
-
-RUN chown -R ehrbase:ehrbase /app
 USER ehrbase
+
 WORKDIR /app
+
+COPY /application/target/ehrbase.jar /app/ehrbase.jar
+COPY --chown=ehrbase:ehrbase /docker-entrypoint.sh /app/docker-entrypoint
+
+RUN chown -R ehrbase:ehrbase /app &\
+    chmod +x /app/docker-entrypoint
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/ehrbase.jar", "--spring.profiles.active=docker"]
+# wrapped in entrypoint to be able to accept cli args and use jacoco cli env var
+ENTRYPOINT ["/app/docker-entrypoint"]

--- a/api/src/main/java/org/ehrbase/api/definitions/ServerConfig.java
+++ b/api/src/main/java/org/ehrbase/api/definitions/ServerConfig.java
@@ -21,7 +21,5 @@ public interface ServerConfig {
 
     int getPort();
 
-    void setPort(int port);
-
     boolean isDisableStrictValidation();
 }

--- a/api/src/main/java/org/ehrbase/api/dto/AqlQueryContext.java
+++ b/api/src/main/java/org/ehrbase/api/dto/AqlQueryContext.java
@@ -22,6 +22,8 @@ import org.ehrbase.openehr.sdk.response.dto.MetaData;
 
 public interface AqlQueryContext {
 
+    String BEAN_NAME = "scopedAqlQueryContext";
+
     interface MetaProperty {
         String propertyName();
     }

--- a/application/src/main/java/org/ehrbase/application/cli/EhrBaseCli.java
+++ b/application/src/main/java/org/ehrbase/application/cli/EhrBaseCli.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.application.cli;
+
+import java.util.Map;
+import org.ehrbase.cli.CliConfiguration;
+import org.ehrbase.cli.CliRunner;
+import org.ehrbase.configuration.EhrBaseCliConfiguration;
+import org.springframework.boot.Banner;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication(exclude = {WebMvcAutoConfiguration.class, RedisAutoConfiguration.class})
+@Import({EhrBaseCliConfiguration.class, CliConfiguration.class})
+public class EhrBaseCli implements CommandLineRunner {
+
+    public static SpringApplication build(String[] args) {
+        return new SpringApplicationBuilder(EhrBaseCli.class)
+                .web(WebApplicationType.NONE)
+                .headless(true)
+                .properties(Map.of(
+                        "spring.main.allow-bean-definition-overriding", "true",
+                        "spring.banner.location", "classpath:banner-cli.txt"))
+                .bannerMode(Banner.Mode.CONSOLE)
+                .logStartupInfo(false)
+                .build(args);
+    }
+
+    private final CliRunner cliRunner;
+
+    public EhrBaseCli(CliRunner cliRunner) {
+        this.cliRunner = cliRunner;
+    }
+
+    @Override
+    public void run(String... args) {
+        cliRunner.run(args);
+    }
+}

--- a/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
+++ b/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Import;
             SecurityAutoConfiguration.class
         })
 @Import({EhrBaseServerConfiguration.class})
+@SuppressWarnings("java:S1118")
 public class EhrBaseServer {
 
     public static SpringApplication build(String[] args) {

--- a/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
+++ b/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
@@ -40,7 +40,6 @@ public class EhrBaseServer {
     public static SpringApplication build(String[] args) {
         return new SpringApplicationBuilder(EhrBaseServer.class)
                 .web(WebApplicationType.SERVLET)
-                .profiles("cli")
                 .build(args);
     }
 }

--- a/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
+++ b/application/src/main/java/org/ehrbase/application/server/EhrBaseServer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.application.server;
+
+import org.ehrbase.configuration.EhrBaseServerConfiguration;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication(
+        exclude = {
+            ManagementWebSecurityAutoConfiguration.class,
+            R2dbcAutoConfiguration.class,
+            SecurityAutoConfiguration.class
+        })
+@Import({EhrBaseServerConfiguration.class})
+public class EhrBaseServer {
+
+    public static SpringApplication build(String[] args) {
+        return new SpringApplicationBuilder(EhrBaseServer.class)
+                .web(WebApplicationType.SERVLET)
+                .profiles("cli")
+                .build(args);
+    }
+}

--- a/application/src/main/resources/banner-cli.txt
+++ b/application/src/main/resources/banner-cli.txt
@@ -1,0 +1,1 @@
+${AnsiColor.BLUE}EHRbase CLI (Spring Boot ${spring-boot.version} EHRbase ${application.formatted-version} https://ehrbase.org/)${AnsiBackground.DEFAULT}${AnsiColor.DEFAULT}

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -212,6 +212,11 @@
       </dependency>
       <dependency>
         <groupId>org.ehrbase.openehr</groupId>
+        <artifactId>cli</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ehrbase.openehr</groupId>
         <artifactId>configuration</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -30,40 +30,26 @@
     <version>2.7.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>application</artifactId>
+  <artifactId>cli</artifactId>
   <packaging>jar</packaging>
-
-
 
   <dependencies>
     <dependency>
       <groupId>org.ehrbase.openehr</groupId>
       <artifactId>configuration</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.ehrbase.openehr</groupId>
-      <artifactId>cli</artifactId>
-    </dependency>
-  </dependencies>
 
-  <build>
-    <finalName>ehrbase</finalName>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>org.ehrbase.application.EhrBase</mainClass>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <!-- test scope -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
 </project>

--- a/cli/src/main/java/org/ehrbase/cli/CliConfiguration.java
+++ b/cli/src/main/java/org/ehrbase/cli/CliConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 vitasystems GmbH.
+ * Copyright (c) 2019-2024 vitasystems GmbH.
  *
  * This file is part of project EHRbase
  *
@@ -15,20 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.application;
+package org.ehrbase.cli;
 
-import java.util.Arrays;
-import org.ehrbase.application.cli.EhrBaseCli;
-import org.ehrbase.application.server.EhrBaseServer;
-import org.ehrbase.cli.CliRunner;
-import org.springframework.boot.SpringApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
-public class EhrBase {
-
-    public static void main(String[] args) {
-
-        SpringApplication app =
-                Arrays.asList(args).contains(CliRunner.CLI) ? EhrBaseCli.build(args) : EhrBaseServer.build(args);
-        app.run(args);
-    }
-}
+@Configuration
+@ComponentScan(basePackages = "org.ehrbase.cli")
+public class CliConfiguration {}

--- a/cli/src/main/java/org/ehrbase/cli/CliRunner.java
+++ b/cli/src/main/java/org/ehrbase/cli/CliRunner.java
@@ -100,7 +100,7 @@ public class CliRunner {
     private void runCommand(CliCommand command, List<String> args) {
         try {
             command.run(args);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.error("Failed to execute [%s]".formatted(command.getName()), e);
             helpCommand.exitFail(e.getMessage());
         }

--- a/cli/src/main/java/org/ehrbase/cli/CliRunner.java
+++ b/cli/src/main/java/org/ehrbase/cli/CliRunner.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+import org.assertj.core.util.Lists;
+import org.ehrbase.cli.cmd.CliCommand;
+import org.ehrbase.cli.cmd.CliHelpCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CliRunner {
+
+    public static final String CLI = "cli";
+
+    private final Logger logger = LoggerFactory.getLogger(CliRunner.class);
+
+    private final CliHelpCommand helpCommand;
+    private final List<CliCommand> commands;
+
+    public CliRunner(List<CliCommand> commands, CliHelpCommand helpCommand) {
+
+        this.helpCommand = helpCommand;
+        this.commands = commands.stream()
+                .sorted(Comparator.comparing(CliCommand::getName))
+                .toList();
+    }
+
+    public void run(String... args) {
+        run(
+                (t, t2) -> {
+                    throw new IllegalStateException(String.format(
+                            "Duplicate command for name %s (attempted merging values %s and %s)", t.getName(), t, t2));
+                },
+                args);
+    }
+
+    public void run(BinaryOperator<CliCommand> onDuplicatedCmd, String... args) {
+
+        List<String> argList = Arrays.asList(args);
+
+        Iterator<String> argIter = argList.iterator();
+        Optional<String> commandName = extractCmd(argIter);
+
+        Map<String, CliCommand> namedCommands =
+                commands.stream().collect(Collectors.toMap(CliCommand::getName, item -> item, onDuplicatedCmd));
+
+        commandName.ifPresentOrElse(
+                name -> Optional.ofNullable(namedCommands.get(name))
+                        .ifPresentOrElse(
+                                command -> runCommand(command, Lists.newArrayList(argIter)),
+                                () -> helpCommand.exitFail("Unknown command %s".formatted(name))),
+                () -> helpCommand.exitFail("No command specified"));
+    }
+
+    private Optional<String> extractCmd(Iterator<String> argIter) {
+
+        if (!argIter.hasNext()) {
+            return Optional.empty();
+        }
+
+        // consume until cli commands
+        while (argIter.hasNext()) {
+            String next = argIter.next();
+            if (next.equals(CLI)) {
+                break;
+            }
+        }
+
+        if (!argIter.hasNext()) {
+            return Optional.empty();
+        }
+        return Optional.of(argIter.next());
+    }
+
+    private void runCommand(CliCommand command, List<String> args) {
+        try {
+            command.run(args);
+        } catch (Exception e) {
+            logger.error("Failed to execute [%s]".formatted(command.getName()), e);
+            helpCommand.exitFail(e.getMessage());
+        }
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.cmd;
+
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.ehrbase.cli.util.ExceptionFriendlyFunction;
+
+public abstract class CliCommand {
+
+    /**
+     * Represents a command CliArgument
+     * @param arg   arg line
+     * @param key   argument key=
+     * @param value argument =value
+     */
+    public record CliArgument(String arg, String key, @Nullable String value) {}
+
+    /**
+     * Represents the Result of a {@link CliArgument} execution
+     */
+    public sealed interface Result permits Result.OK, Result.Unknown {
+
+        Result OK = new OK();
+        Result Unknown = new Unknown();
+
+        final class OK implements Result {}
+
+        final class Unknown implements Result {}
+    }
+
+    protected final String name;
+
+    public CliCommand(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public abstract void run(List<String> args) throws Exception;
+
+    protected static void println(String line) {
+        System.out.println(line);
+        // logger.info(line);
+    }
+
+    protected static void printStep(String line) {
+        println("---------------------------------------------------------------------------");
+        println(line);
+        println("---------------------------------------------------------------------------");
+    }
+
+    public void exitFail(String reason) {
+
+        System.err.println(reason);
+        printUsage();
+        System.exit(-1);
+    }
+
+    protected abstract void printUsage();
+
+    protected void consumeArgs(Iterable<String> args, ExceptionFriendlyFunction<CliArgument, Result> consumer)
+            throws Exception {
+
+        Iterator<String> argIter = args.iterator();
+        if (!argIter.hasNext()) {
+            exitFail("No import argument provided");
+            return;
+        }
+
+        String next;
+        while (argIter.hasNext()) {
+            next = argIter.next();
+            String[] split = next.split("=");
+            CliArgument arg = new CliArgument(next, split[0].replaceAll("--", ""), split.length > 1 ? split[1] : null);
+
+            if (arg.key.equals("help")) {
+                printStep("Help");
+                printUsage();
+                return;
+            }
+
+            Result result = consumer.apply(arg);
+            if (result instanceof Result.Unknown) {
+                exitFail("Unknown argument [%s]".formatted(arg.arg()));
+            }
+        }
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.ehrbase.cli.util.ExceptionFriendlyFunction;
 
+@SuppressWarnings("java:S5803")
 public abstract class CliCommand {
 
     /**
@@ -47,7 +48,7 @@ public abstract class CliCommand {
 
     protected final String name;
 
-    public CliCommand(String name) {
+    protected CliCommand(String name) {
         this.name = name;
     }
 
@@ -55,23 +56,28 @@ public abstract class CliCommand {
         return name;
     }
 
-    public abstract void run(List<String> args) throws Exception;
+    public abstract void run(List<String> args) throws Throwable;
 
-    protected static void println(String line) {
+    @SuppressWarnings("java:S106")
+    void println(String line) {
         System.out.println(line);
-        // logger.info(line);
     }
 
-    protected static void printStep(String line) {
+    protected void printStep(String line) {
         println("---------------------------------------------------------------------------");
         println(line);
         println("---------------------------------------------------------------------------");
     }
 
+    @SuppressWarnings("java:S106")
     public void exitFail(String reason) {
 
         System.err.println(reason);
         printUsage();
+        exit(-1);
+    }
+
+    void exit(int code) {
         System.exit(-1);
     }
 
@@ -82,7 +88,7 @@ public abstract class CliCommand {
 
         Iterator<String> argIter = args.iterator();
         if (!argIter.hasNext()) {
-            exitFail("No import argument provided");
+            exitFail("No argument provided");
             return;
         }
 
@@ -90,13 +96,7 @@ public abstract class CliCommand {
         while (argIter.hasNext()) {
             next = argIter.next();
             String[] split = next.split("=");
-            CliArgument arg = new CliArgument(next, split[0].replaceAll("--", ""), split.length > 1 ? split[1] : null);
-
-            if (arg.key.equals("help")) {
-                printStep("Help");
-                printUsage();
-                return;
-            }
+            CliArgument arg = new CliArgument(next, split[0].replace("--", ""), split.length > 1 ? split[1] : null);
 
             Result result = consumer.apply(arg);
             if (result instanceof Result.Unknown) {

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliCommand.java
@@ -56,10 +56,11 @@ public abstract class CliCommand {
         return name;
     }
 
+    @SuppressWarnings("java:S112")
     public abstract void run(List<String> args) throws Throwable;
 
     @SuppressWarnings("java:S106")
-    void println(String line) {
+    protected void println(String line) {
         System.out.println(line);
     }
 
@@ -78,7 +79,7 @@ public abstract class CliCommand {
     }
 
     void exit(int code) {
-        System.exit(-1);
+        System.exit(code);
     }
 
     protected abstract void printUsage();
@@ -95,6 +96,12 @@ public abstract class CliCommand {
         String next;
         while (argIter.hasNext()) {
             next = argIter.next();
+
+            if (next.equals("help")) {
+                printUsage();
+                return;
+            }
+
             String[] split = next.split("=");
             CliArgument arg = new CliArgument(next, split[0].replace("--", ""), split.length > 1 ? split[1] : null);
 

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliDataBaseCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliDataBaseCommand.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.cmd;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.util.List;
+import javax.sql.DataSource;
+import org.ehrbase.configuration.config.flyway.MigrationStrategy;
+import org.ehrbase.configuration.config.flyway.MigrationStrategyConfig;
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CliDataBaseCommand extends CliCommand {
+
+    protected final DataSource dataSource;
+
+    protected final Flyway flyway;
+
+    protected final MigrationStrategyConfig migrationStrategyConfig;
+
+    public CliDataBaseCommand(DataSource dataSource, Flyway flyway, MigrationStrategyConfig migrationStrategyConfig) {
+        super("database");
+        this.dataSource = dataSource;
+        this.flyway = flyway;
+        this.migrationStrategyConfig = migrationStrategyConfig;
+    }
+
+    @Override
+    public void run(List<String> args) throws Exception {
+
+        consumeArgs(args, arg -> switch (arg.key()) {
+            case "check-connection":
+                yield executeCheckConnection();
+            case "migration-validate":
+                yield executeMigration(MigrationStrategy.VALIDATE);
+            case "migration-migrate":
+                yield executeMigration(MigrationStrategy.MIGRATE);
+            default:
+                yield Result.Unknown;
+        });
+    }
+
+    protected Result executeCheckConnection() {
+
+        printStep("executing Database connection check: %s".formatted(jdbUrl()));
+
+        try (Connection connection = dataSource.getConnection()) {
+            String url = connection.getMetaData().getURL();
+            println("Connection established to %s".formatted(url));
+            return Result.OK;
+        } catch (Exception e) {
+            exitFail("Failed to open connection %s".formatted(jdbUrl()));
+            return Result.Unknown;
+        }
+    }
+
+    protected Result executeMigration(MigrationStrategy migrationStrategy) {
+
+        printStep("executing Flyway with strategy: %s".formatted(migrationStrategy));
+
+        FlywayMigrationStrategy strategy =
+                migrationStrategyConfig.flywayMigrationStrategy(migrationStrategy, migrationStrategy);
+        strategy.migrate(flyway);
+        return Result.OK;
+    }
+
+    protected String jdbUrl() {
+        return ((HikariDataSource) dataSource).getJdbcUrl();
+    }
+
+    @Override
+    protected void printUsage() {
+        println(
+                """
+                Database related operation like connection verification or migration.
+
+                Arguments:
+                  --check-connection    verifies database access by open/close a connection
+                  --migration-validate  validate flyway migration
+                  --migration-migrate   executes flyway migration
+
+                Example:
+
+                database --check-connection --migration-validate
+                """);
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliHelpCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliHelpCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.cmd;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CliHelpCommand extends CliCommand {
+
+    public CliHelpCommand() {
+        super("help");
+    }
+
+    @Override
+    public void run(List<String> args) {
+        if (!args.isEmpty()) {
+            exitFail("illegal arguments %s".formatted(args));
+        }
+
+        printStep("Help");
+        printUsage();
+    }
+
+    @Override
+    protected void printUsage() {
+        println(
+                """
+                Run with subcommand
+
+                cli [sub-command] [arguments]
+                s
+                Sub-commands:
+                    database  database related operation
+                    help      print this help message
+
+                Examples:
+
+                # show this help message
+                cli help
+
+                # show help message of a sub-command
+                cli database
+                cli database help
+
+                # execute sub-command with arguments
+                cli database --check-connection
+                """);
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/cmd/CliHelpCommand.java
+++ b/cli/src/main/java/org/ehrbase/cli/cmd/CliHelpCommand.java
@@ -44,7 +44,7 @@ public class CliHelpCommand extends CliCommand {
                 Run with subcommand
 
                 cli [sub-command] [arguments]
-                s
+
                 Sub-commands:
                     database  database related operation
                     help      print this help message

--- a/cli/src/main/java/org/ehrbase/cli/config/CliAqlQueryContext.java
+++ b/cli/src/main/java/org/ehrbase/cli/config/CliAqlQueryContext.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.config;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.ehrbase.api.dto.AqlQueryContext;
+import org.ehrbase.api.service.StatusService;
+import org.ehrbase.openehr.sdk.response.dto.MetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * AQL query context implementation used for EHRbase CLI that can be configured using
+ * <code>-aql-mode=default|dry_run|show_executed_aql|show_executed_sql|show_query_plane</code> params.
+ */
+@Component(AqlQueryContext.BEAN_NAME)
+public class CliAqlQueryContext implements AqlQueryContext {
+
+    private static final Logger logger = LoggerFactory.getLogger(CliAqlQueryContext.class);
+
+    private enum AqlMode {
+        DEFAULT,
+        DRY_RUN,
+        SHOW_EXECUTED_SQL,
+        SHOW_EXECUTED_AQL,
+        SHOW_QUERY_PLAN
+    }
+
+    private final AqlMode mode;
+
+    private final StatusService statusService;
+
+    private String executedAql;
+
+    private final Map<String, Object> metaProperties = new LinkedHashMap<>();
+
+    public CliAqlQueryContext(StatusService statusService, @Value("${aql-mode:default}") String aqlMode) {
+        this.statusService = statusService;
+
+        this.mode = Arrays.stream(AqlMode.values())
+                .filter(it -> it.name().equalsIgnoreCase(aqlMode))
+                .findFirst()
+                .orElseGet(() -> {
+                    logger.warn(
+                            "Unknown --aql-mode={} not in supported {} using fallback {}",
+                            aqlMode,
+                            Arrays.stream(AqlMode.values())
+                                    .map(it -> it.name().toLowerCase(Locale.ROOT))
+                                    .toList(),
+                            AqlMode.DEFAULT.name().toLowerCase(Locale.ROOT));
+                    return AqlMode.DEFAULT;
+                });
+    }
+
+    @Override
+    public MetaData createMetaData(URI location) {
+        MetaData metaData = new MetaData();
+        metaData.setCreated(OffsetDateTime.now());
+        metaData.setSchemaVersion(AqlQueryContext.OPENEHR_REST_API_VERSION);
+        metaData.setType(MetaData.RESULTSET);
+
+        metaData.setHref(Optional.ofNullable(location).map(URI::toASCIIString).orElse(null));
+
+        metaData.setGenerator("EHRBase-CLI/%s".formatted(statusService.getEhrbaseVersion()));
+
+        metaData.setExecutedAql(this.executedAql);
+
+        if (isDryRun()) {
+            setMetaProperty(AqlQueryContext.EhrbaseMetaProperty.DRY_RUN, true);
+        }
+
+        metaProperties.forEach(metaData::setAdditionalProperty);
+
+        return metaData;
+    }
+
+    @Override
+    public boolean isDryRun() {
+        return AqlMode.DRY_RUN == mode;
+    }
+
+    @Override
+    public boolean showExecutedAql() {
+        return AqlMode.SHOW_EXECUTED_SQL == mode;
+    }
+
+    @Override
+    public boolean showExecutedSql() {
+        return AqlMode.SHOW_EXECUTED_SQL == mode;
+    }
+
+    @Override
+    public boolean showQueryPlan() {
+        return AqlMode.SHOW_QUERY_PLAN == mode;
+    }
+
+    @Override
+    public void setExecutedAql(String executedAql) {
+        this.executedAql = executedAql;
+    }
+
+    @Override
+    public void setMetaProperty(MetaProperty property, Object value) {
+        String name = property.propertyName();
+        if (value == null) {
+            metaProperties.remove(name);
+        } else {
+            metaProperties.put(name, value);
+        }
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/config/CliAqlQueryContext.java
+++ b/cli/src/main/java/org/ehrbase/cli/config/CliAqlQueryContext.java
@@ -18,18 +18,8 @@
 package org.ehrbase.cli.config;
 
 import java.net.URI;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
 import org.ehrbase.api.dto.AqlQueryContext;
-import org.ehrbase.api.service.StatusService;
 import org.ehrbase.openehr.sdk.response.dto.MetaData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -39,96 +29,40 @@ import org.springframework.stereotype.Component;
 @Component(AqlQueryContext.BEAN_NAME)
 public class CliAqlQueryContext implements AqlQueryContext {
 
-    private static final Logger logger = LoggerFactory.getLogger(CliAqlQueryContext.class);
-
-    private enum AqlMode {
-        DEFAULT,
-        DRY_RUN,
-        SHOW_EXECUTED_SQL,
-        SHOW_EXECUTED_AQL,
-        SHOW_QUERY_PLAN
-    }
-
-    private final AqlMode mode;
-
-    private final StatusService statusService;
-
-    private String executedAql;
-
-    private final Map<String, Object> metaProperties = new LinkedHashMap<>();
-
-    public CliAqlQueryContext(StatusService statusService, @Value("${aql-mode:default}") String aqlMode) {
-        this.statusService = statusService;
-
-        this.mode = Arrays.stream(AqlMode.values())
-                .filter(it -> it.name().equalsIgnoreCase(aqlMode))
-                .findFirst()
-                .orElseGet(() -> {
-                    logger.warn(
-                            "Unknown --aql-mode={} not in supported {} using fallback {}",
-                            aqlMode,
-                            Arrays.stream(AqlMode.values())
-                                    .map(it -> it.name().toLowerCase(Locale.ROOT))
-                                    .toList(),
-                            AqlMode.DEFAULT.name().toLowerCase(Locale.ROOT));
-                    return AqlMode.DEFAULT;
-                });
-    }
+    private static final String UNSUPPORTED_MSG = "AQL is not supported on CLI";
 
     @Override
     public MetaData createMetaData(URI location) {
-        MetaData metaData = new MetaData();
-        metaData.setCreated(OffsetDateTime.now());
-        metaData.setSchemaVersion(AqlQueryContext.OPENEHR_REST_API_VERSION);
-        metaData.setType(MetaData.RESULTSET);
-
-        metaData.setHref(Optional.ofNullable(location).map(URI::toASCIIString).orElse(null));
-
-        metaData.setGenerator("EHRBase-CLI/%s".formatted(statusService.getEhrbaseVersion()));
-
-        metaData.setExecutedAql(this.executedAql);
-
-        if (isDryRun()) {
-            setMetaProperty(AqlQueryContext.EhrbaseMetaProperty.DRY_RUN, true);
-        }
-
-        metaProperties.forEach(metaData::setAdditionalProperty);
-
-        return metaData;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public boolean isDryRun() {
-        return AqlMode.DRY_RUN == mode;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public boolean showExecutedAql() {
-        return AqlMode.SHOW_EXECUTED_SQL == mode;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public boolean showExecutedSql() {
-        return AqlMode.SHOW_EXECUTED_SQL == mode;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public boolean showQueryPlan() {
-        return AqlMode.SHOW_QUERY_PLAN == mode;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public void setExecutedAql(String executedAql) {
-        this.executedAql = executedAql;
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     @Override
     public void setMetaProperty(MetaProperty property, Object value) {
-        String name = property.propertyName();
-        if (value == null) {
-            metaProperties.remove(name);
-        } else {
-            metaProperties.put(name, value);
-        }
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 }

--- a/cli/src/main/java/org/ehrbase/cli/config/CliOverwriteConfig.java
+++ b/cli/src/main/java/org/ehrbase/cli/config/CliOverwriteConfig.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 @Configuration
-public class CliOverwriteConfiguration {
+public class CliOverwriteConfig {
 
     @Bean
     @Primary

--- a/cli/src/main/java/org/ehrbase/cli/config/CliOverwriteConfiguration.java
+++ b/cli/src/main/java/org/ehrbase/cli/config/CliOverwriteConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.config;
+
+import org.ehrbase.configuration.config.validation.ValidationConfiguration;
+import org.ehrbase.openehr.sdk.validation.terminology.ExternalTerminologyValidation;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CliOverwriteConfiguration {
+
+    @Bean
+    @Primary
+    public FlywayMigrationStrategy flywayMigrationStrategy() {
+        return flyway -> {
+            // Nop - prevent any flyway interaction
+        };
+    }
+
+    @Bean
+    public ExternalTerminologyValidation externalTerminologyValidator() {
+        return ValidationConfiguration.nopTerminologyValidation();
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/config/NopServerConfig.java
+++ b/cli/src/main/java/org/ehrbase/cli/config/NopServerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.config;
+
+import org.ehrbase.api.definitions.ServerConfig;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "server")
+public class NopServerConfig implements ServerConfig {
+
+    private boolean disableStrictValidation = false;
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    public void setPort(@SuppressWarnings("unused") int port) {
+        // ignored
+    }
+
+    public void setDisableStrictValidation(boolean disableStrictValidation) {
+        this.disableStrictValidation = disableStrictValidation;
+    }
+
+    @Override
+    public boolean isDisableStrictValidation() {
+        return this.disableStrictValidation;
+    }
+}

--- a/cli/src/main/java/org/ehrbase/cli/util/ExceptionFriendlyFunction.java
+++ b/cli/src/main/java/org/ehrbase/cli/util/ExceptionFriendlyFunction.java
@@ -20,5 +20,6 @@ package org.ehrbase.cli.util;
 @FunctionalInterface
 public interface ExceptionFriendlyFunction<T, R> {
 
+    @SuppressWarnings("java:S112")
     R apply(T value) throws Exception;
 }

--- a/cli/src/main/java/org/ehrbase/cli/util/ExceptionFriendlyFunction.java
+++ b/cli/src/main/java/org/ehrbase/cli/util/ExceptionFriendlyFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 vitasystems GmbH.
+ * Copyright (c) 2019-2024 vitasystems GmbH.
  *
  * This file is part of project EHRbase
  *
@@ -15,20 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.application;
+package org.ehrbase.cli.util;
 
-import java.util.Arrays;
-import org.ehrbase.application.cli.EhrBaseCli;
-import org.ehrbase.application.server.EhrBaseServer;
-import org.ehrbase.cli.CliRunner;
-import org.springframework.boot.SpringApplication;
+@FunctionalInterface
+public interface ExceptionFriendlyFunction<T, R> {
 
-public class EhrBase {
-
-    public static void main(String[] args) {
-
-        SpringApplication app =
-                Arrays.asList(args).contains(CliRunner.CLI) ? EhrBaseCli.build(args) : EhrBaseServer.build(args);
-        app.run(args);
-    }
+    R apply(T value) throws Exception;
 }

--- a/cli/src/test/java/org/ehrbase/cli/CliRunnerTest.java
+++ b/cli/src/test/java/org/ehrbase/cli/CliRunnerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import org.ehrbase.cli.cmd.CliCommand;
+import org.ehrbase.cli.cmd.CliHelpCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class CliRunnerTest {
+
+    private CliHelpCommand mockHelpCommand = mock(CliHelpCommand.class);
+
+    private static class CliTestCommand extends CliCommand {
+
+        List<String> args;
+
+        public CliTestCommand(String name) {
+            super(name);
+        }
+
+        @Override
+        public void run(List<String> args) {
+            this.args = args;
+        }
+
+        @Override
+        protected void printUsage() {}
+    }
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(mockHelpCommand);
+    }
+
+    private CliRunner cliRunner(CliCommand... commands) {
+        return new CliRunner(Arrays.stream(commands).toList(), mockHelpCommand);
+    }
+
+    @Test
+    void duplicateCommandError() {
+
+        var cmd1 = new CliTestCommand("duplicate-cmd");
+        var cmd2 = new CliTestCommand("duplicate-cmd");
+        CliRunner cliRunner = cliRunner(cmd1, cmd2);
+        String message =
+                assertThrows(IllegalStateException.class, cliRunner::run).getMessage();
+        assertEquals(
+                "Duplicate command for name duplicate-cmd (attempted merging values %s and %s)".formatted(cmd1, cmd2),
+                message);
+    }
+
+    @Test
+    void runErrorWithoutArguments() {
+
+        cliRunner().run();
+        verify(mockHelpCommand).exitFail(eq("No command specified"));
+    }
+
+    @Test
+    void runErrorWithoutCliArguments() {
+
+        cliRunner().run("--some --other=true --command");
+        verify(mockHelpCommand).exitFail(eq("No command specified"));
+    }
+
+    @Test
+    void runErrorCommandNotExist() {
+
+        cliRunner().run("cli", "does-not-exist");
+        verify(mockHelpCommand).exitFail(eq("Unknown command does-not-exist"));
+    }
+
+    @Test
+    void runCommand() {
+
+        var cmd = new CliTestCommand("capture-the-flag");
+        cliRunner(cmd).run(CliRunner.CLI, "capture-the-flag");
+
+        assertNotNull(cmd.args);
+    }
+
+    @Test
+    void runCommandWithArgument() {
+
+        var cmd = new CliTestCommand("capture-the-flag");
+        cliRunner(cmd).run(CliRunner.CLI, "capture-the-flag", "--flag=true");
+
+        assertNotNull(cmd.args);
+        assertEquals(1, cmd.args.size());
+        assertEquals("--flag=true", cmd.args.getFirst());
+    }
+}

--- a/cli/src/test/java/org/ehrbase/cli/cmd/CliDataBaseCommandTest.java
+++ b/cli/src/test/java/org/ehrbase/cli/cmd/CliDataBaseCommandTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.cmd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.util.List;
+import org.ehrbase.configuration.config.flyway.MigrationStrategy;
+import org.ehrbase.configuration.config.flyway.MigrationStrategyConfig;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+
+class CliDataBaseCommandTest {
+
+    private final HikariDataSource dataSource = mock();
+    private final Flyway flyway = mock();
+    private final MigrationStrategyConfig migrationStrategyConfig = spy(new MigrationStrategyConfig());
+    private final FlywayMigrationStrategy strategy = mock();
+
+    private final CliDataBaseCommand cmd = spy(new CliDataBaseCommand(dataSource, flyway, migrationStrategyConfig));
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(cmd, dataSource, flyway, migrationStrategyConfig, strategy);
+        doNothing().when(cmd).exit(any(Integer.class));
+        doNothing().when(cmd).println(any());
+    }
+
+    @Test
+    void commandNameIsHelp() {
+        assertEquals("database", cmd.getName());
+    }
+
+    @Test
+    void runWithoutArgumentError() throws Exception {
+
+        cmd.run(List.of());
+
+        verify(cmd, times(1)).printUsage();
+        verify(cmd, times(1)).exitFail("No argument provided");
+        verify(cmd, times(1)).exit(-1);
+    }
+
+    @Test
+    void runWithUnknownArgumentError() throws Exception {
+
+        cmd.run(List.of("illegal"));
+
+        verify(cmd, times(1)).printUsage();
+        verify(cmd, times(1)).exitFail("Unknown argument [illegal]");
+        verify(cmd, times(1)).exit(-1);
+    }
+
+    @Test
+    void runCheckConnection() throws Exception {
+
+        var jdbUrl = "jdbc:test//localhost:1234/db";
+        doReturn(jdbUrl).when(dataSource).getJdbcUrl();
+
+        DatabaseMetaData metaData = mock();
+        doReturn(jdbUrl).when(metaData).getURL();
+
+        Connection connection = mock();
+        doReturn(metaData).when(connection).getMetaData();
+
+        doReturn(connection).when(dataSource).getConnection();
+
+        cmd.run(List.of("--check-connection"));
+
+        verify(cmd, never()).printUsage();
+        verify(cmd, never()).exit(any(Integer.class));
+    }
+
+    @Test
+    void runMigrationVerify() throws Exception {
+
+        runMigrationTest("--migration-validate", MigrationStrategy.VALIDATE);
+    }
+
+    @Test
+    void runMigrationMigrate() throws Exception {
+
+        runMigrationTest("--migration-migrate", MigrationStrategy.MIGRATE);
+    }
+
+    private void runMigrationTest(String arg, MigrationStrategy migrationStrategy) throws Exception {
+        doReturn(strategy).when(migrationStrategyConfig).flywayMigrationStrategy(migrationStrategy, migrationStrategy);
+
+        cmd.run(List.of(arg));
+
+        verify(strategy, times(1)).migrate(flyway);
+    }
+}

--- a/cli/src/test/java/org/ehrbase/cli/cmd/CliDataBaseCommandTest.java
+++ b/cli/src/test/java/org/ehrbase/cli/cmd/CliDataBaseCommandTest.java
@@ -81,6 +81,17 @@ class CliDataBaseCommandTest {
     }
 
     @Test
+    void runHelp() throws Exception {
+
+        cmd.run(List.of("help"));
+
+        verify(cmd, times(1)).printUsage();
+        verify(cmd, times(1)).printUsage();
+        verify(cmd, never()).exitFail(any());
+        verify(cmd, never()).exit(any(Integer.class));
+    }
+
+    @Test
     void runCheckConnection() throws Exception {
 
         var jdbUrl = "jdbc:test//localhost:1234/db";

--- a/cli/src/test/java/org/ehrbase/cli/cmd/CliHelpCommandTest.java
+++ b/cli/src/test/java/org/ehrbase/cli/cmd/CliHelpCommandTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.cmd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class CliHelpCommandTest {
+
+    private final CliHelpCommand cmd = spy(new CliHelpCommand());
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(cmd);
+        doNothing().when(cmd).exit(any(Integer.class));
+        doNothing().when(cmd).println(any());
+    }
+
+    @Test
+    void commandNameIsHelp() {
+        assertEquals("help", cmd.getName());
+    }
+
+    @Test
+    void runWithArgumentError() {
+
+        cmd.run(List.of("invalid"));
+
+        verify(cmd, times(1)).exitFail("illegal arguments [invalid]");
+        verify(cmd, times(1)).exit(-1);
+    }
+
+    @Test
+    void runWithoutArgument() {
+
+        cmd.run(List.of());
+
+        verify(cmd, times(1)).printUsage();
+        verify(cmd, never()).exit(any(Integer.class));
+    }
+}

--- a/cli/src/test/java/org/ehrbase/cli/config/CliOverwriteConfigTest.java
+++ b/cli/src/test/java/org/ehrbase/cli/config/CliOverwriteConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.cli.config;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.ehrbase.configuration.config.validation.NopExternalTerminologyValidation;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CliOverwriteConfigTest {
+
+    private final CliOverwriteConfig config = new CliOverwriteConfig();
+
+    @Test
+    void nopFlywayMigrationStrategy() {
+
+        Flyway flyway = mock();
+        config.flywayMigrationStrategy().migrate(flyway);
+        verifyNoInteractions(flyway);
+    }
+
+    @Test
+    void nopExternalTerminologyValidator() {
+
+        Assertions.assertInstanceOf(NopExternalTerminologyValidation.class, config.externalTerminologyValidator());
+    }
+}

--- a/configuration/src/main/java/org/ehrbase/configuration/EhrBaseCliConfiguration.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/EhrBaseCliConfiguration.java
@@ -15,20 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.application;
+package org.ehrbase.configuration;
 
-import java.util.Arrays;
-import org.ehrbase.application.cli.EhrBaseCli;
-import org.ehrbase.application.server.EhrBaseServer;
-import org.ehrbase.cli.CliRunner;
-import org.springframework.boot.SpringApplication;
+import org.ehrbase.ServiceModuleConfiguration;
+import org.ehrbase.configuration.config.flyway.MigrationStrategyConfig;
+import org.ehrbase.openehr.aqlengine.AqlEngineModuleConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
-public class EhrBase {
-
-    public static void main(String[] args) {
-
-        SpringApplication app =
-                Arrays.asList(args).contains(CliRunner.CLI) ? EhrBaseCli.build(args) : EhrBaseServer.build(args);
-        app.run(args);
-    }
-}
+@Configuration
+@Import({ServiceModuleConfiguration.class, AqlEngineModuleConfiguration.class, MigrationStrategyConfig.class})
+public class EhrBaseCliConfiguration {}

--- a/configuration/src/main/java/org/ehrbase/configuration/EhrBaseServerConfiguration.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/EhrBaseServerConfiguration.java
@@ -29,8 +29,9 @@ import org.springframework.context.annotation.Import;
 @ComponentScan
 @Import({
     ServiceModuleConfiguration.class,
-    RestEHRScapeModuleConfiguration.class,
     RestModuleConfiguration.class,
-    AqlEngineModuleConfiguration.class
+    RestEHRScapeModuleConfiguration.class,
+    AqlEngineModuleConfiguration.class,
 })
-public class EhrBaseConfiguration {}
+// @ComponentScan("org.ehrbase.configuration")
+public class EhrBaseServerConfiguration {}

--- a/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategy.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 vitasystems GmbH.
+ * Copyright (c) 2019-2024 vitasystems GmbH.
  *
  * This file is part of project EHRbase
  *
@@ -15,20 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.application;
+package org.ehrbase.configuration.config.flyway;
 
-import java.util.Arrays;
-import org.ehrbase.application.cli.EhrBaseCli;
-import org.ehrbase.application.server.EhrBaseServer;
-import org.ehrbase.cli.CliRunner;
-import org.springframework.boot.SpringApplication;
+import java.util.function.Consumer;
+import org.flywaydb.core.Flyway;
 
-public class EhrBase {
+public enum MigrationStrategy {
+    DISABLED(f -> {}),
+    MIGRATE(Flyway::migrate),
+    VALIDATE(Flyway::validate);
 
-    public static void main(String[] args) {
+    private final Consumer<Flyway> strategy;
 
-        SpringApplication app =
-                Arrays.asList(args).contains(CliRunner.CLI) ? EhrBaseCli.build(args) : EhrBaseServer.build(args);
-        app.run(args);
+    MigrationStrategy(Consumer<Flyway> strategy) {
+        this.strategy = strategy;
+    }
+
+    public void applyStrategy(Flyway flyway) {
+        strategy.accept(flyway);
     }
 }

--- a/configuration/src/main/java/org/ehrbase/configuration/config/validation/NopExternalTerminologyValidation.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/validation/NopExternalTerminologyValidation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.configuration.config.validation;
+
+import com.nedap.archie.rm.datavalues.DvCodedText;
+import java.util.Collections;
+import java.util.List;
+import org.ehrbase.openehr.sdk.util.functional.Try;
+import org.ehrbase.openehr.sdk.validation.ConstraintViolation;
+import org.ehrbase.openehr.sdk.validation.ConstraintViolationException;
+import org.ehrbase.openehr.sdk.validation.terminology.ExternalTerminologyValidation;
+import org.ehrbase.openehr.sdk.validation.terminology.TerminologyParam;
+
+public class NopExternalTerminologyValidation implements ExternalTerminologyValidation {
+
+    private final ConstraintViolation err;
+
+    NopExternalTerminologyValidation(String errorMessage) {
+        this.err = new ConstraintViolation(errorMessage);
+    }
+
+    public Try<Boolean, ConstraintViolationException> validate(TerminologyParam param) {
+        return Try.failure(new ConstraintViolationException(List.of(err)));
+    }
+
+    public boolean supports(TerminologyParam param) {
+        return false;
+    }
+
+    public List<DvCodedText> expand(TerminologyParam param) {
+        return Collections.emptyList();
+    }
+}

--- a/configuration/src/main/java/org/ehrbase/configuration/config/validation/ValidationConfiguration.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/validation/ValidationConfiguration.java
@@ -18,20 +18,13 @@
 package org.ehrbase.configuration.config.validation;
 
 import com.jayway.jsonpath.DocumentContext;
-import com.nedap.archie.rm.datavalues.DvCodedText;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.ehrbase.api.exception.BadGatewayException;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.cache.CacheProvider;
-import org.ehrbase.openehr.sdk.util.functional.Try;
-import org.ehrbase.openehr.sdk.validation.ConstraintViolation;
-import org.ehrbase.openehr.sdk.validation.ConstraintViolationException;
 import org.ehrbase.openehr.sdk.validation.terminology.ExternalTerminologyValidation;
 import org.ehrbase.openehr.sdk.validation.terminology.ExternalTerminologyValidationChain;
-import org.ehrbase.openehr.sdk.validation.terminology.TerminologyParam;
 import org.ehrbase.service.validation.FhirTerminologyValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,22 +127,7 @@ public class ValidationConfiguration {
     }
 
     public static ExternalTerminologyValidation nopTerminologyValidation() {
-        return new ExternalTerminologyValidation() {
-
-            private final ConstraintViolation err = new ConstraintViolation(ERR_MSG);
-
-            public Try<Boolean, ConstraintViolationException> validate(TerminologyParam param) {
-                return Try.failure(new ConstraintViolationException(List.of(err)));
-            }
-
-            public boolean supports(TerminologyParam param) {
-                return false;
-            }
-
-            public List<DvCodedText> expand(TerminologyParam param) {
-                return Collections.emptyList();
-            }
-        };
+        return new NopExternalTerminologyValidation(ERR_MSG);
     }
 
     private FhirTerminologyValidation fhirTerminologyValidation(String url, WebClient webClient) {

--- a/configuration/src/main/java/org/ehrbase/configuration/config/validation/ValidationConfiguration.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/validation/ValidationConfiguration.java
@@ -54,7 +54,7 @@ import org.springframework.web.reactive.function.client.WebClientException;
 public class ValidationConfiguration {
 
     private static final String ERR_MSG = "External terminology validation is disabled, consider to enable it";
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(ValidationConfiguration.class);
     private final ValidationProperties properties;
     private final CacheProvider cacheProvider;
     private final OAuth2AuthorizedClientManager authorizedClientManager;
@@ -133,7 +133,7 @@ public class ValidationConfiguration {
         return builder.build();
     }
 
-    public ExternalTerminologyValidation nopTerminologyValidation() {
+    public static ExternalTerminologyValidation nopTerminologyValidation() {
         return new ExternalTerminologyValidation() {
 
             private final ConstraintViolation err = new ConstraintViolation(ERR_MSG);

--- a/configuration/src/main/resources/application.yml
+++ b/configuration/src/main/resources/application.yml
@@ -140,6 +140,7 @@ logging:
     org.jooq: info
     org.jooq.Constants: warn
     org.springframework: info
+    org.springframework.security.web.DefaultSecurityFilterChain: warn
     org.flywaydb.core.internal.license.VersionPrinter: warn
   pattern:
     console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr([%X]){faint} %clr(${PID}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java ${JAVA_OPTS} -jar /app/ehrbase.jar --spring.profiles.active=docker ${@}

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,9 @@
 
   <modules>
     <module>bom</module>
-    <module>api</module>
     <module>application</module>
+    <module>api</module>
+    <module>cli</module>
     <module>jooq-pg</module>
     <module>rest-ehr-scape</module>
     <module>rest-openehr</module>

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/aql/RequestScopedAqlQueryContext.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/aql/RequestScopedAqlQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 vitasystems GmbH.
+ * Copyright (c) 2019-2024 vitasystems GmbH.
  *
  * This file is part of project EHRbase
  *
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehrbase.rest.openehr;
+package org.ehrbase.rest.openehr.aql;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -33,11 +33,11 @@ import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * Holds the metadata for the response to an AQL request.
- *
+ * <p></p>
  * Note: it is expected that per request no more than one AQL query is executed
  */
 @RequestScope
-@Component("requestScopedAqlQueryContext")
+@Component(AqlQueryContext.BEAN_NAME)
 public class RequestScopedAqlQueryContext implements AqlQueryContext {
 
     @Value("${ehrbase.rest.aql.response.generator-details-enabled:false}")

--- a/tests/DockerfileTest
+++ b/tests/DockerfileTest
@@ -23,10 +23,14 @@ RUN unzip jacoco-agent.zip && \
 #
 FROM ${EHRBASE_IMAGE}
 
-COPY --from=builder /build/*.jar /app/
-
 USER root
+
+COPY --chown=<user>:<group> --from=builder /build/*.jar /app/
+COPY --chown=<user>:<group> tests/docker-int-test-entrypoint.sh /app/docker-int-test-entrypoint.sh
+
+RUN chmod +x /app/docker-int-test-entrypoint.sh
 
 ENV JACOCO_RESULT_PATH=/app/coverage/jacoco.exec
 
-ENTRYPOINT java -jar -Dspring.profiles.active=docker -javaagent:/app/jacoco-agent.jar=destfile=${JACOCO_RESULT_PATH},append=false,includes=org.ehrbase.* /app/ehrbase.jar
+# wrapped in entrypoint to be able to accept cli args and use jacoco cli env var
+ENTRYPOINT ["/app/docker-int-test-entrypoint.sh"]

--- a/tests/docker-int-test-entrypoint.sh
+++ b/tests/docker-int-test-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Jacoco agent location:   /app/jacoco-agent.jar"
+echo "Jacoco destination file: ${JACOCO_RESULT_PATH}"
+java -jar -Dspring.profiles.active=docker -javaagent:/app/jacoco-agent.jar=destfile=${JACOCO_RESULT_PATH},append=false,includes=org.ehrbase.* /app/ehrbase.jar ${@}


### PR DESCRIPTION
# Changes

Add CLI app mode with commands to run pre migration operations. The CLI mode uses the same spring application stack without WebMVC. This allows to re-use most of the existing configuration. 

To start the cli mode append `cli` as an command line argument, followed by the sub command and it's options.

example (docker):
```sh
$ docker run -i --rm ehrbase:next cli help

EHRbase CLI (Spring Boot 3.2.5 EHRbase  https://ehrbase.org/)
---------------------------------------------------------------------------
Help
---------------------------------------------------------------------------
Run with subcommand

cli [sub-command] [arguments]
s
Sub-commands:
    database  database related operation
    help      print this help message

Examples:

# show this help message
cli help

# show help message of a sub-command
cli database
cli database help

# execute sub-command with arguments
cli database --check-connection
```
 
The currently implementation support execution of flyway migrations by using

```sh
$ docker run -i --rm ehrbase:next cli database --migration-migrate
```


# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 