### PR TITLE
CDR-1614 Make build db timeout configurable

### DIFF
--- a/jooq-pg/pom.xml
+++ b/jooq-pg/pom.xml
@@ -80,7 +80,7 @@
                   <!-- The log message is not usable as indicator since the DB restarts multiple times during init -->
                   <!--<log>database system is ready to accept connections</log>-->
                   <log>listening on IPv.*</log>
-                  <time>120000</time>
+                  <time>${database.timeout}</time>
                 </wait>
                 <log>
                   <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <database.user>ehrbase</database.user>
     <database.pass>ehrbase</database.pass>
     <database.name>ehrbase</database.name>
+    <database.timeout>120000</database.timeout>
     <database.external>false</database.external>
     <test.profile>unit</test.profile>
   </properties>


### PR DESCRIPTION
# Changes

Allow to configure maven build DB startup timeout.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 