### PR TITLE
implement #1540 - order by and where clauses for EHR time_crated/value and VERSION commit_audit/time_committed/value

### DIFF
--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayer.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/asl/AqlSqlLayer.java
@@ -325,10 +325,12 @@ public class AqlSqlLayer {
                     .filter(tc -> StructureRmType.COMPOSITION.getAlias().equals(tc.aliasedRmType()))
                     .map(AslRmTypeAndConcept::concept)
                     .toList();
-            case OV_TIME_COMMITTED_DV, EHR_TIME_CREATED_DV -> AslUtils.streamStringPrimitives(comparison)
-                    .map(AslUtils::toOffsetDateTime)
-                    .filter(Objects::nonNull)
-                    .toList();
+            case OV_TIME_COMMITTED, OV_TIME_COMMITTED_DV, 
+                    EHR_TIME_CREATED, EHR_TIME_CREATED_DV ->
+                AslUtils.streamStringPrimitives(comparison)
+                        .map(AslUtils::toOffsetDateTime)
+                        .filter(Objects::nonNull)
+                        .toList();
             case AD_CHANGE_TYPE_CODE_STRING -> AslUtils.streamStringPrimitives(comparison)
                     .map(StringPrimitive::getValue)
                     .map(ChangeTypeUtils::getJooqChangeTypeByCode)

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/FeatureCheckUtils.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/FeatureCheckUtils.java
@@ -78,7 +78,8 @@ final class FeatureCheckUtils {
                     Pair.of(
                             "commit_audit/time_committed",
                             Set.of(ClauseType.SELECT, ClauseType.WHERE, ClauseType.ORDER_BY)),
-                    Pair.of("commit_audit/time_committed/value", Set.of(ClauseType.SELECT)),
+                    Pair.of("commit_audit/time_committed/value",
+                            Set.of(ClauseType.SELECT, ClauseType.WHERE, ClauseType.ORDER_BY)),
                     Pair.of("commit_audit/system_id", Set.of(ClauseType.SELECT, ClauseType.WHERE)),
                     Pair.of("commit_audit/description", Set.of(ClauseType.SELECT)),
                     Pair.of(
@@ -211,7 +212,7 @@ final class FeatureCheckUtils {
             }
 
             return AslExtractedColumn.find(containmentType, path)
-                    .filter(ec -> !EnumSet.of(AslExtractedColumn.EHR_TIME_CREATED, AslExtractedColumn.EHR_SYSTEM_ID_DV)
+                    .filter(ec -> !EnumSet.of(AslExtractedColumn.EHR_SYSTEM_ID_DV)
                                     .contains(ec)
                             || clauseType == ClauseType.SELECT)
                     .map(ec -> new PathDetails(ec, Set.of("String")))

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/OrderByCheck.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/OrderByCheck.java
@@ -61,7 +61,6 @@ final class OrderByCheck implements FeatureCheck {
         FeatureCheckUtils.PathDetails pathWithType = FeatureCheckUtils.findSupportedIdentifiedPath(
                 ip, false, ClauseType.ORDER_BY, systemService.getSystemId());
         if (EnumSet.of(
-                        AslExtractedColumn.OV_TIME_COMMITTED,
                         AslExtractedColumn.AD_SYSTEM_ID,
                         AslExtractedColumn.AD_CHANGE_TYPE_TERMINOLOGY_ID_VALUE)
                 .contains(pathWithType.extractedColumn())) {

--- a/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/WhereCheck.java
+++ b/aql-engine/src/main/java/org/ehrbase/openehr/aqlengine/featurecheck/WhereCheck.java
@@ -76,10 +76,6 @@ final class WhereCheck implements FeatureCheck {
                 throw new AqlFeatureNotImplementedException(
                         "Conditions on 'archetype_details/template_id/value' only support =,!= and MATCHES");
             }
-            if (pathWithType.extractedColumn() == AslExtractedColumn.OV_TIME_COMMITTED) {
-                throw new AqlFeatureNotImplementedException("Conditions on %s of VERSION"
-                        .formatted(conditionField.getPath().render()));
-            }
             if (EnumSet.of(
                                     AslExtractedColumn.AD_CHANGE_TYPE_VALUE,
                                     AslExtractedColumn.AD_CHANGE_TYPE_CODE_STRING,

--- a/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
+++ b/aql-engine/src/test/java/org/ehrbase/openehr/aqlengine/featurecheck/AqlQueryFeatureCheckTest.java
@@ -176,6 +176,8 @@ class AqlQueryFeatureCheckTest {
                 "SELECT c FROM COMPOSITION c WHERE c/uid/value = 'b037bf7c-0ecb-40fb-aada-fc7d559815ea::::1'",
                 "SELECT c[openEHR-EHR-COMPOSITION.sample_blood_pressure.v1,'Blood pressure (Training sample)'] FROM COMPOSITION c",
                 "SELECT e/ehr_id/value, e/time_created, e/time_created/value FROM EHR e WHERE e/time_created > '2021-01-02T12:13:14+01:00' ORDER BY e/time_created",
+                "SELECT e/ehr_id/value FROM EHR e WHERE e/time_created/value > '2021-01-02T12:13:14+01:00'",
+                "SELECT e/ehr_id/value, e/time_created/value FROM EHR e ORDER BY e/time_created/value",
                 """
                     SELECT
                      e/ehr_id/value,
@@ -306,7 +308,6 @@ class AqlQueryFeatureCheckTest {
                    SELECT e/ehr_id/value, SUM(c/uid/value)
                    FROM EHR e CONTAINS COMPOSITION c
                 """,
-                "SELECT e/ehr_id/value FROM EHR e WHERE e/time_created/value > '2021-01-02T12:13:14+01:00'",
                 "SELECT e/ehr_id/value FROM EHR e ORDER BY e/time_created/value"
             })
     void ensureQueryNotSupported(String aql) {


### PR DESCRIPTION
# Changes

- Implements `WHERE` and `ORDER BY` on VERSION `commit_audit/time_committed/value`
- Implements `WHERE` and `ORDER BY` on EHR `time_created/value`

# Related issue

fixes #1540 

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 