### PR TITLE
Enable user access to the welcome page while authentication is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
  ### Added
  ### Changed 
+* Enable user access to the welcome page while authentication is enabled ([#1400](https://github.com/ehrbase/ehrbase/pull/1400))
  ### Fixed 
 
 ## [2.7.0]

--- a/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigBasicAuth.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigBasicAuth.java
@@ -21,6 +21,8 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 
 import java.util.List;
 import javax.annotation.PostConstruct;
+
+import jakarta.servlet.DispatcherType;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -62,11 +64,11 @@ public final class SecurityConfigBasicAuth extends SecurityConfig {
         return http.addFilterBefore(new SecurityFilter(), BasicAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> {
 
-                    // respond with proper 404 instead of 401 when reaching a route that does not exist. To understand
-                    // this case, since Spring 6 all paths are secured, when you use any path doesn't exist that will
-                    // match to "/error" but "/error" have been secured, so you need to add "/error" to your permitAll()
-                    // config to respond with a proper 404.
-                    auth = auth.requestMatchers(antMatcher("/error/**")).permitAll();
+                    // Permit dispatcher types forward and error
+                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll();
+
+                    // Permit welcome page and img
+                    auth.requestMatchers("/", "/img/**").permitAll();
 
                     // secure /rest/admin/** so that only admins can access it
                     auth = auth.requestMatchers(antMatcher("/rest/admin/**")).hasRole(ADMIN);

--- a/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigBasicAuth.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigBasicAuth.java
@@ -19,10 +19,9 @@ package org.ehrbase.configuration.config.security;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 import javax.annotation.PostConstruct;
-
-import jakarta.servlet.DispatcherType;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -65,7 +64,8 @@ public final class SecurityConfigBasicAuth extends SecurityConfig {
                 .authorizeHttpRequests(auth -> {
 
                     // Permit dispatcher types forward and error
-                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll();
+                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR)
+                            .permitAll();
 
                     // Permit welcome page and img
                     auth.requestMatchers("/", "/img/**").permitAll();

--- a/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigOAuth2.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigOAuth2.java
@@ -19,14 +19,13 @@ package org.ehrbase.configuration.config.security;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
+import jakarta.servlet.DispatcherType;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
-
-import jakarta.servlet.DispatcherType;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
@@ -81,7 +80,8 @@ public final class SecurityConfigOAuth2 extends SecurityConfig {
                 .authorizeHttpRequests(auth -> {
 
                     // Permit dispatcher types forward and error
-                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll();
+                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR)
+                            .permitAll();
 
                     // Permit welcome page and img
                     auth.requestMatchers("/", "/img/**").permitAll();

--- a/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigOAuth2.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/security/SecurityConfigOAuth2.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
+
+import jakarta.servlet.DispatcherType;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
@@ -78,11 +80,11 @@ public final class SecurityConfigOAuth2 extends SecurityConfig {
         return http.addFilterBefore(new SecurityFilter(), BearerTokenAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> {
 
-                    // respond with proper 404 instead of 401 when reaching a route that does not exist. To understand
-                    // this case, since Spring 6 all paths are secured, when you use any path doesn't exist that will
-                    // match to "/error" but "/error" have been secured, so you need to add "/error" to your permitAll()
-                    // config to respond with a proper 404.
-                    auth = auth.requestMatchers(antMatcher("/error/**")).permitAll();
+                    // Permit dispatcher types forward and error
+                    auth.dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll();
+
+                    // Permit welcome page and img
+                    auth.requestMatchers("/", "/img/**").permitAll();
 
                     // secure /rest/admin/** so that only admins can access it
                     auth = auth.requestMatchers(antMatcher("/rest/admin/**")).hasRole(adminRole);


### PR DESCRIPTION
# Changes

Enable user access to the welcome page while authentication is enabled.

# Additional information 

Permit DispatcherType.FORWARD and DispatcherType.ERROR in both OAuth2 and BasicAuth configurations. Also added permissions for the welcome page and images, ensuring better error handling and user access to welcome resources.

# Related issue

No issue was reported

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 