### PR TITLE
Start preparing changes for sonatype migration

### DIFF
--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Sanity check to ensure docker push only happen on dev/main/tag[v] refs
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  github.ref == 'refs/heads/feature/CDR-1909#ossrh-migration' }} # || startsWith(github.ref, 'refs/heads/release/') }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  startsWith(github.ref, 'refs/heads/feature/CDR-1909') }} # || startsWith(github.ref, 'refs/heads/release/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -33,9 +33,9 @@ jobs:
           java-version: 21
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_TOKEN
+          server-id: central
+          server-username: CENTRAL_SONATYPE_USERNAME
+          server-password: CENTRAL_SONATYPE_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
@@ -54,6 +54,6 @@ jobs:
       - name: Publish - Maven Central
         run: mvn -B deploy -P release -DskipTests
         env:
-          OSSRH_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.CENTRAL_SONATYPE_TOKEN }}
+          CENTRAL_SONATYPE_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
+          CENTRAL_SONATYPE_TOKEN: ${{ secrets.CENTRAL_SONATYPE_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Sanity check to ensure docker push only happen on dev/main/tag[v] refs
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }} # || startsWith(github.ref, 'refs/heads/release/') }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  github.ref == 'refs/heads/feature/CDR-1909' }} # || startsWith(github.ref, 'refs/heads/release/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Sanity check to ensure docker push only happen on dev/main/tag[v] refs
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  github.ref == 'refs/heads/feature/CDR-1909' }} # || startsWith(github.ref, 'refs/heads/release/') }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  github.ref == 'refs/heads/feature/CDR-1909#ossrh-migration' }} # || startsWith(github.ref, 'refs/heads/release/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -54,6 +54,6 @@ jobs:
       - name: Publish - Maven Central
         run: mvn -B deploy -P release -DskipTests
         env:
-          OSSRH_USERNAME: ${{ secrets.S01_OSSRH_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.S01_OSSRH_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.CENTRAL_SONATYPE_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -2,7 +2,7 @@ name: "Maven Publish"
 
 on:
   workflow_call:
-  workflow_dispatch:
+  # workflow_dispatch: <- is this needed?
 
 jobs:
 
@@ -13,7 +13,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Sanity check to ensure docker push only happen on dev/main/tag[v] refs
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' ||  startsWith(github.ref, 'refs/heads/feature/CDR-1909') }} # || startsWith(github.ref, 'refs/heads/release/') }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }} # || startsWith(github.ref, 'refs/heads/release/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/job-maven-publish.yml
+++ b/.github/workflows/job-maven-publish.yml
@@ -2,7 +2,7 @@ name: "Maven Publish"
 
 on:
   workflow_call:
-  # workflow_dispatch: <- is this needed?
+  workflow_dispatch:
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
  ### Added
  ### Changed 
+- Publishing artifacts directly to central.sonatype.com [#1512](https://github.com/ehrbase/ehrbase/pull/1512)
  ### Fixed 
 
 ## [2.18.0]

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,7 +92,7 @@
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <maven-jacoco-plugin.version>0.8.12</maven-jacoco-plugin.version>
     <maven-spotless-maven-plugin.version>2.43.0</maven-spotless-maven-plugin.version>
-    <maven-nexus-staging-plugin.version>1.7.0</maven-nexus-staging-plugin.version>
+    <maven-central-publishing-plugin.version>0.8.0</maven-central-publishing-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <maven-versions-maven-plugin.version>2.17.1</maven-versions-maven-plugin.version>
     <maven-dockerfile-maven-plugin.version>1.4.13</maven-dockerfile-maven-plugin.version>
@@ -407,9 +407,9 @@
           <version>${maven-gpg-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${maven-nexus-staging-plugin.version}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${maven-central-publishing-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.spotify</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,7 +58,7 @@
     <archie.version>3.13.0</archie.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
-    <ehrbase.openehr.sdk.version>2.23.0</ehrbase.openehr.sdk.version>
+    <ehrbase.openehr.sdk.version>2.24.0-SNAPSHOT</ehrbase.openehr.sdk.version>
     <flyway.version>11.1.1</flyway.version>
     <jackson-bom.version>2.18.1</jackson-bom.version>
     <javamelody.version>1.99.1</javamelody.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -100,30 +100,6 @@
 
   </properties>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>ossrh-snapshots</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,15 @@
           </compilerArgs>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,10 @@
   <description>EHRbase openEHR server</description>
 
   <repositories>
+    <!-- Repository for openEHR-SDK snapshots -->
     <repository>
-      <id>ossrh-snapshots</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
# Changes

Publishing artifacts directly to Central Sonatype because of ossrh sunset.

# Related issue

https://central.sonatype.org/news/20250326_ossrh_sunset/