### PR TITLE
Parse AQL string before passing to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  ### Added
  ### Changed 
  ### Fixed
-- AQL query is parsed using `AqlQueryRequest.parse` and then passed `AqlService.query` method [#1522](https://github.com/ehrbase/ehrbase/pull/1522)
- ### Fixed 
 - Fix terminology validation URL extraction [#1507](https://github.com/ehrbase/ehrbase/pull/1507)
 
 ## [2.20.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  ### Added
  ### Changed 
  ### Fixed
-  - Fix terminology validation URL extraction [#1507](https://github.com/ehrbase/ehrbase/pull/1507)
+- AQL query is parsed using `AqlQueryRequest.parse` and then passed `AqlService.query` method [#1522](https://github.com/ehrbase/ehrbase/pull/1522)
+ ### Fixed 
+- Fix terminology validation URL extraction [#1507](https://github.com/ehrbase/ehrbase/pull/1507)
 
 ## [2.20.0]
  ### Added

--- a/api/src/main/java/org/ehrbase/api/dto/AqlQueryRequest.java
+++ b/api/src/main/java/org/ehrbase/api/dto/AqlQueryRequest.java
@@ -30,7 +30,7 @@ import org.ehrbase.openehr.sdk.aql.parser.AqlQueryParser;
 /**
  * The requested AQL to be executed by {@link AqlQueryService#query(AqlQueryRequest)}.
  *
- * @param aqlQuery    the actual aql string
+ * @param aqlQuery    the actual aql query
  * @param parameters  additional query parameters
  * @param fetch       query limit to apply
  * @param offset      query offset to apply
@@ -46,7 +46,7 @@ public record AqlQueryRequest(
      *
      * @see AqlQueryRequest
      */
-    public static AqlQueryRequest parse(
+    public static AqlQueryRequest prepare(
             @Nonnull String queryString,
             @Nullable Map<String, Object> parameters,
             @Nullable Long fetch,

--- a/api/src/main/java/org/ehrbase/api/dto/AqlQueryRequest.java
+++ b/api/src/main/java/org/ehrbase/api/dto/AqlQueryRequest.java
@@ -20,6 +20,7 @@ package org.ehrbase.api.dto;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.ehrbase.api.exception.IllegalAqlException;
@@ -73,14 +74,8 @@ public record AqlQueryRequest(
         if (parameters == null) {
             return Map.of();
         }
-        parameters.entrySet().forEach(e -> {
-            Object ov = e.getValue();
-            Object nv = handleExplicitParameterTypes(ov);
-            if (ov != nv) {
-                e.setValue(nv);
-            }
-        });
-        return parameters;
+        return parameters.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> handleExplicitParameterTypes(entry.getValue())));
     }
 
     /**

--- a/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
+++ b/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
@@ -19,7 +19,6 @@ package org.ehrbase.api.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.ehrbase.api.exception.IllegalAqlException;
@@ -56,61 +55,5 @@ class AqlQueryRequestTest {
         assertThat(request.parameters()).isEmpty();
         assertThat(request.fetch()).isEqualTo(10L);
         assertThat(request.offset()).isEqualTo(25L);
-    }
-
-    @Test
-    void withXmlParamsAdjusted() {
-
-        AqlQueryRequest request = new AqlQueryRequest(
-                new AqlQuery(),
-                Map.of(
-                        "p_string", "some-string",
-                        "p_xml_num", Map.of("type", "num", "", 42.12),
-                        "p_xml_int", Map.of("type", "int", "", 11)
-                        // "p_list": L
-
-                        ),
-                null,
-                null);
-        assertThat(request.parameters())
-                .containsAllEntriesOf(Map.of("p_string", "some-string", "p_xml_num", 42.12, "p_xml_int", 11));
-        assertThat(request.fetch()).isNull();
-        assertThat(request.offset()).isNull();
-    }
-
-    @Test
-    void withXmlParamsWithoutTypeAdjusted() {
-
-        AqlQueryRequest request = new AqlQueryRequest(
-                new AqlQuery(),
-                Map.of(
-                        "p_xml_num", Map.of("num", 42.12),
-                        "p_xml_int", Map.of("int", 11)
-                        // "p_list": L
-
-                        ),
-                null,
-                null);
-        assertThat(request.parameters()).containsAllEntriesOf(Map.of("p_xml_num", 42.12, "p_xml_int", 11));
-        assertThat(request.fetch()).isNull();
-        assertThat(request.offset()).isNull();
-    }
-
-    @Test
-    void withXmlParamListsAdjusted() {
-
-        AqlQueryRequest request = new AqlQueryRequest(
-                new AqlQuery(),
-                Map.of(
-                        "p_xml_list", Map.of("", List.of("value_1", "value_2")),
-                        "p_xml_list_alternative", List.of("some", "other", "value")),
-                null,
-                null);
-        assertThat(request.parameters())
-                .containsAllEntriesOf(Map.of(
-                        "p_xml_list", List.of("value_1", "value_2"),
-                        "p_xml_list_alternative", List.of("some", "other", "value")));
-        assertThat(request.fetch()).isNull();
-        assertThat(request.offset()).isNull();
     }
 }

--- a/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
+++ b/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.Test;
 class AqlQueryRequestTest {
 
     @Test
-    void parseAqlQueryRequest() {
+    void prepareAqlQueryRequest() {
 
-        AqlQueryRequest request = AqlQueryRequest.parse("SELECT e/ehr_id/value FROM EHR e", Map.of(), null, null);
+        AqlQueryRequest request = AqlQueryRequest.prepare("SELECT e/ehr_id/value FROM EHR e", Map.of(), null, null);
         assertThat(request.aqlQuery().render()).isEqualTo("SELECT e/ehr_id/value FROM EHR e");
         assertThat(request.parameters()).isEmpty();
         assertThat(request.fetch()).isNull();
@@ -38,14 +38,12 @@ class AqlQueryRequestTest {
     }
 
     @Test
-    void parseInvalidAql() {
+    void prepareInvalidAql() {
 
         Map<String, Object> parameter = Map.of();
         Assertions.assertThatThrownBy(
-                        () -> AqlQueryRequest.parse("SELECT invalid FROM INVALID i", parameter, null, null))
-                .isInstanceOf(IllegalAqlException.class)
-                .hasMessage(
-                        "Could not parse AQL query: Cannot parse SELECT invalid FROM INVALID i: unknown FROM alias 'invalid'");
+                        () -> AqlQueryRequest.prepare("SELECT invalid FROM INVALID i", parameter, null, null))
+                .isInstanceOf(IllegalAqlException.class);
     }
 
     @Test

--- a/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
+++ b/api/src/test/java/org/ehrbase/api/dto/AqlQueryRequestTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.ehrbase.api.exception.IllegalAqlException;
+import org.ehrbase.openehr.sdk.aql.dto.AqlQuery;
+import org.junit.jupiter.api.Test;
+
+class AqlQueryRequestTest {
+
+    @Test
+    void parseAqlQueryRequest() {
+
+        AqlQueryRequest request = AqlQueryRequest.parse("SELECT e/ehr_id/value FROM EHR e", Map.of(), null, null);
+        assertThat(request.aqlQuery().render()).isEqualTo("SELECT e/ehr_id/value FROM EHR e");
+        assertThat(request.parameters()).isEmpty();
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+
+    @Test
+    void parseInvalidAql() {
+
+        Map<String, Object> parameter = Map.of();
+        Assertions.assertThatThrownBy(
+                        () -> AqlQueryRequest.parse("SELECT invalid FROM INVALID i", parameter, null, null))
+                .isInstanceOf(IllegalAqlException.class)
+                .hasMessage(
+                        "Could not parse AQL query: Cannot parse SELECT invalid FROM INVALID i: unknown FROM alias 'invalid'");
+    }
+
+    @Test
+    void withLimitAndFetch() {
+
+        AqlQueryRequest request = new AqlQueryRequest(new AqlQuery(), Map.of(), 10L, 25L);
+        assertThat(request.parameters()).isEmpty();
+        assertThat(request.fetch()).isEqualTo(10L);
+        assertThat(request.offset()).isEqualTo(25L);
+    }
+
+    @Test
+    void withXmlParamsAdjusted() {
+
+        AqlQueryRequest request = new AqlQueryRequest(
+                new AqlQuery(),
+                Map.of(
+                        "p_string", "some-string",
+                        "p_xml_num", Map.of("type", "num", "", 42.12),
+                        "p_xml_int", Map.of("type", "int", "", 11)
+                        // "p_list": L
+
+                        ),
+                null,
+                null);
+        assertThat(request.parameters())
+                .containsAllEntriesOf(Map.of("p_string", "some-string", "p_xml_num", 42.12, "p_xml_int", 11));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+
+    @Test
+    void withXmlParamsWithoutTypeAdjusted() {
+
+        AqlQueryRequest request = new AqlQueryRequest(
+                new AqlQuery(),
+                Map.of(
+                        "p_xml_num", Map.of("num", 42.12),
+                        "p_xml_int", Map.of("int", 11)
+                        // "p_list": L
+
+                        ),
+                null,
+                null);
+        assertThat(request.parameters()).containsAllEntriesOf(Map.of("p_xml_num", 42.12, "p_xml_int", 11));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+
+    @Test
+    void withXmlParamListsAdjusted() {
+
+        AqlQueryRequest request = new AqlQueryRequest(
+                new AqlQuery(),
+                Map.of(
+                        "p_xml_list", Map.of("", List.of("value_1", "value_2")),
+                        "p_xml_list_alternative", List.of("some", "other", "value")),
+                null,
+                null);
+        assertThat(request.parameters())
+                .containsAllEntriesOf(Map.of(
+                        "p_xml_list", List.of("value_1", "value_2"),
+                        "p_xml_list_alternative", List.of("some", "other", "value")));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+}

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/service/AqlQueryServiceImp.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/service/AqlQueryServiceImp.java
@@ -31,7 +31,6 @@ import java.util.stream.LongStream;
 import org.ehrbase.api.dto.AqlQueryContext;
 import org.ehrbase.api.dto.AqlQueryRequest;
 import org.ehrbase.api.exception.BadGatewayException;
-import org.ehrbase.api.exception.IllegalAqlException;
 import org.ehrbase.api.exception.InternalServerException;
 import org.ehrbase.api.service.AqlQueryService;
 import org.ehrbase.openehr.aqlengine.AqlQueryParsingPostProcessor;
@@ -45,8 +44,6 @@ import org.ehrbase.openehr.aqlengine.querywrapper.select.SelectWrapper.SelectTyp
 import org.ehrbase.openehr.aqlengine.repository.AqlQueryRepository;
 import org.ehrbase.openehr.aqlengine.repository.PreparedQuery;
 import org.ehrbase.openehr.sdk.aql.dto.AqlQuery;
-import org.ehrbase.openehr.sdk.aql.parser.AqlParseException;
-import org.ehrbase.openehr.sdk.aql.parser.AqlQueryParser;
 import org.ehrbase.openehr.sdk.aql.render.AqlRenderer;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryResultDto;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.query.ResultHolder;
@@ -92,15 +89,11 @@ public class AqlQueryServiceImp implements AqlQueryService {
     }
 
     @Override
-    public QueryResultDto query(AqlQueryRequest aqlQuery) {
-        return queryAql(aqlQuery);
-    }
-
-    private QueryResultDto queryAql(AqlQueryRequest aqlQueryRequest) {
+    public QueryResultDto query(AqlQueryRequest aqlQueryRequest) {
 
         // TODO: check that select aliases are not duplicated
         try {
-            AqlQuery aqlQuery = AqlQueryParser.parse(aqlQueryRequest.queryString());
+            AqlQuery aqlQuery = aqlQueryRequest.aqlQuery();
 
             // apply AQL postprocessors
             aqlPostProcessors.forEach(p -> p.afterParseAql(aqlQuery, aqlQueryRequest, aqlQueryContext));
@@ -169,8 +162,6 @@ public class AqlQueryServiceImp implements AqlQueryService {
             throw new BadGatewayException(errorMessage("Bad gateway", e), e);
         } catch (DataAccessException e) {
             throw new InternalServerException(errorMessage("Data Access Error", e), e);
-        } catch (AqlParseException e) {
-            throw new IllegalAqlException(errorMessage("Could not parse AQL query", e), e);
         }
     }
 

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/AqlLimitPostProcessorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/AqlLimitPostProcessorTest.java
@@ -120,7 +120,7 @@ class AqlLimitPostProcessorTest {
                 fetchPrecedence)
                 .afterParseAql(
                         AqlQuery.parse(query),
-                        AqlQueryRequest.parse(
+                        AqlQueryRequest.prepare(
                             query,
                             Map.of(),
                             parseLong(paramLimit).orElse(null),

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/AqlLimitPostProcessorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/AqlLimitPostProcessorTest.java
@@ -120,14 +120,12 @@ class AqlLimitPostProcessorTest {
                 fetchPrecedence)
                 .afterParseAql(
                         AqlQuery.parse(query),
-                        new AqlQueryRequest(
-                        query,
-                        Map.of(),
-                        parseLong(paramLimit).orElse(null),
-                        Optional.ofNullable(paramOffset)
-                                .filter(s -> !s.isEmpty())
-                                .map(Long::parseLong)
-                                .orElse(null)),
+                        AqlQueryRequest.parse(
+                            query,
+                            Map.of(),
+                            parseLong(paramLimit).orElse(null),
+                            Optional.ofNullable(paramOffset).filter(s -> !s.isEmpty()).map(Long::parseLong).orElse(null)
+                        ),
                         new TestAqlQueryContext());
         // @format:on
     }

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
@@ -272,7 +272,7 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
     AqlQueryRequest createRequest(
             @NonNull String queryString, Map<String, Object> parameters, Optional<Long> fetch, Optional<Long> offset) {
 
-        return AqlQueryRequest.parse(
+        return AqlQueryRequest.prepare(
                 queryString,
                 rewriteExplicitParameterTypes(parameters), // rewrite is needed for explicit XML params
                 fetch.orElse(null),

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
@@ -270,7 +270,7 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
     private AqlQueryRequest createRequest(
             @NonNull String queryString, Map<String, Object> parameters, Optional<Long> fetch, Optional<Long> offset) {
 
-        return new AqlQueryRequest(queryString, parameters, fetch.orElse(null), offset.orElse(null));
+        return AqlQueryRequest.parse(queryString, parameters, fetch.orElse(null), offset.orElse(null));
     }
 
     protected QueryResponseData createQueryResponse(

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrQueryController.java
@@ -24,9 +24,11 @@ import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.ehrbase.api.dto.AqlQueryContext;
 import org.ehrbase.api.dto.AqlQueryRequest;
@@ -267,10 +269,14 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
         return createRequest(queryString, queryParameters, fetch, offset);
     }
 
-    private AqlQueryRequest createRequest(
+    AqlQueryRequest createRequest(
             @NonNull String queryString, Map<String, Object> parameters, Optional<Long> fetch, Optional<Long> offset) {
 
-        return AqlQueryRequest.parse(queryString, parameters, fetch.orElse(null), offset.orElse(null));
+        return AqlQueryRequest.parse(
+                queryString,
+                rewriteExplicitParameterTypes(parameters), // rewrite is needed for explicit XML params
+                fetch.orElse(null),
+                offset.orElse(null));
     }
 
     protected QueryResponseData createQueryResponse(
@@ -289,6 +295,14 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
                 queryDefinitionResultDto.getQualifiedName() + "/" + queryDefinitionResultDto.getVersion());
     }
 
+    private static Map<String, Object> rewriteExplicitParameterTypes(Map<String, Object> parameters) {
+        if (parameters == null) {
+            return Map.of();
+        }
+        return parameters.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> handleExplicitParameterTypes(entry.getValue())));
+    }
+
     private static Optional<Long> optionalLong(String name, Map<String, Object> params) {
         return Optional.of(name).map(params::get).map(o -> switch (o) {
             case Integer i -> i.longValue();
@@ -302,5 +316,49 @@ public class OpenehrQueryController extends BaseController implements QueryApiSp
             }
             default -> throw new InvalidApiParameterException("invalid '%s' value '%s'".formatted(name, o));
         });
+    }
+
+    /**
+     * Allows for explicit types via xml: <param type="int">1</param> in query parameters.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Object handleExplicitParameterTypes(Object paramValue) {
+        return switch (paramValue) {
+            case Map<?, ?> map -> {
+                if (map.get("type") instanceof String type) {
+                    yield switch (type) {
+                        case "int" -> intValue(map, "").orElse(paramValue);
+                        case "num" -> numValue(map, "").orElse(paramValue);
+                        default -> handleExplicitParameterTypes(map.get(""));
+                    };
+                } else if (map.get("") instanceof List children && !children.isEmpty()) {
+                    yield children.stream()
+                            .map(OpenehrQueryController::handleExplicitParameterTypes)
+                            .toList();
+                } else {
+                    yield intValue(map, "int")
+                            .orElseGet(() -> numValue(map, "num").orElse(paramValue));
+                }
+            }
+            case List list -> {
+                for (int i = 0, s = list.size(); i < s; i++) {
+                    var value = list.get(i);
+                    var normalized = handleExplicitParameterTypes(value);
+                    if (value != normalized) {
+                        list.set(i, normalized);
+                    }
+                }
+                yield paramValue;
+            }
+            default -> paramValue;
+        };
+    }
+
+    private static Optional<Object> intValue(Map<?, ?> paramValues, String key) {
+        return Optional.of(key).map(paramValues::get).map(Object::toString).map(Integer::parseInt);
+    }
+
+    private static Optional<Object> numValue(Map<?, ?> paramValues, String key) {
+        return Optional.of(key).map(paramValues::get).map(Object::toString).map(Double::parseDouble);
     }
 }

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
@@ -104,7 +104,8 @@ public class OpenehrQueryControllerTest {
         ResponseEntity<QueryResponseData> response = controller()
                 .executeAdHocQuery(SAMPLE_QUERY, offset, fetch, SAMPLE_PARAMETER_MAP, MediaType.APPLICATION_JSON_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(
+                AqlQueryRequest.prepare(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     private Long toLong(Object obj) {
@@ -126,7 +127,8 @@ public class OpenehrQueryControllerTest {
                         MediaType.APPLICATION_JSON_VALUE,
                         MediaType.APPLICATION_FORM_URLENCODED_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(
+                AqlQueryRequest.prepare(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     private static Map<String, Object> sampleAqlQuery(Object fetch, Object offset) {
@@ -182,7 +184,8 @@ public class OpenehrQueryControllerTest {
                         SAMPLE_PARAMETER_MAP,
                         MediaType.APPLICATION_JSON_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(
+                AqlQueryRequest.prepare(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     @Test
@@ -217,7 +220,8 @@ public class OpenehrQueryControllerTest {
                         MediaType.APPLICATION_JSON_VALUE,
                         sampleAqlJson(fetch, offset));
         assertMetaData(response);
-        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(
+                AqlQueryRequest.prepare(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     @Test

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
@@ -17,6 +17,7 @@
  */
 package org.ehrbase.rest.openehr;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -30,7 +31,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.ehrbase.api.dto.AqlQueryContext;
 import org.ehrbase.api.dto.AqlQueryRequest;
 import org.ehrbase.api.exception.InvalidApiParameterException;
@@ -243,6 +246,64 @@ public class OpenehrQueryControllerTest {
                                 sampleAqlJson(null, "invalid")))
                 .getMessage();
         assertEquals("invalid 'offset' value 'invalid'", message);
+    }
+
+    @Test
+    void createRequestWithXmlParamsAdjusted() {
+
+        AqlQueryRequest request = controller()
+                .createRequest(
+                        "SELECT e FROM EHR e",
+                        Map.of(
+                                "p_string", "some-string",
+                                "p_xml_num", Map.of("type", "num", "", 42.12),
+                                "p_xml_int", Map.of("type", "int", "", 11)
+                                // "p_list": L
+                                ),
+                        Optional.empty(),
+                        Optional.empty());
+        assertThat(request.parameters())
+                .containsAllEntriesOf(Map.of("p_string", "some-string", "p_xml_num", 42.12, "p_xml_int", 11));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+
+    @Test
+    void createRequestWithXmlParamsWithoutTypeAdjusted() {
+
+        AqlQueryRequest request = controller()
+                .createRequest(
+                        "SELECT c FROM COMPOSITION c",
+                        Map.of(
+                                "p_xml_num", Map.of("num", 42.12),
+                                "p_xml_int", Map.of("int", 11)
+                                // "p_list": L
+
+                                ),
+                        Optional.empty(),
+                        Optional.empty());
+        assertThat(request.parameters()).containsAllEntriesOf(Map.of("p_xml_num", 42.12, "p_xml_int", 11));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
+    }
+
+    @Test
+    void createRequestWithXmlParamListsAdjusted() {
+
+        AqlQueryRequest request = controller()
+                .createRequest(
+                        "SELECT e, c FROM EHR e CONTAINS COMPOSITION c",
+                        Map.of(
+                                "p_xml_list", Map.of("", List.of("value_1", "value_2")),
+                                "p_xml_list_alternative", List.of("some", "other", "value")),
+                        Optional.empty(),
+                        Optional.empty());
+        assertThat(request.parameters())
+                .containsAllEntriesOf(Map.of(
+                        "p_xml_list", List.of("value_1", "value_2"),
+                        "p_xml_list_alternative", List.of("some", "other", "value")));
+        assertThat(request.fetch()).isNull();
+        assertThat(request.offset()).isNull();
     }
 
     private void assertAqlQueryRequest(AqlQueryRequest aqlQueryRequest) {

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrQueryControllerTest.java
@@ -101,7 +101,7 @@ public class OpenehrQueryControllerTest {
         ResponseEntity<QueryResponseData> response = controller()
                 .executeAdHocQuery(SAMPLE_QUERY, offset, fetch, SAMPLE_PARAMETER_MAP, MediaType.APPLICATION_JSON_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(new AqlQueryRequest(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     private Long toLong(Object obj) {
@@ -123,7 +123,7 @@ public class OpenehrQueryControllerTest {
                         MediaType.APPLICATION_JSON_VALUE,
                         MediaType.APPLICATION_FORM_URLENCODED_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(new AqlQueryRequest(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     private static Map<String, Object> sampleAqlQuery(Object fetch, Object offset) {
@@ -179,7 +179,7 @@ public class OpenehrQueryControllerTest {
                         SAMPLE_PARAMETER_MAP,
                         MediaType.APPLICATION_JSON_VALUE);
         assertMetaData(response);
-        assertAqlQueryRequest(new AqlQueryRequest(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     @Test
@@ -214,7 +214,7 @@ public class OpenehrQueryControllerTest {
                         MediaType.APPLICATION_JSON_VALUE,
                         sampleAqlJson(fetch, offset));
         assertMetaData(response);
-        assertAqlQueryRequest(new AqlQueryRequest(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
+        assertAqlQueryRequest(AqlQueryRequest.parse(SAMPLE_QUERY, SAMPLE_PARAMETER_MAP, toLong(fetch), toLong(offset)));
     }
 
     @Test


### PR DESCRIPTION
# Changes

Instead of parsing the AQL string in the AqlService service - this step is not preformed by the AqlQueryRequest so that an already parsed query can be passed down to the service.

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 