### PR TITLE
CDR-2022 Bump SDK to 2.24.0-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,7 +58,7 @@
     <archie.version>3.13.0</archie.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
-    <ehrbase.openehr.sdk.version>2.23.0</ehrbase.openehr.sdk.version>
+    <ehrbase.openehr.sdk.version>2.24.0-SNAPSHOT</ehrbase.openehr.sdk.version>
     <flyway.version>11.1.1</flyway.version>
     <jackson-bom.version>2.18.1</jackson-bom.version>
     <javamelody.version>1.99.1</javamelody.version>


### PR DESCRIPTION
# Changes

Bump SDK to 2.24.0-SNAPSHOT