### PR TITLE
Fix banner app version by using resource filtering

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -48,6 +48,14 @@
 
   <build>
     <finalName>ehrbase</finalName>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/application/src/main/resources/banner-cli.txt
+++ b/application/src/main/resources/banner-cli.txt
@@ -1,1 +1,1 @@
-${AnsiColor.BLUE}EHRbase CLI (Spring Boot ${spring-boot.version} EHRbase ${application.formatted-version} https://ehrbase.org/)${AnsiBackground.DEFAULT}${AnsiColor.DEFAULT}
+${AnsiColor.BLUE}EHRbase CLI (Spring Boot ${spring-boot.version} EHRbase @project.version@ https://ehrbase.org/)${AnsiBackground.DEFAULT}${AnsiColor.DEFAULT}

--- a/application/src/main/resources/banner.txt
+++ b/application/src/main/resources/banner.txt
@@ -6,5 +6,5 @@ ${AnsiColor.BLUE}
 | |____| |  | | | \ \| |_) | (_| \__ \  __/
 |______|_|  |_|_|  \_\_.__/ \__,_|___/\___|
 Spring Boot ${spring-boot.version}
-EHRbase ${application.formatted-version}
+EHRbase @project.version@
 https://ehrbase.org/ ${AnsiBackground.DEFAULT}${AnsiColor.DEFAULT}


### PR DESCRIPTION
# Changes

Fix missing EHRbase app version in banner.txt by using resource filtering instead of property.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 