### PR TITLE
CDR-1901 - Remove EHRBase Template Id header

### DIFF
--- a/api/src/main/java/org/ehrbase/api/rest/EHRbaseHeader.java
+++ b/api/src/main/java/org/ehrbase/api/rest/EHRbaseHeader.java
@@ -24,8 +24,6 @@ public final class EHRbaseHeader {
 
     private EHRbaseHeader() {}
 
-    public static final String TEMPLATE_ID = "EHRBase-Template-ID";
-
     /**
      * Used by the /query endpoint to perform only a dry run query.
      */

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
@@ -435,8 +435,6 @@ public class OpenehrCompositionController extends BaseController implements Comp
             templateId = compositionService.retrieveTemplateId(compositionId);
         }
 
-        respHeaders.addIfAbsent(EHRbaseHeader.TEMPLATE_ID, templateId);
-
         HttpRestContext.register(
                 EHR_ID,
                 ehrId,


### PR DESCRIPTION
# Changes

- Removed the non-standard template id header usages (usage not clear)
- Queries to retrieve this id may still happen as the id is used in auditing, for example

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 