### PR TITLE
Contains expression semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Disabled by default, since it may produce unexpected results if the paths do not follow the archetype definitions. 
   [#1521](https://github.com/ehrbase/ehrbase/pull/1521)
  ### Changed 
+- AQL: CONTAINS with a node predicate now excludes results from nested archetypes.
+  To restore the previous behaviour set `ehrbase.aql.archetype-local-node-predicates = false`[#1524](https://github.com/ehrbase/ehrbase/pull/1524)
  ### Fixed
 - Fix terminology validation URL extraction [#1507](https://github.com/ehrbase/ehrbase/pull/1507)
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -51,3 +51,20 @@ As the code for the composition category 'episodic' has changed from 435 to 451,
 For smaller systems this can be checked via AQL:
 `SELECT c/archetype_details/template_id/value, count(*) FROM COMPOSITION c WHERE c/category/code/value = '435'`.
 Please open an issue on github in case you need instructions on correcting the data.
+
+## EHRbase 2.21.0
+
+In AQL queries CONTAINS expressions with a node predicate now exclude results from nested archetypes.
+
+Example:
+```
+SELECT el
+FROM OBSERVATION[openEHR-EHR-OBSERVATION.blood_pressure.v2] CONTAINS ELEMENT el[at0004] 
+```
+will be no longer contain from ELEMENTs returned by
+```
+SELECT el
+FROM OBSERVATION[openEHR-EHR-OBSERVATION.blood_pressure.v2] CONTAINS CLUSTER c[openEHR-EHR-CLUSTER.device.v1] CONTAINS ELEMENT el[at0004] 
+```
+
+To restore the previous behaviour set `ehrbase.aql.archetype-local-node-predicates = false`

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/AqlConfigurationProperties.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/AqlConfigurationProperties.java
@@ -17,7 +17,7 @@
  */
 package org.ehrbase.openehr.aqlengine;
 
-import java.util.Optional;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties.Experimental.AqlOnFolder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -29,12 +29,51 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * </ul>
  */
 @ConfigurationProperties(prefix = "ehrbase.aql")
-public record AqlConfigurationProperties(boolean pgLljWorkaround, Experimental experimental) {
+public final class AqlConfigurationProperties {
+    private boolean pgLljWorkaround;
+    private boolean archetypeLocalNodePredicates = true;
+    private boolean pathNodeSkipping;
+    private Experimental experimental = new Experimental(new AqlOnFolder(false));
 
-    public AqlConfigurationProperties(boolean pgLljWorkaround, Experimental experimental) {
+    public boolean pgLljWorkaround() {
+        return pgLljWorkaround;
+    }
+
+    public boolean archetypeLocalNodePredicates() {
+        return archetypeLocalNodePredicates;
+    }
+
+    public boolean pathNodeSkipping() {
+        return pathNodeSkipping;
+    }
+
+    public Experimental experimental() {
+        return experimental;
+    }
+
+    public void setPgLljWorkaround(final boolean pgLljWorkaround) {
         this.pgLljWorkaround = pgLljWorkaround;
-        this.experimental = Optional.ofNullable(experimental)
-                .orElseGet(() -> new Experimental(new Experimental.AqlOnFolder(false)));
+    }
+
+    public void setArchetypeLocalNodePredicates(final boolean archetypeLocalNodePredicates) {
+        this.archetypeLocalNodePredicates = archetypeLocalNodePredicates;
+    }
+
+    public void setPathNodeSkipping(final boolean pathNodeSkipping) {
+        this.pathNodeSkipping = pathNodeSkipping;
+    }
+
+    public void setExperimental(final Experimental experimental) {
+        this.experimental = experimental;
+    }
+
+    @Override
+    public String toString() {
+        return "AqlConfigurationProperties[" + "pgLljWorkaround="
+                + pgLljWorkaround + ", " + "archetypeLocalNodePredicates="
+                + archetypeLocalNodePredicates + ", " + "pathNodeSkipping="
+                + pathNodeSkipping + ", " + "experimental="
+                + experimental + ']';
     }
 
     public record Experimental(AqlOnFolder aqlOnFolder) {

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayer.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayer.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.ehrbase.api.knowledge.KnowledgeCacheService;
 import org.ehrbase.api.service.SystemService;
 import org.ehrbase.jooq.pg.enums.ContributionChangeType;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 import org.ehrbase.openehr.aqlengine.ChangeTypeUtils;
 import org.ehrbase.openehr.aqlengine.asl.AslUtils.AliasProvider;
 import org.ehrbase.openehr.aqlengine.asl.model.AslRmTypeAndConcept;
@@ -100,10 +101,15 @@ public class AqlSqlLayer {
 
     private final KnowledgeCacheService knowledgeCache;
     private final SystemService systemService;
+    private final AqlConfigurationProperties aqlConfigurationProperties;
 
-    public AqlSqlLayer(KnowledgeCacheService knowledgeCache, SystemService systemService) {
+    public AqlSqlLayer(
+            KnowledgeCacheService knowledgeCache,
+            SystemService systemService,
+            final AqlConfigurationProperties aqlConfigurationProperties) {
         this.knowledgeCache = knowledgeCache;
         this.systemService = systemService;
+        this.aqlConfigurationProperties = aqlConfigurationProperties;
     }
 
     public AslRootQuery buildAslRootQuery(AqlQueryWrapper query) {
@@ -112,8 +118,9 @@ public class AqlSqlLayer {
         AslRootQuery aslQuery = new AslRootQuery();
 
         // FROM
-        AslFromCreator.ContainsToOwnerProvider containsToStructureSubquery =
-                new AslFromCreator(aliasProvider, knowledgeCache).addFromClause(aslQuery, query);
+        AslFromCreator.ContainsToOwnerProvider containsToStructureSubquery = new AslFromCreator(
+                        aliasProvider, knowledgeCache, aqlConfigurationProperties.archetypeLocalNodePredicates())
+                .addFromClause(aslQuery, query);
 
         // Paths
         final AslPathCreator.PathToField pathToField = new AslPathCreator(

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AslUtils.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AslUtils.java
@@ -507,7 +507,7 @@ public final class AslUtils {
                         findFieldForOwner(EHR_TABLE_ID_FIELD, left.getSelect(), leftOwner),
                         AslConditionOperator.EQ,
                         findFieldForOwner(AslStructureColumn.EHR_ID, right.getSelect(), rightOwner)))
-                : joinSameRootObjectConditions(left, leftOwner, right, rightOwner);
+                : sameVersionedObjectJoinConditions(left, leftOwner, right, rightOwner);
 
         return concatStreams(
                 idConditions,
@@ -709,13 +709,13 @@ public final class AslUtils {
 
         // use only the num cap range condition
         if (parentWrapper == null || !childWrapper.isAtCode()) {
-            return joinNumCapBetweenConditions(left, leftOwner, right, rightOwner);
+            return numCapBetweenJoinConditions(left, leftOwner, right, rightOwner);
         }
 
         if (parentWrapper.isArchetype()) {
             return concatStreams(
                     Stream.of(archetypeParentContainsCondition(left, leftOwner, right, rightOwner)),
-                    joinNumCapBetweenConditions(left, leftOwner, right, rightOwner));
+                    numCapBetweenJoinConditions(left, leftOwner, right, rightOwner));
         }
 
         if (parentWrapper.isAtCode()) {

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AslUtils.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AslUtils.java
@@ -486,11 +486,6 @@ public final class AslUtils {
     }
 
     public static Stream<AslFieldFieldQueryCondition> descendantJoinConditionProviders(
-            AslQuery left, AslStructureQuery leftOwner, AslQuery right, AslStructureQuery rightOwner) {
-        return descendantJoinConditionProviders(left, leftOwner, right, rightOwner, null, null);
-    }
-
-    public static Stream<AslFieldFieldQueryCondition> descendantJoinConditionProviders(
             AslQuery left,
             AslStructureQuery leftOwner,
             AslQuery right,

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/FromCheck.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/FromCheck.java
@@ -151,7 +151,9 @@ final class FromCheck implements FeatureCheck {
                 var next = ensureStructureContainsSupported(cce, parentStructure);
                 StructureRoot structureRoot =
                         Optional.of(next).map(Pair::getRight).orElse(parentStructure);
-                ensureNodePredicateContainmentSupported(parentStructure, parent, cce, structureRoot);
+                if (aqlConfiguration.archetypeLocalNodePredicates()) {
+                    ensureNodePredicateContainmentSupported(parentStructure, parent, cce, structureRoot);
+                }
                 ensureContainmentSupported(next.getLeft(), structureRoot, cce);
 
                 ensureContainmentStructureSupported(parentStructure, cce, structureRoot);

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/pathanalysis/PathCohesionAnalysis.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/pathanalysis/PathCohesionAnalysis.java
@@ -20,6 +20,7 @@ package org.ehrbase.openehr.aqlengine.pathanalysis;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,15 +90,22 @@ public final class PathCohesionAnalysis {
 
         Map<AbstractContainmentExpression, List<IdentifiedPath>> roots = AqlQueryUtils.allIdentifiedPaths(query)
                 .distinct()
-                .collect(Collectors.groupingBy(IdentifiedPath::getRoot));
+                .collect(Collectors.groupingBy(IdentifiedPath::getRoot, IdentityHashMap::new, Collectors.toList()));
 
-        return roots.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> {
-            PathNode rootNode = createRootNode(e);
+        return roots.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> {
+                            PathNode rootNode = createRootNode(e);
 
-            PathCohesionTreeNode joinTree = PathCohesionTreeNode.root(rootNode, e.getValue());
-            fillJoinTree(joinTree, 0);
-            return joinTree;
-        }));
+                            PathCohesionTreeNode joinTree = PathCohesionTreeNode.root(rootNode, e.getValue());
+                            fillJoinTree(joinTree, 0);
+                            return joinTree;
+                        },
+                        (a, b) -> {
+                            throw new UnsupportedOperationException();
+                        },
+                        IdentityHashMap::new));
     }
 
     private static PathNode createRootNode(Map.Entry<AbstractContainmentExpression, List<IdentifiedPath>> e) {

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
@@ -170,10 +170,22 @@ public final class AqlQueryWrapper {
         final List<ContainsWrapper> chain = new ArrayList<>();
         final ContainsSetOperationWrapper setOperator;
 
+        ContainsWrapper parent = null;
         Containment next = root;
         while (next instanceof AbstractContainmentExpression c) {
 
-            chain.add(containsDescs.get(next));
+            ContainsWrapper current = containsDescs.get(next);
+            chain.add(current);
+
+            // TODO: could have a setter on the contains wrapper?
+            if (current instanceof RmContainsWrapper rcw) {
+                rcw.setParent(parent);
+            } else if (current instanceof VersionContainsWrapper vcw) {
+                vcw.setParent(parent);
+            }
+
+            parent = current;
+
             if (next instanceof ContainmentVersionExpression) {
                 // Version descriptor represents itself and its child, so the child itself is not added
                 next = ((AbstractContainmentExpression) c.getContains()).getContains();

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
@@ -33,8 +33,12 @@ import org.ehrbase.openehr.aqlengine.querywrapper.contains.RmContainsWrapper;
 import org.ehrbase.openehr.aqlengine.querywrapper.contains.VersionContainsWrapper;
 import org.ehrbase.openehr.aqlengine.querywrapper.orderby.OrderByWrapper;
 import org.ehrbase.openehr.aqlengine.querywrapper.select.SelectWrapper;
+import org.ehrbase.openehr.aqlengine.querywrapper.select.SelectWrapper.SelectType;
 import org.ehrbase.openehr.aqlengine.querywrapper.where.ComparisonOperatorConditionWrapper;
+import org.ehrbase.openehr.aqlengine.querywrapper.where.ComparisonOperatorConditionWrapper.IdentifiedPathWrapper;
 import org.ehrbase.openehr.aqlengine.querywrapper.where.ConditionWrapper;
+import org.ehrbase.openehr.aqlengine.querywrapper.where.ConditionWrapper.ComparisonConditionOperator;
+import org.ehrbase.openehr.aqlengine.querywrapper.where.ConditionWrapper.LogicalConditionOperator;
 import org.ehrbase.openehr.aqlengine.querywrapper.where.LogicalOperatorConditionWrapper;
 import org.ehrbase.openehr.sdk.aql.dto.AqlQuery;
 import org.ehrbase.openehr.sdk.aql.dto.condition.ComparisonOperatorCondition;
@@ -99,7 +103,7 @@ public final class AqlQueryWrapper {
     }
 
     public Stream<SelectWrapper> nonPrimitiveSelects() {
-        return selects.stream().filter(sd -> sd.type() != SelectWrapper.SelectType.PRIMITIVE);
+        return selects.stream().filter(sd -> sd.type() != SelectType.PRIMITIVE);
     }
 
     /**
@@ -126,7 +130,7 @@ public final class AqlQueryWrapper {
                     .forEach(c -> containsDescs.put(c, new VersionContainsWrapper(c.getIdentifier(), (RmContainsWrapper)
                             containsDescs.get(c.getContains()))));
 
-            fromClause = buildContainsChain(fromRoot, containsDescs);
+            fromClause = buildContainsChain(fromRoot, containsDescs, null);
         }
 
         List<SelectWrapper> selects = aqlQuery.getSelect().getStatement().stream()
@@ -166,25 +170,21 @@ public final class AqlQueryWrapper {
     }
 
     private static ContainsChain buildContainsChain(
-            Containment root, Map<AbstractContainmentExpression, ContainsWrapper> containsDescs) {
+            Containment root,
+            Map<AbstractContainmentExpression, ContainsWrapper> containsDescs,
+            ContainsWrapper parent) {
         final List<ContainsWrapper> chain = new ArrayList<>();
         final ContainsSetOperationWrapper setOperator;
 
-        ContainsWrapper parent = null;
+        ContainsWrapper currentParent = parent;
         Containment next = root;
         while (next instanceof AbstractContainmentExpression c) {
 
             ContainsWrapper current = containsDescs.get(next);
             chain.add(current);
+            current.setParent(currentParent);
 
-            // TODO: could have a setter on the contains wrapper?
-            if (current instanceof RmContainsWrapper rcw) {
-                rcw.setParent(parent);
-            } else if (current instanceof VersionContainsWrapper vcw) {
-                vcw.setParent(parent);
-            }
-
-            parent = current;
+            currentParent = current;
 
             if (next instanceof ContainmentVersionExpression) {
                 // Version descriptor represents itself and its child, so the child itself is not added
@@ -195,10 +195,11 @@ public final class AqlQueryWrapper {
         }
 
         if (next instanceof ContainmentSetOperator o) {
+            final ContainsWrapper finalCurrentParent = currentParent;
             setOperator = new ContainsSetOperationWrapper(
                     o.getSymbol(),
                     o.getValues().stream()
-                            .map(c -> buildContainsChain(c, containsDescs))
+                            .map(c -> buildContainsChain(c, containsDescs, finalCurrentParent))
                             .toList());
         } else {
             setOperator = null;
@@ -209,12 +210,11 @@ public final class AqlQueryWrapper {
 
     private static SelectWrapper buildSelectDescriptor(
             Map<AbstractContainmentExpression, ContainsWrapper> containsDescs, SelectExpression s) {
-        Pair<SelectWrapper.SelectType, IdentifiedPath> typeAndPath =
+        Pair<SelectType, IdentifiedPath> typeAndPath =
                 switch (s.getColumnExpression()) {
-                    case IdentifiedPath i -> Pair.of(SelectWrapper.SelectType.PATH, i);
-                    case AggregateFunction af -> Pair.of(
-                            SelectWrapper.SelectType.AGGREGATE_FUNCTION, af.getIdentifiedPath());
-                    case Primitive __ -> Pair.of(SelectWrapper.SelectType.PRIMITIVE, null);
+                    case IdentifiedPath i -> Pair.of(SelectType.PATH, i);
+                    case AggregateFunction af -> Pair.of(SelectType.AGGREGATE_FUNCTION, af.getIdentifiedPath());
+                    case Primitive __ -> Pair.of(SelectType.PRIMITIVE, null);
                     default -> throw new IllegalArgumentException("Unknown ColumnExpression type in SELECT");
                 };
         return new SelectWrapper(
@@ -231,62 +231,55 @@ public final class AqlQueryWrapper {
             WhereCondition where, Map<AbstractContainmentExpression, ContainsWrapper> containsDescs, boolean negate) {
         return switch (where) {
             case ComparisonOperatorCondition c -> new ComparisonOperatorConditionWrapper(
-                    new ComparisonOperatorConditionWrapper.IdentifiedPathWrapper(
+                    new IdentifiedPathWrapper(
                             containsDescs.get(((IdentifiedPath) c.getStatement()).getRoot()),
                             (IdentifiedPath) c.getStatement()),
-                    ConditionWrapper.ComparisonConditionOperator.valueOf(
-                            c.getSymbol().name(), negate),
+                    ComparisonConditionOperator.valueOf(c.getSymbol().name(), negate),
                     (Primitive) c.getValue());
             case MatchesCondition c -> negate
                     ? new LogicalOperatorConditionWrapper(
-                            ConditionWrapper.LogicalConditionOperator.AND,
+                            LogicalConditionOperator.AND,
                             c.getValues().stream()
                                     .map(Primitive.class::cast)
                                     .map(v -> (ConditionWrapper) new ComparisonOperatorConditionWrapper(
-                                            new ComparisonOperatorConditionWrapper.IdentifiedPathWrapper(
+                                            new IdentifiedPathWrapper(
                                                     containsDescs.get(
                                                             c.getStatement().getRoot()),
                                                     c.getStatement()),
-                                            ConditionWrapper.ComparisonConditionOperator.NEQ,
+                                            ComparisonConditionOperator.NEQ,
                                             v))
                                     .toList())
                     : new ComparisonOperatorConditionWrapper(
-                            new ComparisonOperatorConditionWrapper.IdentifiedPathWrapper(
+                            new IdentifiedPathWrapper(
                                     containsDescs.get(c.getStatement().getRoot()), c.getStatement()),
-                            ConditionWrapper.ComparisonConditionOperator.MATCHES,
+                            ComparisonConditionOperator.MATCHES,
                             c.getValues().stream().map(Primitive.class::cast).toList());
             case LikeCondition c -> {
                 ComparisonOperatorConditionWrapper condition = new ComparisonOperatorConditionWrapper(
-                        new ComparisonOperatorConditionWrapper.IdentifiedPathWrapper(
+                        new IdentifiedPathWrapper(
                                 containsDescs.get(c.getStatement().getRoot()), c.getStatement()),
-                        ConditionWrapper.ComparisonConditionOperator.LIKE,
+                        ComparisonConditionOperator.LIKE,
                         (Primitive) c.getValue());
                 yield negate
-                        ? new LogicalOperatorConditionWrapper(
-                                ConditionWrapper.LogicalConditionOperator.NOT, List.of(condition))
+                        ? new LogicalOperatorConditionWrapper(LogicalConditionOperator.NOT, List.of(condition))
                         : condition;
             }
             case ExistsCondition c -> {
                 ComparisonOperatorConditionWrapper comparisonOperatorConditionDescriptor =
                         new ComparisonOperatorConditionWrapper(
-                                new ComparisonOperatorConditionWrapper.IdentifiedPathWrapper(
+                                new IdentifiedPathWrapper(
                                         containsDescs.get(c.getValue().getRoot()), c.getValue()),
-                                ConditionWrapper.ComparisonConditionOperator.EXISTS,
+                                ComparisonConditionOperator.EXISTS,
                                 List.of());
                 yield negate
                         ? new LogicalOperatorConditionWrapper(
-                                ConditionWrapper.LogicalConditionOperator.NOT,
-                                List.of(comparisonOperatorConditionDescriptor))
+                                LogicalConditionOperator.NOT, List.of(comparisonOperatorConditionDescriptor))
                         : comparisonOperatorConditionDescriptor;
             }
             case LogicalOperatorCondition c -> new LogicalOperatorConditionWrapper(
                     switch (c.getSymbol()) {
-                        case OR -> negate
-                                ? ConditionWrapper.LogicalConditionOperator.AND
-                                : ConditionWrapper.LogicalConditionOperator.OR;
-                        case AND -> negate
-                                ? ConditionWrapper.LogicalConditionOperator.OR
-                                : ConditionWrapper.LogicalConditionOperator.AND;
+                        case OR -> negate ? LogicalConditionOperator.AND : LogicalConditionOperator.OR;
+                        case AND -> negate ? LogicalConditionOperator.OR : LogicalConditionOperator.AND;
                     },
                     c.getValues().stream()
                             .map(w -> buildWhereDescriptor(w, containsDescs, negate))

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/AqlQueryWrapper.java
@@ -18,7 +18,7 @@
 package org.ehrbase.openehr.aqlengine.querywrapper;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,7 +114,7 @@ public final class AqlQueryWrapper {
      * @return
      */
     public static AqlQueryWrapper create(AqlQuery aqlQuery, final boolean enableNodeSkipping) {
-        Map<AbstractContainmentExpression, ContainsWrapper> containsDescs = new LinkedHashMap<>();
+        Map<AbstractContainmentExpression, ContainsWrapper> containsDescs = new IdentityHashMap<>();
 
         ContainsChain fromClause;
         {

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/ContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/ContainsWrapper.java
@@ -28,4 +28,6 @@ public sealed interface ContainsWrapper permits RmContainsWrapper, VersionContai
     boolean isArchetype();
 
     ContainsWrapper getParent();
+
+    void setParent(ContainsWrapper parent);
 }

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/ContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/ContainsWrapper.java
@@ -19,11 +19,13 @@ package org.ehrbase.openehr.aqlengine.querywrapper.contains;
 
 public sealed interface ContainsWrapper permits RmContainsWrapper, VersionContainsWrapper {
 
-    default String getRmType() {
-        throw new UnsupportedOperationException();
-    }
+    String getRmType();
 
-    default String alias() {
-        throw new UnsupportedOperationException();
-    }
+    String alias();
+
+    boolean isAtCode();
+
+    boolean isArchetype();
+
+    ContainsWrapper getParent();
 }

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/RmContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/RmContainsWrapper.java
@@ -86,7 +86,7 @@ public final class RmContainsWrapper implements ContainsWrapper {
 
     private boolean hasConsistentNodeIdPrefixes(String... allowedPrefixes) {
         List<AndOperatorPredicate> predicates = containment.getPredicates();
-        if (predicates.isEmpty()) {
+        if (predicates == null || predicates.isEmpty()) {
             return false;
         }
 

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/RmContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/RmContainsWrapper.java
@@ -21,15 +21,12 @@ import static org.ehrbase.openehr.aqlengine.asl.model.AslRmTypeAndConcept.ARCHET
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.ehrbase.openehr.dbformat.StructureRmType;
 import org.ehrbase.openehr.sdk.aql.dto.containment.ContainmentClassExpression;
 import org.ehrbase.openehr.sdk.aql.dto.operand.StringPrimitive;
 import org.ehrbase.openehr.sdk.aql.dto.path.AndOperatorPredicate;
 import org.ehrbase.openehr.sdk.aql.dto.path.AqlObjectPathUtil;
 import org.ehrbase.openehr.sdk.aql.dto.path.ComparisonOperatorPredicate.PredicateComparisonOperator;
-import org.ehrbase.openehr.sdk.aql.util.AqlUtil;
 
 public final class RmContainsWrapper implements ContainsWrapper {
     private final ContainmentClassExpression containment;
@@ -94,19 +91,18 @@ public final class RmContainsWrapper implements ContainsWrapper {
         }
 
         return predicates.stream()
-            .map(andPred -> {
-                List<String> nodeIdValues = andPred.getOperands()
-                    .stream()
-                    .filter(p -> AqlObjectPathUtil.ARCHETYPE_NODE_ID.equals(p.getPath())
-                                 && p.getOperator() == PredicateComparisonOperator.EQ
-                                 && p.getValue() instanceof StringPrimitive)
-                    .map(p -> ((StringPrimitive) p.getValue()).getValue())
-                    .toList();
+                .map(andPred -> {
+                    List<String> nodeIdValues = andPred.getOperands().stream()
+                            .filter(p -> AqlObjectPathUtil.ARCHETYPE_NODE_ID.equals(p.getPath())
+                                    && p.getOperator() == PredicateComparisonOperator.EQ
+                                    && p.getValue() instanceof StringPrimitive)
+                            .map(p -> ((StringPrimitive) p.getValue()).getValue())
+                            .toList();
 
-                return !nodeIdValues.isEmpty() && nodeIdValues.stream()
-                    .allMatch(value -> Arrays.stream(allowedPrefixes)
-                        .anyMatch(value::startsWith));
-            })
-            .reduce(true, Boolean::logicalAnd);
+                    return !nodeIdValues.isEmpty()
+                            && nodeIdValues.stream().allMatch(value -> Arrays.stream(allowedPrefixes)
+                                    .anyMatch(value::startsWith));
+                })
+                .reduce(true, Boolean::logicalAnd);
     }
 }

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/VersionContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/VersionContainsWrapper.java
@@ -54,6 +54,7 @@ public final class VersionContainsWrapper implements ContainsWrapper {
         return parent;
     }
 
+    @Override
     public void setParent(ContainsWrapper parent) {
         this.parent = parent;
     }

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/VersionContainsWrapper.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/querywrapper/contains/VersionContainsWrapper.java
@@ -22,6 +22,7 @@ import org.ehrbase.openehr.sdk.util.rmconstants.RmConstants;
 public final class VersionContainsWrapper implements ContainsWrapper {
     private final String alias;
     private final RmContainsWrapper child;
+    private ContainsWrapper parent;
 
     public VersionContainsWrapper(String alias, RmContainsWrapper child) {
         this.alias = alias;
@@ -36,6 +37,25 @@ public final class VersionContainsWrapper implements ContainsWrapper {
     @Override
     public String alias() {
         return alias;
+    }
+
+    @Override
+    public boolean isAtCode() {
+        return false;
+    }
+
+    @Override
+    public boolean isArchetype() {
+        return false;
+    }
+
+    @Override
+    public ContainsWrapper getParent() {
+        return parent;
+    }
+
+    public void setParent(ContainsWrapper parent) {
+        this.parent = parent;
     }
 
     public RmContainsWrapper child() {

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayerTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayerTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ehrbase.api.knowledge.KnowledgeCacheService;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 import org.ehrbase.openehr.aqlengine.asl.model.field.AslField;
 import org.ehrbase.openehr.aqlengine.asl.model.field.AslRmPathField;
 import org.ehrbase.openehr.aqlengine.asl.model.field.AslSubqueryField;
@@ -404,7 +405,8 @@ public class AqlSqlLayerTest {
         AqlQuery aqlQuery = AqlQueryParser.parse(query);
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, pathSkipping);
 
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslRootQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         new AslCleanupPostProcessor().afterBuildAsl(aslRootQuery, aqlQuery, queryWrapper, null);
         return aslRootQuery;

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayerTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayerTest.java
@@ -400,6 +400,367 @@ public class AqlSqlLayerTest {
         assertThat(AslGraph.createAslGraph(aslQuery)).isEqualToIgnoringNewLines(expected);
     }
 
+    @Test
+    void testSimpleNodePredicateContainment() {
+        AslRootQuery aslQuery = buildSqlQuery(
+                """
+        SELECT
+            e/ehr_id/value
+        FROM EHR e CONTAINS OBSERVATION [openEHR-EHR-OBSERVATION.o1o1o1.v1] CONTAINS CLUSTER[at0001] CONTAINS ELEMENT[at0002]
+        """,
+                false);
+
+        String expected =
+                """
+                AslRootQuery
+                  SELECT
+                    sEHR_e_0.sEHR_e_0_id /* ehr_id/value */
+                  FROM
+                    sEHR_e_0: StructureQuery
+                      SELECT
+                        sEHR_e_0.sEHR_e_0_id /* ehr_id/value */
+                      FROM EHR
+                    sOB_0: StructureQuery
+                      SELECT
+                        sOB_0.sOB_0_vo_id
+                        sOB_0.sOB_0_num
+                        sOB_0.sOB_0_ehr_id
+                      WHERE
+                        sOB_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.o1o1o1.v1]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sOB_0.sOB_0_rm_entity IN [OB]
+                      JOIN sEHR_e_0 -> sOB_0
+                        on
+                          DelegatingJoinCondition ->
+                              sEHR_e_0.sEHR_e_0_id /* ehr_id/value */ EQ sOB_0.sOB_0_ehr_id
+
+                    sCL_0: StructureQuery
+                      SELECT
+                        sCL_0.sCL_0_vo_id
+                        sCL_0.sCL_0_num
+                        sCL_0.sCL_0_num_cap
+                        sCL_0.sCL_0_citem_num
+                      WHERE
+                        sCL_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0001]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sCL_0.sCL_0_rm_entity IN [CL]
+                      JOIN sOB_0 -> sCL_0
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_0.sOB_0_vo_id EQ sCL_0.sCL_0_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_0.sOB_0_num EQ sCL_0.sCL_0_citem_num
+
+                    sE_0: StructureQuery
+                      SELECT
+                        sE_0.sE_0_vo_id
+                        sE_0.sE_0_num
+                        sE_0.sE_0_citem_num
+                      WHERE
+                        sE_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0002]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sE_0.sE_0_rm_entity IN [E]
+                      JOIN sCL_0 -> sE_0
+                        on
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_vo_id EQ sE_0.sE_0_vo_id
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_citem_num EQ sE_0.sE_0_citem_num
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_num LT sE_0.sE_0_num
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_num_cap GT_EQ sE_0.sE_0_num
+                """;
+
+        assertThat(AslGraph.createAslGraph(aslQuery)).isEqualToIgnoringNewLines(expected);
+    }
+
+    @Test
+    void testNodePredicateContainment() {
+        AslRootQuery aslQuery = buildSqlQuery(
+                """
+        SELECT
+            e/ehr_id/value
+        FROM EHR e CONTAINS
+        (
+            (OBSERVATION [openEHR-EHR-OBSERVATION.o1o1o1.v1] CONTAINS CLUSTER[at0001] CONTAINS ELEMENT[at0002])
+            AND
+            (
+                OBSERVATION [openEHR-EHR-OBSERVATION.o2o2o2.v1] CONTAINS
+                (
+                    (CLUSTER[at0001] CONTAINS ELEMENT[at0002])
+                    OR(
+                        ELEMENT[at0003]
+                        AND
+                        (CLUSTER[at0001] CONTAINS ELEMENT[at0002])
+                        AND
+                        (CLUSTER[openEHR-EHR-CLUSTER.cl.v1] CONTAINS ELEMENT[at0002])
+                    )
+                )
+            )
+        )
+        """,
+                false);
+
+        String expected =
+                """
+                AslRootQuery
+                  SELECT
+                    sEHR_e_0.sEHR_e_0_id /* ehr_id/value */
+                  FROM
+                    sEHR_e_0: StructureQuery
+                      SELECT
+                        sEHR_e_0.sEHR_e_0_id /* ehr_id/value */
+                      FROM EHR
+                    sOB_0: StructureQuery
+                      SELECT
+                        sOB_0.sOB_0_vo_id
+                        sOB_0.sOB_0_num
+                        sOB_0.sOB_0_ehr_id
+                      WHERE
+                        sOB_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.o1o1o1.v1]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sOB_0.sOB_0_rm_entity IN [OB]
+                      JOIN sEHR_e_0 -> sOB_0
+                        on
+                          DelegatingJoinCondition ->
+                              sEHR_e_0.sEHR_e_0_id /* ehr_id/value */ EQ sOB_0.sOB_0_ehr_id
+
+                    sCL_0: StructureQuery
+                      SELECT
+                        sCL_0.sCL_0_vo_id
+                        sCL_0.sCL_0_num
+                        sCL_0.sCL_0_num_cap
+                        sCL_0.sCL_0_citem_num
+                      WHERE
+                        sCL_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0001]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sCL_0.sCL_0_rm_entity IN [CL]
+                      JOIN sOB_0 -> sCL_0
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_0.sOB_0_vo_id EQ sCL_0.sCL_0_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_0.sOB_0_num EQ sCL_0.sCL_0_citem_num
+
+                    sE_0: StructureQuery
+                      SELECT
+                        sE_0.sE_0_vo_id
+                        sE_0.sE_0_num
+                        sE_0.sE_0_citem_num
+                      WHERE
+                        sE_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0002]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sE_0.sE_0_rm_entity IN [E]
+                      JOIN sCL_0 -> sE_0
+                        on
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_vo_id EQ sE_0.sE_0_vo_id
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_citem_num EQ sE_0.sE_0_citem_num
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_num LT sE_0.sE_0_num
+
+                          DelegatingJoinCondition ->
+                              sCL_0.sCL_0_num_cap GT_EQ sE_0.sE_0_num
+
+                    sOB_1: StructureQuery
+                      SELECT
+                        sOB_1.sOB_1_vo_id
+                        sOB_1.sOB_1_num
+                        sOB_1.sOB_1_num_cap
+                        sOB_1.sOB_1_ehr_id
+                      WHERE
+                        sOB_1.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.o2o2o2.v1]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sOB_1.sOB_1_rm_entity IN [OB]
+                      JOIN sEHR_e_0 -> sOB_1
+                        on
+                          DelegatingJoinCondition ->
+                              sEHR_e_0.sEHR_e_0_id /* ehr_id/value */ EQ sOB_1.sOB_1_ehr_id
+
+                    or_sq_0: EncapsulatingQuery
+                      SELECT
+                        sCL_1.sCL_1_vo_id
+                        sCL_1.sCL_1_num
+                        sCL_1.sCL_1_num_cap
+                        sCL_1.sCL_1_citem_num
+                        sE_1.sE_1_vo_id
+                        sE_1.sE_1_num
+                        sE_1.sE_1_citem_num
+                        FROM
+                          sCL_1: StructureQuery
+                              SELECT
+                                sCL_1.sCL_1_vo_id
+                                sCL_1.sCL_1_num
+                                sCL_1.sCL_1_num_cap
+                                sCL_1.sCL_1_citem_num
+                              WHERE
+                                sCL_1.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0001]]
+                              FROM COMPOSITION
+                              STRUCTURE CONDITIONS
+                                sCL_1.sCL_1_rm_entity IN [CL]
+
+                          sE_1: StructureQuery
+                              SELECT
+                                sE_1.sE_1_vo_id
+                                sE_1.sE_1_num
+                                sE_1.sE_1_citem_num
+                              WHERE
+                                sE_1.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0002]]
+                              FROM COMPOSITION
+                              STRUCTURE CONDITIONS
+                                sE_1.sE_1_rm_entity IN [E]
+                              JOIN sCL_1 -> sE_1
+                                on
+                                  DelegatingJoinCondition ->
+                                      sCL_1.sCL_1_vo_id EQ sE_1.sE_1_vo_id
+
+                                  DelegatingJoinCondition ->
+                                      sCL_1.sCL_1_citem_num EQ sE_1.sE_1_citem_num
+
+                                  DelegatingJoinCondition ->
+                                      sCL_1.sCL_1_num LT sE_1.sE_1_num
+
+                                  DelegatingJoinCondition ->
+                                      sCL_1.sCL_1_num_cap GT_EQ sE_1.sE_1_num
+
+
+                      LEFT_OUTER_JOIN sOB_1 -> or_sq_0
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_vo_id EQ sCL_1.sCL_1_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_num EQ sCL_1.sCL_1_citem_num
+
+                    sE_2: StructureQuery
+                      SELECT
+                        sE_2.sE_2_vo_id
+                        sE_2.sE_2_citem_num
+                      WHERE
+                        sE_2.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0003]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sE_2.sE_2_rm_entity IN [E]
+                      LEFT_OUTER_JOIN sOB_1 -> sE_2
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_vo_id EQ sE_2.sE_2_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_num EQ sE_2.sE_2_citem_num
+
+                    sCL_2: StructureQuery
+                      SELECT
+                        sCL_2.sCL_2_vo_id
+                        sCL_2.sCL_2_num
+                        sCL_2.sCL_2_num_cap
+                        sCL_2.sCL_2_citem_num
+                      WHERE
+                        sCL_2.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0001]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sCL_2.sCL_2_rm_entity IN [CL]
+                      LEFT_OUTER_JOIN sOB_1 -> sCL_2
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_vo_id EQ sCL_2.sCL_2_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_num EQ sCL_2.sCL_2_citem_num
+
+                    sE_3: StructureQuery
+                      SELECT
+                        sE_3.sE_3_vo_id
+                        sE_3.sE_3_num
+                        sE_3.sE_3_citem_num
+                      WHERE
+                        sE_3.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0002]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sE_3.sE_3_rm_entity IN [E]
+                      LEFT_OUTER_JOIN sCL_2 -> sE_3
+                        on
+                          DelegatingJoinCondition ->
+                              sCL_2.sCL_2_vo_id EQ sE_3.sE_3_vo_id
+
+                          DelegatingJoinCondition ->
+                              sCL_2.sCL_2_citem_num EQ sE_3.sE_3_citem_num
+
+                          DelegatingJoinCondition ->
+                              sCL_2.sCL_2_num LT sE_3.sE_3_num
+
+                          DelegatingJoinCondition ->
+                              sCL_2.sCL_2_num_cap GT_EQ sE_3.sE_3_num
+
+                    sCL_3: StructureQuery
+                      SELECT
+                        sCL_3.sCL_3_vo_id
+                        sCL_3.sCL_3_num
+                      WHERE
+                        sCL_3.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=CL, concept=.cl.v1]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sCL_3.sCL_3_rm_entity IN [CL]
+                      LEFT_OUTER_JOIN sOB_1 -> sCL_3
+                        on
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_vo_id EQ sCL_3.sCL_3_vo_id
+
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_num LT sCL_3.sCL_3_num
+
+                          DelegatingJoinCondition ->
+                              sOB_1.sOB_1_num_cap GT_EQ sCL_3.sCL_3_num
+
+                    sE_4: StructureQuery
+                      SELECT
+                        sE_4.sE_4_vo_id
+                        sE_4.sE_4_citem_num
+                      WHERE
+                        sE_4.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=null, concept=at0002]]
+                      FROM COMPOSITION
+                      STRUCTURE CONDITIONS
+                        sE_4.sE_4_rm_entity IN [E]
+                      LEFT_OUTER_JOIN sCL_3 -> sE_4
+                        on
+                          DelegatingJoinCondition ->
+                              sCL_3.sCL_3_vo_id EQ sE_4.sE_4_vo_id
+
+                          DelegatingJoinCondition ->
+                              sCL_3.sCL_3_num EQ sE_4.sE_4_citem_num
+
+                  WHERE
+                    OR
+                      NOT_NULL sCL_1.sCL_1_vo_id
+                      AND
+                        NOT_NULL sE_2.sE_2_vo_id
+                        AND
+                          NOT_NULL sCL_2.sCL_2_vo_id
+                          NOT_NULL sE_3.sE_3_vo_id
+                        AND
+                          NOT_NULL sCL_3.sCL_3_vo_id
+                          NOT_NULL sE_4.sE_4_vo_id
+                """;
+
+        assertThat(AslGraph.createAslGraph(aslQuery)).isEqualToIgnoringNewLines(expected);
+    }
+
     private AslRootQuery buildSqlQuery(String query, final boolean pathSkipping) {
 
         AqlQuery aqlQuery = AqlQueryParser.parse(query);

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
@@ -194,7 +194,6 @@ class AslCleanupPostProcessorTest {
               SELECT
                 sOB_o_0.sOB_o_0_vo_id
                 sOB_o_0.sOB_o_0_num
-                sOB_o_0.sOB_o_0_num_cap
                 sOB_o_0.sOB_o_0_entity_name /* name/value */
               WHERE
                 sOB_o_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.test.v0]]
@@ -209,7 +208,7 @@ class AslCleanupPostProcessorTest {
             sE_el_0: StructureQuery
               SELECT
                 sE_el_0.sE_el_0_vo_id
-                sE_el_0.sE_el_0_num
+                sE_el_0.sE_el_0_citem_num
                 sE_el_0.sE_el_0_entity_name /* name/value */
                 sE_el_0.sE_el_0_data
               WHERE
@@ -223,10 +222,7 @@ class AslCleanupPostProcessorTest {
                       sOB_o_0.sOB_o_0_vo_id EQ sE_el_0.sE_el_0_vo_id
 
                   DelegatingJoinCondition ->
-                      sOB_o_0.sOB_o_0_num LT sE_el_0.sE_el_0_num
-
-                  DelegatingJoinCondition ->
-                      sOB_o_0.sOB_o_0_num_cap GT_EQ sE_el_0.sE_el_0_num
+                    sOB_o_0.sOB_o_0_num EQ sE_el_0.sE_el_0_citem_num
 
             p_eq_0: EncapsulatingQuery
               SELECT

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
@@ -194,6 +194,7 @@ class AslCleanupPostProcessorTest {
               SELECT
                 sOB_o_0.sOB_o_0_vo_id
                 sOB_o_0.sOB_o_0_num
+                sOB_o_0.sOB_o_0_num_cap
                 sOB_o_0.sOB_o_0_entity_name /* name/value */
               WHERE
                 sOB_o_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.test.v0]]
@@ -208,6 +209,7 @@ class AslCleanupPostProcessorTest {
             sE_el_0: StructureQuery
               SELECT
                 sE_el_0.sE_el_0_vo_id
+                sE_el_0.sE_el_0_num
                 sE_el_0.sE_el_0_citem_num
                 sE_el_0.sE_el_0_entity_name /* name/value */
                 sE_el_0.sE_el_0_data
@@ -223,6 +225,12 @@ class AslCleanupPostProcessorTest {
 
                   DelegatingJoinCondition ->
                     sOB_o_0.sOB_o_0_num EQ sE_el_0.sE_el_0_citem_num
+
+                  DelegatingJoinCondition ->
+                    sOB_o_0.sOB_o_0_num LT sE_el_0.sE_el_0_num
+
+                  DelegatingJoinCondition ->
+                    sOB_o_0.sOB_o_0_num_cap GT_EQ sE_el_0.sE_el_0_num
 
             p_eq_0: EncapsulatingQuery
               SELECT

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslCleanupPostProcessorTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ehrbase.api.knowledge.KnowledgeCacheService;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 import org.ehrbase.openehr.aqlengine.AqlEhrPathPostProcessor;
 import org.ehrbase.openehr.aqlengine.AqlFromEhrOptimisationPostProcessor;
 import org.ehrbase.openehr.aqlengine.AqlQueryParsingPostProcessor;
@@ -194,7 +195,6 @@ class AslCleanupPostProcessorTest {
               SELECT
                 sOB_o_0.sOB_o_0_vo_id
                 sOB_o_0.sOB_o_0_num
-                sOB_o_0.sOB_o_0_num_cap
                 sOB_o_0.sOB_o_0_entity_name /* name/value */
               WHERE
                 sOB_o_0.?? -- COMPLEX ARCHETYPE_NODE_ID archetype_node_id EQ [AslRmTypeAndConcept[aliasedRmType=OB, concept=.test.v0]]
@@ -209,7 +209,6 @@ class AslCleanupPostProcessorTest {
             sE_el_0: StructureQuery
               SELECT
                 sE_el_0.sE_el_0_vo_id
-                sE_el_0.sE_el_0_num
                 sE_el_0.sE_el_0_citem_num
                 sE_el_0.sE_el_0_entity_name /* name/value */
                 sE_el_0.sE_el_0_data
@@ -224,13 +223,7 @@ class AslCleanupPostProcessorTest {
                       sOB_o_0.sOB_o_0_vo_id EQ sE_el_0.sE_el_0_vo_id
 
                   DelegatingJoinCondition ->
-                    sOB_o_0.sOB_o_0_num EQ sE_el_0.sE_el_0_citem_num
-
-                  DelegatingJoinCondition ->
-                    sOB_o_0.sOB_o_0_num LT sE_el_0.sE_el_0_num
-
-                  DelegatingJoinCondition ->
-                    sOB_o_0.sOB_o_0_num_cap GT_EQ sE_el_0.sE_el_0_num
+                      sOB_o_0.sOB_o_0_num EQ sE_el_0.sE_el_0_citem_num
 
             p_eq_0: EncapsulatingQuery
               SELECT
@@ -394,7 +387,8 @@ class AslCleanupPostProcessorTest {
         }
 
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         return new AslResult(aqlQuery, queryWrapper, aslQuery);
     }

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslFromCreatorTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslFromCreatorTest.java
@@ -51,7 +51,7 @@ class AslFromCreatorTest {
         var aqlQuery = AqlQueryParser.parse(aql);
         var queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
 
-        var aslFromCreator = new AslFromCreator(aliasProvider, mockKnowledgeCacheService);
+        var aslFromCreator = new AslFromCreator(aliasProvider, mockKnowledgeCacheService, true);
         aslFromCreator.addFromClause(aslQuery, queryWrapper);
 
         return aslQuery;

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslGraphTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/asl/AslGraphTest.java
@@ -17,6 +17,7 @@
  */
 package org.ehrbase.openehr.aqlengine.asl;
 
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 import org.ehrbase.openehr.aqlengine.asl.model.query.AslRootQuery;
 import org.ehrbase.openehr.aqlengine.querywrapper.AqlQueryWrapper;
 import org.ehrbase.openehr.sdk.aql.dto.AqlQuery;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class AslGraphTest {
 
     @Test
-    @Disabled("What is this testing - there is no assert?")
+    @Disabled
     void printDataQueryGraph() {
 
         AqlQuery aqlQuery = AqlQueryParser.parse(
@@ -43,7 +44,8 @@ class AslGraphTest {
 
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
 
-        AslRootQuery rootQuery = new AqlSqlLayer(null, () -> "node").buildAslRootQuery(queryWrapper);
+        AslRootQuery rootQuery =
+                new AqlSqlLayer(null, () -> "node", new AqlConfigurationProperties()).buildAslRootQuery(queryWrapper);
 
         System.out.println(AslGraph.createAslGraph(rootQuery));
     }

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.ehrbase.api.exception.AqlFeatureNotImplementedException;
 import org.ehrbase.api.exception.IllegalAqlException;
 import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties.Experimental;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties.Experimental.AqlOnFolder;
 import org.ehrbase.openehr.dbformat.StructureRmType;
 import org.ehrbase.openehr.sdk.aql.dto.AqlQuery;
 import org.ehrbase.openehr.sdk.aql.parser.AqlQueryParser;
@@ -606,9 +608,8 @@ class AqlQueryFeatureCheckTest {
     }
 
     private AqlConfigurationProperties propertiesWithAqlOnFolderEnabled(boolean aqlOnFolderEnabled) {
-        return new AqlConfigurationProperties(
-                false,
-                new AqlConfigurationProperties.Experimental(
-                        new AqlConfigurationProperties.Experimental.AqlOnFolder(aqlOnFolderEnabled)));
+        AqlConfigurationProperties aqlConfigurationProperties = new AqlConfigurationProperties();
+        aqlConfigurationProperties.setExperimental(new Experimental(new AqlOnFolder(aqlOnFolderEnabled)));
+        return aqlConfigurationProperties;
     }
 }

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
@@ -182,8 +182,10 @@ class AqlQueryFeatureCheckTest {
                     WHERE e/system_id/value = 'abc'
                     ORDER BY e/system_id/value
                 """,
-                "SELECT e/value FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS EVENT [at0002] CONTAINS ELEMENT e [at0004]",
-                "SELECT e/time FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS EVENT e [at0002]",
+                "SELECT 1 FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS CLUSTER [at0002] CONTAINS ELEMENT e [at0004]",
+                "SELECT 1 FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS ((CLUSTER [at0002] CONTAINS ELEMENT e [at0004]) OR (CLUSTER[at0005] AND CLUSTER[at0006]))",
+                "SELECT 1 FROM OBSERVATION o CONTAINS CLUSTER [openEHR-EHR-CLUSTER.cl.v0] CONTAINS ELEMENT e [at0004]",
+                "SELECT 1 FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS EVENT e [at0002]",
             })
     void ensureQuerySupported(String aql) {
 
@@ -358,13 +360,15 @@ class AqlQueryFeatureCheckTest {
             strings = {
                 "SELECT c FROM COMPOSITION c CONTAINS EHR_STATUS",
                 "SELECT c FROM COMPOSITION c CONTAINS ELEMENT CONTAINS EHR_STATUS",
-                "SELECT e FROM EHR CONTAINS COMPOSITION CONTAINS EHR_STATUS CONTAINS ELEMENT e"
+                "SELECT e FROM EHR CONTAINS COMPOSITION CONTAINS EHR_STATUS CONTAINS ELEMENT e",
+                "SELECT e FROM VERSION[LATEST_VERSION] CONTAINS ELEMENT e",
+                "SELECT 1 FROM COMPOSITION[at0001]",
+                "SELECT 1 FROM OBSERVATION o CONTAINS ((CLUSTER [at0002] CONTAINS ELEMENT e [at0004]) OR (CLUSTER[at0005] AND CLUSTER[at0006]))",
+                "SELECT 1 FROM COMPOSITION CONTAINS CLUSTER[at0001]"
             })
     void ensureContainsRejected(String aql) {
 
-        assertThatThrownBy(() -> runEnsureQuerySupported(aql))
-                .isInstanceOf(IllegalAqlException.class)
-                .hasMessageContainingAll("Structure ", " cannot CONTAIN ", " (of structure ");
+        assertThatThrownBy(() -> runEnsureQuerySupported(aql)).isInstanceOf(IllegalAqlException.class);
     }
 
     @ParameterizedTest
@@ -391,12 +395,15 @@ class AqlQueryFeatureCheckTest {
 
     @ParameterizedTest
     @ValueSource(
-            strings = {"SELECT f FROM COMPOSITION CONTAINS FOLDER f", "SELECT f FROM EHR_STATUS CONTAINS FOLDER f"})
+            strings = {
+                "SELECT f FROM COMPOSITION CONTAINS FOLDER f",
+                "SELECT f FROM EHR_STATUS CONTAINS FOLDER f",
+                "SELECT 1 FROM FOLDER CONTAINS COMPOSITION[at0001]"
+            })
     void ensureContainsRejectedExperimentalAqlOnFolder(String aql) {
 
         assertThatThrownBy(() -> runEnsureQuerySupportedAqlOnFolderEnabled(aql))
-                .isInstanceOf(IllegalAqlException.class)
-                .hasMessageContainingAll("Structure ", " cannot CONTAIN ", " (of structure ");
+                .isInstanceOf(IllegalAqlException.class);
     }
 
     @ParameterizedTest

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
@@ -181,7 +181,9 @@ class AqlQueryFeatureCheckTest {
                     FROM EHR e
                     WHERE e/system_id/value = 'abc'
                     ORDER BY e/system_id/value
-                """
+                """,
+                "SELECT e/value FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS EVENT [at0002] CONTAINS ELEMENT e [at0004]",
+                "SELECT e/time FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1] CONTAINS EVENT e [at0002]",
             })
     void ensureQuerySupported(String aql) {
 

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/sql/AqlSqlQueryBuilderTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/sql/AqlSqlQueryBuilderTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.ehrbase.api.knowledge.KnowledgeCacheService;
 import org.ehrbase.api.service.TemplateService;
+import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 import org.ehrbase.openehr.aqlengine.AqlEhrPathPostProcessor;
 import org.ehrbase.openehr.aqlengine.AqlFromEhrOptimisationPostProcessor;
 import org.ehrbase.openehr.aqlengine.asl.AqlSqlLayer;
@@ -104,7 +105,8 @@ FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1]
         new AqlFromEhrOptimisationPostProcessor().afterParseAql(aqlQuery, null, null);
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
 
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         new AslCleanupPostProcessor().afterBuildAsl(aslQuery, aqlQuery, queryWrapper, null);
 
@@ -140,7 +142,8 @@ FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1]
         AqlQuery aqlQuery = AqlQueryParser.parse(aql);
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
 
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         AqlSqlQueryBuilder sqlQueryBuilder = aqlSqlQueryBuilder();
 
@@ -251,7 +254,8 @@ FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1]
     void aslGraphRegression(String name, String aql, String aslGraph) {
         AqlQuery aqlQuery = AqlQueryParser.parse(aql);
         AqlQueryWrapper queryWrapper = AqlQueryWrapper.create(aqlQuery, false);
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         assertThat(AslGraph.createAslGraph(aslQuery)).isEqualToIgnoringWhitespace(aslGraph);
     }
@@ -273,7 +277,8 @@ FROM OBSERVATION o[openEHR-EHR-OBSERVATION.ooo.v1]
     }
 
     private SelectQuery<Record> buildSqlQuery(AqlQueryWrapper queryWrapper) {
-        AqlSqlLayer aqlSqlLayer = new AqlSqlLayer(mockKnowledgeCacheService, () -> "node");
+        AqlSqlLayer aqlSqlLayer =
+                new AqlSqlLayer(mockKnowledgeCacheService, () -> "node", new AqlConfigurationProperties());
         AslRootQuery aslQuery = aqlSqlLayer.buildAslRootQuery(queryWrapper);
         AqlSqlQueryBuilder sqlQueryBuilder = aqlSqlQueryBuilder();
 

--- a/aql-engine/src/test/java/org/ehrbase/openehr/util/TestConfig.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/util/TestConfig.java
@@ -22,9 +22,6 @@ import org.ehrbase.openehr.aqlengine.AqlConfigurationProperties;
 public class TestConfig {
 
     public static AqlConfigurationProperties aqlConfigurationProperties() {
-        return new AqlConfigurationProperties(
-                false,
-                new AqlConfigurationProperties.Experimental(
-                        new AqlConfigurationProperties.Experimental.AqlOnFolder(false)));
+        return new AqlConfigurationProperties();
     }
 }

--- a/configuration/src/main/resources/application.yml
+++ b/configuration/src/main/resources/application.yml
@@ -90,6 +90,8 @@ ehrbase:
     # Improves AQL performance for paths containing consecutive at-/id-codes
     # May produce unexpected results if the paths do not follow the archetype definitions
     path-node-skipping: false
+    # CONTAINS with a node predicate excludes results from nested archetypes
+    archetype-local-node-predicates: true
     pg-llj-workaround: true
     experimental:
       aql-on-folder:


### PR DESCRIPTION
# Changes

> Improve CONTAINS expression semantics when using at-code predicates.
If the parent CONTAINS expression is an archetype, it must be located within that archetype.
If the parent CONTAINS expression is an at-code, it must be located within the same parent archetype and be a descendant.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 