### PR TITLE
Feature/cdr 1667 gracefully exit on future db version v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  ### Changed 
 * Added check for duplicate version IDs during Folder creation as well as check for Folder uid and if-match header id during update ([#1410](https://github.com/ehrbase/ehrbase/pull/1410))
 * Remove EHR from AQL if not needed for the query ([#1448](https://github.com/ehrbase/ehrbase/pull/1448))
+* Update flyway to V11 to Gracefully exit in case installed flyway DB is newer than supported ([#1450](https://github.com/ehrbase/ehrbase/pull/1450))
  ### Fixed 
-* Allow Template overwrite with renamed property from `system.allow-template-overwrite` to `ehrbase.template..allow-overwrite` ([#1440](https://github.com/ehrbase/ehrbase/pull/1440))
+* Allow Template overwrite with renamed property from `system.allow-template-overwrite` to `ehrbase.template.allow-overwrite` ([#1440](https://github.com/ehrbase/ehrbase/pull/1440))
 
 ## [2.11.0]
  ### Added

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,7 @@
     <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <ehrbase.openehr.sdk.version>2.20.0</ehrbase.openehr.sdk.version>
-    <flyway.version>11.1.0</flyway.version>
+    <flyway.version>11.1.1</flyway.version>
     <jackson-bom.version>2.18.1</jackson-bom.version>
     <javamelody.version>1.99.1</javamelody.version>
     <jooq.version>3.19.15</jooq.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,7 @@
     <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <ehrbase.openehr.sdk.version>2.20.0</ehrbase.openehr.sdk.version>
-    <flyway.version>8.5.13</flyway.version>
+    <flyway.version>11.1.0</flyway.version>
     <jackson-bom.version>2.18.1</jackson-bom.version>
     <javamelody.version>1.99.1</javamelody.version>
     <jooq.version>3.19.15</jooq.version>
@@ -303,6 +303,11 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
+        <version>${flyway.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-database-postgresql</artifactId>
         <version>${flyway.version}</version>
       </dependency>
       <dependency>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -94,16 +94,6 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
-    </dependency>
-    <!--
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-database-postgresql</artifactId>
-    </dependency>
-    -->
-    <dependency>
       <groupId>org.ehrbase.openehr</groupId>
       <artifactId>service</artifactId>
     </dependency>

--- a/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategyConfig.java
+++ b/configuration/src/main/java/org/ehrbase/configuration/config/flyway/MigrationStrategyConfig.java
@@ -20,6 +20,7 @@ package org.ehrbase.configuration.config.flyway;
 import java.util.Map;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -83,6 +84,10 @@ public class MigrationStrategyConfig {
     private FluentConfiguration setSchema(Flyway flyway, String schema) {
         return Flyway.configure()
                 .dataSource(flyway.getConfiguration().getDataSource())
+                .validateOnMigrate(true)
+                // does not ignore *:Future migrations
+                // see https://documentation.red-gate.com/fd/ignore-migration-patterns-224919720.html
+                .ignoreMigrationPatterns(ValidatePattern.fromPattern("*:Ignored"))
                 .schemas(schema);
     }
 }

--- a/configuration/src/main/resources/application.yml
+++ b/configuration/src/main/resources/application.yml
@@ -149,7 +149,6 @@ logging:
     org.jooq.Constants: warn
     org.springframework: info
     org.springframework.security.web.DefaultSecurityFilterChain: warn
-    org.flywaydb.core.internal.license.VersionPrinter: warn
   pattern:
     console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr([%X]){faint} %clr(${PID}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx'
 

--- a/jooq-pg/pom.xml
+++ b/jooq-pg/pom.xml
@@ -54,6 +54,10 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -122,13 +126,11 @@
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
           </dependency>
-          <!--
           <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
             <version>${flyway.version}</version>
           </dependency>
-          -->
         </dependencies>
         <executions>
           <execution>


### PR DESCRIPTION
# Changes

Update to Flyway V11.

Changed flyway config to gracefully fail in case an "older" ehrbase version is deployed against a newer database version.
In such cases EHRBase will now fail with the following message

```
Caused by: org.flywaydb.core.api.exception.FlywayValidateException: Validate failed: Migrations have failed validation
Detected applied migration not resolved locally: 20.
If you removed this migration intentionally, run repair to mark the migration as deleted.
Need more flexibility with validation rules? Learn more: https://rd.gt/3AbJUZE
```

An Alternative solution for https://github.com/ehrbase/ehrbase/pull/1449