### PR TITLE
CDR-1616 Refactor allow-template overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
  ### Added
- ### Changed 
+ ### Changed
  ### Fixed 
+* Allow Template overwrite with renamed property from `system.allow-template-overwrite` to `ehrbase.template..allow-overwrite` ([#1440](https://github.com/ehrbase/ehrbase/pull/1440))
 
 ## [2.11.0]
  ### Added

--- a/configuration/src/main/resources/application.yml
+++ b/configuration/src/main/resources/application.yml
@@ -91,6 +91,9 @@ ehrbase:
     experimental:
       aql-on-folder:
         enabled: false
+  template:
+    # Allows to override templates using POST
+    allow-overwrite: false
   rest:
     aql:
       # allows to control query execution using debug params
@@ -130,10 +133,6 @@ cache:
     expire-after-write:
       duration: 300
       unit: SECONDS
-
-
-system:
-  allow-template-overwrite: false
 
 openehr-api:
   context-path: /rest/openehr

--- a/service/src/main/java/org/ehrbase/service/TemplateStorage.java
+++ b/service/src/main/java/org/ehrbase/service/TemplateStorage.java
@@ -28,6 +28,12 @@ import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
 public interface TemplateStorage {
 
     /**
+     * Determinate if template overwriting is enabled for this storage
+     * @return allowTemplateOverwrite
+     */
+    boolean allowTemplateOverwrite();
+
+    /**
      * List all Templates in the store;
      *
      * @return @see {@link TemplateMetaData}

--- a/service/src/test/java/org/ehrbase/service/KnowledgeCacheServiceTest.java
+++ b/service/src/test/java/org/ehrbase/service/KnowledgeCacheServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.util.List;
+import java.util.Optional;
+import org.ehrbase.api.exception.StateConflictException;
+import org.ehrbase.api.knowledge.KnowledgeCacheService;
+import org.ehrbase.cache.CacheProvider;
+import org.ehrbase.cache.CacheProviderImp;
+import org.ehrbase.openehr.sdk.test_data.operationaltemplate.OperationalTemplateTestData;
+import org.ehrbase.test.fixtures.TemplateFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+
+class KnowledgeCacheServiceTest {
+
+    private final TemplateStorage mockTemplateStorage = mock();
+    private SimpleCacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(mockTemplateStorage);
+
+        cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+                new ConcurrentMapCache(CacheProvider.TEMPLATE_ID_UUID_CACHE.name()),
+                new ConcurrentMapCache(CacheProvider.TEMPLATE_UUID_ID_CACHE.name()),
+                new ConcurrentMapCache(CacheProvider.INTROSPECT_CACHE.name()) // For WebTemplate representation
+                ));
+        cacheManager.initializeCaches();
+    }
+
+    private KnowledgeCacheService service() {
+
+        return new KnowledgeCacheServiceImp(mockTemplateStorage, new CacheProviderImp(cacheManager));
+    }
+
+    @Test
+    void addOperationalTemplate() {
+
+        TemplateFixture.TestTemplate testTemplate = parse(OperationalTemplateTestData.MINIMAL_ACTION);
+        String templateId = service().addOperationalTemplate(testTemplate.operationaltemplate());
+
+        assertThat(templateId).isNotNull().isEqualTo(testTemplate.templateId());
+    }
+
+    @Test
+    void addOperationalTemplateCanNotBeOverwritten() {
+
+        TemplateFixture.TestTemplate testTemplate = parse(OperationalTemplateTestData.MINIMAL_ACTION);
+
+        doReturn(Optional.of(testTemplate.metaData()))
+                .when(mockTemplateStorage)
+                .readTemplate(testTemplate.templateId());
+
+        KnowledgeCacheService service = service();
+        OPERATIONALTEMPLATE operationaltemplate = testTemplate.operationaltemplate();
+        assertThatThrownBy(() -> service.addOperationalTemplate(operationaltemplate))
+                .isInstanceOf(StateConflictException.class)
+                .hasMessage("Operational template with this template ID already exists: %s"
+                        .formatted(testTemplate.templateId()));
+    }
+
+    @Test
+    void addOperationalTemplateAllowOverwrite() {
+
+        TemplateFixture.TestTemplate testTemplate = parse(OperationalTemplateTestData.MINIMAL_ACTION);
+
+        doReturn(Optional.of(testTemplate.metaData()))
+                .when(mockTemplateStorage)
+                .readTemplate(testTemplate.templateId());
+        doReturn(true).when(mockTemplateStorage).allowTemplateOverwrite();
+
+        KnowledgeCacheService service = spy(service());
+        String templateId = service.addOperationalTemplate(testTemplate.operationaltemplate());
+
+        assertThat(templateId).isNotNull().isEqualTo(testTemplate.templateId());
+    }
+
+    private TemplateFixture.TestTemplate parse(OperationalTemplateTestData operationalTemplateTestData) {
+
+        TemplateFixture.TestTemplate testTemplate = TemplateFixture.fixtureTemplate(operationalTemplateTestData);
+
+        doReturn(testTemplate.metaData()).when(mockTemplateStorage).storeTemplate(testTemplate.operationaltemplate());
+        return testTemplate;
+    }
+}

--- a/service/src/test/java/org/ehrbase/service/TemplateDBStorageServiceTest.java
+++ b/service/src/test/java/org/ehrbase/service/TemplateDBStorageServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.ehrbase.api.exception.UnprocessableEntityException;
+import org.ehrbase.api.knowledge.TemplateMetaData;
+import org.ehrbase.openehr.sdk.test_data.operationaltemplate.OperationalTemplateTestData;
+import org.ehrbase.repository.CompositionRepository;
+import org.ehrbase.repository.TemplateStoreRepository;
+import org.ehrbase.test.fixtures.TemplateFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
+
+class TemplateDBStorageServiceTest {
+
+    private final CompositionRepository mockCompositionRepository = mock();
+    private final TemplateStoreRepository mockTemplateStoreRepository = mock();
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(mockCompositionRepository, mockTemplateStoreRepository);
+    }
+
+    private TemplateDBStorageService service(boolean allowTemplateOverwrite) {
+        return new TemplateDBStorageService(
+                mockCompositionRepository, mockTemplateStoreRepository, allowTemplateOverwrite);
+    }
+
+    private TemplateFixture.TestTemplate testTemplate() {
+        return TemplateFixture.fixtureTemplate(OperationalTemplateTestData.MINIMAL_INSTRUCTION);
+    }
+
+    @Test
+    void storeTemplateNoExist() {
+
+        TemplateFixture.TestTemplate testTemplate = testTemplate();
+        TemplateMetaData expectedTemplateMetaData = new TemplateMetaData();
+
+        // mock not exist
+        doReturn(Optional.empty()).when(mockTemplateStoreRepository).findUuidByTemplateId(testTemplate.templateId());
+        doReturn(expectedTemplateMetaData).when(mockTemplateStoreRepository).store(testTemplate.operationaltemplate());
+
+        TemplateMetaData resultMetaData = service(false).storeTemplate(testTemplate.operationaltemplate());
+
+        verify(mockTemplateStoreRepository, times(1)).store(testTemplate.operationaltemplate());
+        assertThat(expectedTemplateMetaData).isSameAs(resultMetaData);
+    }
+
+    @Test
+    void storeTemplateExistReplaceNotUsed() {
+
+        TemplateFixture.TestTemplate testTemplate = testTemplate();
+        TemplateMetaData expectedTemplateMetaData = new TemplateMetaData();
+
+        // mock template exist
+        doReturn(Optional.of(testTemplate.metaData().getInternalId()))
+                .when(mockTemplateStoreRepository)
+                .findUuidByTemplateId(testTemplate.templateId());
+        doReturn(expectedTemplateMetaData).when(mockTemplateStoreRepository).update(testTemplate.operationaltemplate());
+
+        TemplateMetaData resultMetaData = service(false).storeTemplate(testTemplate.operationaltemplate());
+
+        verify(mockTemplateStoreRepository, times(1)).update(same(testTemplate.operationaltemplate()));
+        assertThat(expectedTemplateMetaData).isSameAs(resultMetaData);
+    }
+
+    @Test
+    void storeTemplateExistCouldReplaceWhenInUse() {
+
+        TemplateFixture.TestTemplate testTemplate = testTemplate();
+
+        // mock template exist and in use
+        doReturn(Optional.of(testTemplate.metaData().getInternalId()))
+                .when(mockTemplateStoreRepository)
+                .findUuidByTemplateId(testTemplate.templateId());
+        doReturn(true).when(mockCompositionRepository).isTemplateUsed(testTemplate.templateId());
+
+        TemplateDBStorageService service = service(false);
+        OPERATIONALTEMPLATE operationaltemplate = testTemplate.operationaltemplate();
+        assertThatThrownBy(() -> service.storeTemplate(operationaltemplate))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("Cannot update template %s since it is used by at least one composition"
+                        .formatted(testTemplate.templateId()));
+    }
+
+    @Test
+    void storeTemplateExistAllowOverwriteReplaceWhenInUse() {
+
+        TemplateFixture.TestTemplate testTemplate = testTemplate();
+        TemplateMetaData expectedTemplateMetaData = new TemplateMetaData();
+
+        // mock template exist and in use
+        doReturn(Optional.of(testTemplate.metaData().getInternalId()))
+                .when(mockTemplateStoreRepository)
+                .findUuidByTemplateId(testTemplate.templateId());
+        doReturn(true).when(mockCompositionRepository).isTemplateUsed(testTemplate.templateId());
+        // mock update result
+        doReturn(expectedTemplateMetaData).when(mockTemplateStoreRepository).update(testTemplate.operationaltemplate());
+
+        TemplateMetaData resultMetaData = service(true).storeTemplate(testTemplate.operationaltemplate());
+
+        verify(mockTemplateStoreRepository, times(1)).update(same(testTemplate.operationaltemplate()));
+        assertThat(expectedTemplateMetaData).isSameAs(resultMetaData);
+    }
+}

--- a/service/src/test/java/org/ehrbase/test/fixtures/TemplateFixture.java
+++ b/service/src/test/java/org/ehrbase/test/fixtures/TemplateFixture.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019-2024 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.test.fixtures;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.apache.xmlbeans.XmlException;
+import org.ehrbase.api.knowledge.TemplateMetaData;
+import org.ehrbase.openehr.sdk.test_data.operationaltemplate.OperationalTemplateTestData;
+import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
+import org.openehr.schemas.v1.TemplateDocument;
+
+public class TemplateFixture {
+
+    public record TestTemplate(String templateId, OPERATIONALTEMPLATE operationaltemplate, TemplateMetaData metaData) {}
+
+    public static TestTemplate fixtureTemplate(OperationalTemplateTestData operationalTemplateTestData) {
+        return fixtureTemplate(operationalTemplateTestData, UUID.fromString("b65165e8-b4a6-4c23-84a0-ec58cfb481c1"));
+    }
+
+    public static TestTemplate fixtureTemplate(
+            OperationalTemplateTestData operationalTemplateTestData, UUID internalUUID) {
+        try (var in = operationalTemplateTestData.getStream()) {
+            OPERATIONALTEMPLATE template = TemplateDocument.Factory.parse(in).getTemplate();
+
+            TemplateMetaData metaData = new TemplateMetaData();
+            metaData.setOperationalTemplate(template);
+            metaData.setInternalId(internalUUID);
+            metaData.setCreatedOn(OffsetDateTime.parse("2020-10-10T12:00:00Z"));
+
+            return new TestTemplate(operationalTemplateTestData.getTemplateId(), template, metaData);
+
+        } catch (XmlException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
# Changes

Fixed template overwrite and renamed old property from `system.allow-template-overwrite` (`SYSTEM_ALLOWTEMPLATEOVERWRITE`) to `ehrbase.template..allow-overwrite` (`EHRBASE_TEMPLATE_ALLOWOVERWRITE`)

see #1411 

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 