### PR TITLE
Fix pom issues for release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,6 +30,7 @@
     </parent>
 
     <artifactId>api</artifactId>
+    <name>EHRbase Internal API</name>
 
     <dependencies>
         <dependency>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -32,8 +32,7 @@
 
   <artifactId>application</artifactId>
   <packaging>jar</packaging>
-
-
+  <name>EHRbase Application</name>
 
   <dependencies>
     <dependency>

--- a/aql-engine/pom.xml
+++ b/aql-engine/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>aql-engine</artifactId>
+  <name>EHRbase AQL Engine</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -72,6 +72,7 @@
     <!-- spring -->
     <spring-boot.version>3.4.2</spring-boot.version>
     <springdoc-openapi.version>2.8.5</springdoc-openapi.version>
+    <spring-security.version>spring-security.version</spring-security.version>
 
     <!-- not used ehrbase but needed for the version plugin -->
     <log4j.version>2.24.2</log4j.version>
@@ -295,14 +296,6 @@
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
         <version>${git-commit-id-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-web</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-config</artifactId>
       </dependency>
 
       <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -31,6 +31,7 @@
 
   <artifactId>cli</artifactId>
   <packaging>jar</packaging>
+  <name>EHRbase CLI</name>
 
   <dependencies>
     <dependency>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -32,6 +32,7 @@
 
   <artifactId>configuration</artifactId>
   <packaging>jar</packaging>
+  <name>EHRbase Configuration</name>
 
   <dependencies>
     <dependency>

--- a/jooq-pg/pom.xml
+++ b/jooq-pg/pom.xml
@@ -32,9 +32,7 @@
   </parent>
 
   <artifactId>jooq-pg</artifactId>
-
-  <name>jooq-pg</name>
-
+  <name>EHRbase JOOQ</name>
 
   <properties>
     <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -10,6 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>plugin</artifactId>
+  <name>EHRbase Plugin</name>
 
   <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   <artifactId>server</artifactId>
   <version>2.19.0</version>
   <packaging>pom</packaging>
-  <name>ehrbase server</name>
+  <name>EHRbase server</name>
   <description>EHRbase openEHR server</description>
 
   <repositories>

--- a/rest-ehr-scape/pom.xml
+++ b/rest-ehr-scape/pom.xml
@@ -32,6 +32,7 @@
     </parent>
 
     <artifactId>rest-ehr-scape</artifactId>
+    <name>EHRbase ehrscape REST</name>
 
     <dependencies>
         <dependency>

--- a/rest-openehr/pom.xml
+++ b/rest-openehr/pom.xml
@@ -32,6 +32,7 @@
     </parent>
 
     <artifactId>rest-openehr</artifactId>
+    <name>EHRbase openEHR REST</name>
 
     <dependencies>
         <dependency>

--- a/rm-db-format/pom.xml
+++ b/rm-db-format/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>rm-db-format</artifactId>
+  <name>EHRbase RM DB Format</name>
 
   <dependencies>
     <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -31,6 +31,7 @@
   </parent>
 
   <artifactId>service</artifactId>
+  <name>EHRbase Service</name>
 
   <dependencies>
     <dependency>

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -33,6 +33,7 @@
 
   <artifactId>test-coverage</artifactId>
   <packaging>pom</packaging>
+  <name>EHRbase Test Coverage</name>
 
   <properties>
     <!-- per default, we disable and skip al coverage generation to speed up our local test execution -->


### PR DESCRIPTION
# Changes

The new sonatype central deployment is more strict when it comes to releases.
Added names to all modules and removed not needed dependencies