### PR TITLE
CDR-1967 Ensure AQL transactions are only used for execute and explain

### DIFF
--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/repository/PreparedQuery.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/repository/PreparedQuery.java
@@ -40,8 +40,12 @@ public final class PreparedQuery {
         this.postProcessors = postProcessors;
     }
 
+    public String getQuerySql() {
+        return selectQuery.getSQL();
+    }
+
     @Override
     public String toString() {
-        return selectQuery.getSQL();
+        return getQuerySql();
     }
 }

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/service/AqlQueryServiceImp.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/service/AqlQueryServiceImp.java
@@ -140,8 +140,7 @@ public class AqlQueryServiceImp implements AqlQueryService {
                 // aql debug options
                 if (aqlQueryContext.showExecutedSql()) {
                     aqlQueryContext.setMetaProperty(
-                            AqlQueryContext.EhrbaseMetaProperty.EXECUTED_SQL,
-                            AqlQueryRepository.getQuerySql(preparedQuery));
+                            AqlQueryContext.EhrbaseMetaProperty.EXECUTED_SQL, preparedQuery.getQuerySql());
                 }
                 if (aqlQueryContext.showQueryPlan()) {
                     // for dry-run omit analyze


### PR DESCRIPTION
# Changes

Ensure only one transaction is used during AQL processing. Currently two transactions are created, one for the query preparation and another one for the execution. Now only a single transaction is created for the execution and another for an explain - if needed. 

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 