### PR TITLE
Use a random container name during build

### DIFF
--- a/jooq-pg/pom.xml
+++ b/jooq-pg/pom.xml
@@ -37,7 +37,7 @@
 
 
   <properties>
-    <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+    <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
     <database.docker.image>ehrbase/ehrbase-postgres:16.2-mvp</database.docker.image>
   </properties>
 
@@ -69,6 +69,8 @@
               <name>${database.docker.image}</name>
               <alias>postgres</alias>
               <run>
+                <!-- let the docker engine chose a random container name to prevent clashed during parallel builds @see https://dmp.fabric8.io/#container-name -->
+                <containerNamePattern>%e</containerNamePattern>
                 <env>
                   <EHRBASE_USER_ADMIN>${database.user}</EHRBASE_USER_ADMIN>
                   <EHRBASE_PASSWORD_ADMIN>${database.pass}</EHRBASE_PASSWORD_ADMIN>


### PR DESCRIPTION
Preventing docker container name clashes during parallel builds by letting docker assign a random name


# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 