### PR TITLE
CDR-1667 gracefully exit on future db version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  ### Changed 
 * Added check for duplicate version IDs during Folder creation as well as check for Folder uid and if-match header id during update ([#1410](https://github.com/ehrbase/ehrbase/pull/1410))
 * Remove EHR from AQL if not needed for the query ([#1448](https://github.com/ehrbase/ehrbase/pull/1448))
+* Gracefully exit in case installed flyway DB is newer than supported ([#1449](https://github.com/ehrbase/ehrbase/pull/1449))
  ### Fixed 
-* Allow Template overwrite with renamed property from `system.allow-template-overwrite` to `ehrbase.template..allow-overwrite` ([#1440](https://github.com/ehrbase/ehrbase/pull/1440))
+* Allow Template overwrite with renamed property from `system.allow-template-overwrite` to `ehrbase.template.allow-overwrite` ([#1440](https://github.com/ehrbase/ehrbase/pull/1440))
 
 ## [2.11.0]
  ### Added

--- a/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategyConfig.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategyConfig.java
@@ -80,9 +80,11 @@ public class MigrationStrategyConfig {
         };
     }
 
+    @SuppressWarnings("deprecation") // for ignoreFutureMigrations until flyway is updated
     private FluentConfiguration setSchema(Flyway flyway, String schema) {
         return Flyway.configure()
                 .dataSource(flyway.getConfiguration().getDataSource())
+                .ignoreFutureMigrations(false) // deprecated call will be removed in Flyway V9 and defaults to false
                 .schemas(schema);
     }
 }


### PR DESCRIPTION
# Changes

Changed flyway config to gracefully fail in case an "older" ehrbase version is deployed against a newer database version.
In such cases EHRBase will now fail with the following message

```
Caused by: org.flywaydb.core.api.exception.FlywayValidateException: Validate failed: Migrations have failed validation
Detected applied migration not resolved locally: 20.
If you removed this migration intentionally, run repair to mark the migration as deleted.
Need more flexibility with validation rules? Learn more: https://rd.gt/3AbJUZE
```

An Alternative we could also update to Flyway 11 https://github.com/ehrbase/ehrbase/pull/1450