### PR TITLE
Refactor getStoredQueryList to comply with REST API specifications

### DIFF
--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryController.java
@@ -29,6 +29,7 @@ import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.ehrbase.api.exception.GeneralRequestProcessingException;
@@ -37,7 +38,6 @@ import org.ehrbase.api.exception.UnexpectedSwitchCaseException;
 import org.ehrbase.api.exception.UnsupportedMediaTypeException;
 import org.ehrbase.api.rest.HttpRestContext;
 import org.ehrbase.api.service.StoredQueryService;
-import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionListResponseData;
 import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionResponseData;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryDefinitionResultDto;
 import org.ehrbase.rest.BaseController;
@@ -85,13 +85,15 @@ public class OpenehrDefinitionQueryController extends BaseController implements 
      */
     @Override
     @GetMapping(value = {"/{qualified_query_name}", ""})
-    public ResponseEntity<QueryDefinitionListResponseData> getStoredQueryList(
+    public ResponseEntity<List<QueryDefinitionResponseData>> getStoredQueryList(
             @RequestHeader(value = ACCEPT, required = false) String accept,
             @PathVariable(value = "qualified_query_name", required = false) String qualifiedQueryName) {
 
         registerLocation(qualifiedQueryName, null);
-        QueryDefinitionListResponseData responseData =
-                new QueryDefinitionListResponseData(storedQueryService.retrieveStoredQueries(qualifiedQueryName));
+        List<QueryDefinitionResponseData> responseData =
+                storedQueryService.retrieveStoredQueries(qualifiedQueryName).stream()
+                        .map(QueryDefinitionResponseData::new)
+                        .toList();
 
         HttpRestContext.register(QUERY_ID, qualifiedQueryName);
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/DefinitionQueryApiSpecification.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/specification/DefinitionQueryApiSpecification.java
@@ -20,8 +20,8 @@ package org.ehrbase.rest.openehr.specification;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Optional;
-import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionListResponseData;
 import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionResponseData;
 import org.springframework.http.ResponseEntity;
 
@@ -34,8 +34,8 @@ public interface DefinitionQueryApiSpecification {
             externalDocs =
                     @ExternalDocumentation(
                             url =
-                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definitions.html#definitions-stored-query-get"))
-    ResponseEntity<QueryDefinitionListResponseData> getStoredQueryList(String accept, String qualifiedQueryName);
+                                    "https://specifications.openehr.org/releases/ITS-REST/latest/definition.html#tag/Query/operation/definition_query_list"))
+    ResponseEntity<List<QueryDefinitionResponseData>> getStoredQueryList(String accept, String qualifiedQueryName);
 
     @Operation(
             summary = "Store a query",

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrDefinitionQueryControllerTest.java
@@ -30,7 +30,6 @@ import java.util.function.Consumer;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.UnsupportedMediaTypeException;
 import org.ehrbase.api.service.StoredQueryService;
-import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionListResponseData;
 import org.ehrbase.openehr.sdk.response.dto.QueryDefinitionResponseData;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryDefinitionResultDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -158,12 +157,12 @@ public class OpenehrDefinitionQueryControllerTest {
 
         doReturn(List.of()).when(mockStoredQueryService).retrieveStoredQueries("some-query");
 
-        ResponseEntity<QueryDefinitionListResponseData> response =
+        ResponseEntity<List<QueryDefinitionResponseData>> response =
                 controller().getStoredQueryList(accept, "some-query");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull().satisfies(dto -> assertThat(dto.size())
-                .isZero());
+        assertThat(response.getBody()).isNotNull().satisfies(dto -> assertThat(dto)
+                .isEmpty());
     }
 
     @ParameterizedTest
@@ -174,12 +173,12 @@ public class OpenehrDefinitionQueryControllerTest {
                 .when(mockStoredQueryService)
                 .retrieveStoredQueries("test-query");
 
-        ResponseEntity<QueryDefinitionListResponseData> response =
+        ResponseEntity<List<QueryDefinitionResponseData>> response =
                 controller().getStoredQueryList(accept, "test-query");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull().satisfies(dto -> assertThat(dto.size())
-                .isEqualTo(1));
+        assertThat(response.getBody()).isNotNull().satisfies(dto -> assertThat(dto)
+                .hasSize(1));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# Changes

Working on EHRBase Sandbox, I noticed that the response sent back while calling the "List stored queries" operation is wrong (or outdated), according to the [specifications](https://specifications.openehr.org/releases/ITS-REST/Release-1.0.3/definition.html#tag/Query/operation/definition_query_list).

Previous:
```json
{
  "versions": [
    {
      "saved": "2025-01-23T12:12:59.561596Z",
      "name": "org.openehr::compositions",
      "type": "AQL",
      "version": "1.0.0"
    }
  ]
}
```

New:
```json
[
    {
        "q": "SELECT c FROM EHR e CONTAINS COMPOSITION c[openEHR-EHR-COMPOSITION.encounter.v1] CONTAINS OBSERVATION obs[openEHR-EHR-OBSERVATION.blood_pressure.v1] WHERE obs/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude >= $systolic_bp",
        "name": "org.openehr::compositions",
        "type": "AQL",
        "version": "2.0.0",
        "saved": "2025-01-23T19:11:08.11303+01:00"
    }
]
```

# Related issue

n/a

# Additional information 

n/a

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 