### PR TITLE
update subject namespace regex

### DIFF
--- a/service/src/main/java/org/ehrbase/service/ValidationServiceImp.java
+++ b/service/src/main/java/org/ehrbase/service/ValidationServiceImp.java
@@ -67,7 +67,7 @@ public class ValidationServiceImp implements ValidationService {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final Pattern NAMESPACE_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9-_:/&+?]*");
+    private static final Pattern NAMESPACE_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9_.:\/&?=+-]*");
 
     private final KnowledgeCacheServiceImp knowledgeCacheService;
 

--- a/service/src/test/java/org/ehrbase/service/ValidationServiceTest.java
+++ b/service/src/test/java/org/ehrbase/service/ValidationServiceTest.java
@@ -359,7 +359,7 @@ class ValidationServiceTest {
                 .hasMessage(
                         """
                         Message at /subject/external_ref (/subject/external_ref):  Invariant Namespace_valid failed on type PARTY_REF
-                        Message at /subject/external_ref/namespace (/subject/external_ref/namespace):  Invariant namespace of class EHR_STATUS does not match pattern [[a-zA-Z][a-zA-Z0-9-_:/&+?]*]""");
+                        Message at /subject/external_ref/namespace (/subject/external_ref/namespace):  Invariant namespace of class EHR_STATUS does not match pattern [[a-zA-Z][a-zA-Z0-9_.:\/&?=+-]*]""");
     }
 
     @Test


### PR DESCRIPTION
# Changes

Updated the ehr_status subject namespace regex with the new version copied from the base spec that allows ‘.’.
Updated the message in test.

# Related issue

Closes #1058

https://discourse.openehr.org/t/openehr-postman-workspace/6738/3?u=joostholslag

# Additional information 
Draft because I did not (yet) test the change. And I’m inexperienced with java. So please review carefully
CR for the spec change: https://openehr.atlassian.net/browse/SPECBASE-27

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 