### PR TITLE
CDR-2498 - parse if match value; disallow weak validators and wildcards; respect the shape of the object version id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
  ### Added
  ### Changed 
+- `If-Match` header values that do not identify a single version are now rejected with `412 Precondition Failed` before the update is applied, instead of failing later with a misleading error. This covers weak validators (`W/"..."`), the `*` wildcard, improperly quoted values, and values not shaped like `object_id::creating_system_id::version_tree_id`, on composition update, EHR_STATUS update and directory update/delete [#1644](https://github.com/ehrbase/ehrbase/pull/1644)
  ### Fixed 
 - Accept double-quoted (RFC 7232 ETag-style) `If-Match` header values on composition and EHR_STATUS update, fixes [#1639](https://github.com/ehrbase/ehrbase/issues/1639)
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/BaseController.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.NotAcceptableException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
+import org.ehrbase.api.exception.PreconditionFailedException;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.CompositionFormat;
 import org.ehrbase.rest.openehr.format.CompositionRepresentation;
 import org.ehrbase.rest.openehr.format.OpenEHRMediaType;
@@ -244,15 +245,66 @@ public abstract class BaseController {
         return OptionalInt.empty();
     }
 
-    /**
-     * Strips the optional ETag-style double quotes (RFC 7232) from an <code>If-Match</code> header value,
-     * so that both <code>"value"</code> and <code>value</code> are accepted.
-     *
-     * @param ifMatch raw <code>If-Match</code> header value
-     * @return the value without surrounding double quotes
-     */
-    protected static String unwrapIfMatchValue(String ifMatch) {
-        return StringUtils.unwrap(ifMatch, '"');
+    /// Strips the optional ETag-style double quotes (RFC 7232) from an `If-Match` header value,
+    /// so that both `"value"` and `value` are accepted, and checks that the value has the general
+    /// shape of an OBJECT_VERSION_ID: `object_id::creating_system_id::version_tree_id`.
+    ///
+    /// @param ifMatch raw `If-Match` header value
+    /// @return the value without surrounding double quotes
+    /// @throws PreconditionFailedException if the value is missing, a weak validator (`W/`), the `*` wildcard,
+    ///         improperly quoted, or not shaped like an OBJECT_VERSION_ID
+    protected static String parseIfMatchHeaderValue(String ifMatch) {
+        int length = ifMatch == null ? 0 : ifMatch.length();
+
+        // precondition failed on no content in the header
+        if (length == 0) {
+            throw new PreconditionFailedException("If-Match header is missing or empty");
+        }
+
+        // precondition failed if header uses a weak validator
+        if (length >= 2 && ifMatch.charAt(0) == 'W' && ifMatch.charAt(1) == '/') {
+            throw new PreconditionFailedException(
+                    "If-Match header [%s] must not be a weak validator".formatted(ifMatch));
+        }
+
+        int start = 0;
+        int end = length;
+        // check if the header value is quoted
+        if (ifMatch.charAt(0) == '"') {
+            // quoted: precondition failed if the end quote is missing
+            if (ifMatch.indexOf('"', 1) != length - 1) {
+                throw new PreconditionFailedException(
+                        "If-Match header [%s] is not a valid version uid".formatted(ifMatch));
+            }
+            start = 1;
+            end = length - 1;
+            // unquoted - precondition failed if there are other quotes in the header value
+        } else if (ifMatch.indexOf('"') >= 0) {
+            throw new PreconditionFailedException("If-Match header [%s] is not a valid version uid".formatted(ifMatch));
+        }
+
+        // precondition failed if the header is using a wildcard
+        if (end - start == 1 && ifMatch.charAt(start) == '*') {
+            throw new PreconditionFailedException(
+                    "If-Match header must reference a specific version, '*' is not supported");
+        }
+
+        int sep1 = ifMatch.indexOf("::", start);
+        int sep2 = ifMatch.indexOf("::", sep1 + 2);
+        int sep3 = ifMatch.indexOf("::", sep2 + 2);
+
+        // given the shape: s1::s2::s3
+        // for a valid shape the first and second separators are positive and third separator is negative
+        // thus we reject cases when:
+        // sep1 <= start => no separator or empty s1
+        // sep2 <= sep1 + 2 => no second separator, or empty s2
+        // sep2 + 2 >= end => no s3
+        // sep3 >= 0 => multiple separators
+        if (sep1 <= start || sep2 <= sep1 + 2 || sep2 + 2 >= end || sep3 >= 0) {
+            throw new PreconditionFailedException("If-Match header [%s] is not a valid version uid".formatted(ifMatch));
+        }
+
+        return start == 0 ? ifMatch : ifMatch.substring(start, end);
     }
 
     /**

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrCompositionController.java
@@ -192,7 +192,7 @@ public class OpenehrCompositionController extends BaseController implements Comp
         final Optional<InternalResponse<CompositionResponseData>> respData;
         try {
             // If-Match may be sent with or without surrounding double quotes (RFC 7232 ETag form)
-            ObjectVersionId ifMatchId = new ObjectVersionId(unwrapIfMatchValue(ifMatch));
+            ObjectVersionId ifMatchId = new ObjectVersionId(parseIfMatchHeaderValue(ifMatch));
             String compositionVersionUid = compositionService
                     .update(ehrId, ifMatchId, compoObj)
                     .orElseThrow(() -> new InternalServerException("Failed to create composition"))

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrDirectoryController.java
@@ -100,7 +100,7 @@ public class OpenehrDirectoryController extends BaseController implements Direct
             @RequestHeader(name = OPENEHR_AUDIT_DETAILS, required = false) String openEhrAuditDetails,
             @RequestBody Folder folder) {
 
-        folderId.setValue(unwrapIfMatchValue(folderId.getValue()));
+        folderId.setValue(parseIfMatchHeaderValue(folderId.getValue()));
 
         // Update folder and get new version
         Folder updatedFolder = directoryService.update(ehrId, folder, folderId);
@@ -120,7 +120,7 @@ public class OpenehrDirectoryController extends BaseController implements Direct
             @RequestHeader(name = HttpHeaders.ACCEPT, defaultValue = MediaType.APPLICATION_JSON_VALUE) String accept,
             @RequestHeader(name = HttpHeaders.IF_MATCH) ObjectVersionId folderId) {
 
-        folderId.setValue(unwrapIfMatchValue(folderId.getValue()));
+        folderId.setValue(parseIfMatchHeaderValue(folderId.getValue()));
 
         directoryService.delete(ehrId, folderId);
 

--- a/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrStatusController.java
+++ b/rest-openehr/src/main/java/org/ehrbase/rest/openehr/OpenehrEhrStatusController.java
@@ -120,7 +120,7 @@ public class OpenehrEhrStatusController extends BaseController implements EhrSta
         HttpRestContext.register(EHR_ID, ehrId);
 
         // update EHR_STATUS and check for success
-        ObjectVersionId targetObjId = new ObjectVersionId(unwrapIfMatchValue(versionUid));
+        ObjectVersionId targetObjId = new ObjectVersionId(parseIfMatchHeaderValue(versionUid));
         EhrStatus ehrResult = ehrService.updateStatus(ehrId, ehrStatusDto, targetObjId, null, null);
         UIDBasedId statusUid = ehrResult.getUid();
 

--- a/rest-openehr/src/test/java/org/ehrbase/rest/BaseControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/BaseControllerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 vitasystems GmbH.
+ *
+ * This file is part of project EHRbase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.ehrbase.api.exception.PreconditionFailedException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BaseControllerTest {
+
+    private static final String UID = "305eb2fd-c228-445c-ada7-5429d852fbb2";
+
+    private static final String NOT_A_VERSION_UID = "If-Match header [%s] is not a valid version uid";
+
+    /**
+     * Values that are a valid <code>If-Match</code>, in quoted (RFC 7232 ETag) or unquoted form.
+     * The expected result is always the bare OBJECT_VERSION_ID.
+     */
+    @ParameterizedTest(name = "[{index}] {0} -> {1}")
+    @CsvSource(
+            delimiter = ';',
+            value = {
+                // unquoted
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1 ; 305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1",
+                // quoted, as emitted by the ETag response header
+                "\"305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1\" ; 305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1",
+                // creating_system_id may contain dots and dashes
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::some-system.example.org::42 ; 305eb2fd-c228-445c-ada7-5429d852fbb2::some-system.example.org::42",
+                // a branched version_tree_id is a valid OBJECT_VERSION_ID shape
+                "\"305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1.0.1\" ; 305eb2fd-c228-445c-ada7-5429d852fbb2::local.ehrbase.org::1.0.1"
+            })
+    void parseIfMatchHeaderValueAccepts(String ifMatch, String expected) {
+        assertThat(BaseController.parseIfMatchHeaderValue(ifMatch)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> rejectedIfMatchValues() {
+        return Stream.of(
+                // no usable content
+                Arguments.of(null, "If-Match header is missing or empty"),
+                Arguments.of("", "If-Match header is missing or empty"),
+
+                // weak validators are not acceptable for a state-changing request (RFC 7232 §3.1)
+                Arguments.of(
+                        "W/\"%s::local.ehrbase.org::1\"".formatted(UID),
+                        "If-Match header [W/\"%s::local.ehrbase.org::1\"] must not be a weak validator".formatted(UID)),
+                Arguments.of(
+                        "W/%s::local.ehrbase.org::1".formatted(UID),
+                        "If-Match header [W/%s::local.ehrbase.org::1] must not be a weak validator".formatted(UID)),
+
+                // the wildcard cannot express "this specific version"
+                Arguments.of("*", "If-Match header must reference a specific version, '*' is not supported"),
+                Arguments.of("\"*\"", "If-Match header must reference a specific version, '*' is not supported"),
+
+                // unbalanced or stray quotes
+                Arguments.of(
+                        "\"%s::local.ehrbase.org::1".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("\"%s::local.ehrbase.org::1".formatted(UID))),
+                Arguments.of(
+                        "%s::local.ehrbase.org::1\"".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("%s::local.ehrbase.org::1\"".formatted(UID))),
+                Arguments.of(
+                        "\"%s\"::local.ehrbase.org::1\"".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("\"%s\"::local.ehrbase.org::1\"".formatted(UID))),
+                Arguments.of("\"", NOT_A_VERSION_UID.formatted("\"")),
+                Arguments.of("\"\"", NOT_A_VERSION_UID.formatted("\"\"")),
+
+                // a list of validators is not supported, only a single version
+                Arguments.of(
+                        "\"%s::local.ehrbase.org::1\", \"%s::local.ehrbase.org::2\"".formatted(UID, UID),
+                        NOT_A_VERSION_UID.formatted(
+                                "\"%s::local.ehrbase.org::1\", \"%s::local.ehrbase.org::2\"".formatted(UID, UID))),
+
+                // not shaped like object_id::creating_system_id::version_tree_id
+                Arguments.of(UID, NOT_A_VERSION_UID.formatted(UID)),
+                Arguments.of(
+                        "%s::local.ehrbase.org".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("%s::local.ehrbase.org".formatted(UID))),
+                Arguments.of("::local.ehrbase.org::1", NOT_A_VERSION_UID.formatted("::local.ehrbase.org::1")),
+                Arguments.of("\"::local.ehrbase.org::1\"", NOT_A_VERSION_UID.formatted("\"::local.ehrbase.org::1\"")),
+                Arguments.of("%s::::1".formatted(UID), NOT_A_VERSION_UID.formatted("%s::::1".formatted(UID))),
+                Arguments.of(
+                        "%s::local.ehrbase.org::".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("%s::local.ehrbase.org::".formatted(UID))),
+                Arguments.of(
+                        "\"%s::local.ehrbase.org::\"".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("\"%s::local.ehrbase.org::\"".formatted(UID))),
+                Arguments.of(
+                        "%s::local.ehrbase.org::1::2".formatted(UID),
+                        NOT_A_VERSION_UID.formatted("%s::local.ehrbase.org::1::2".formatted(UID))));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("rejectedIfMatchValues")
+    void parseIfMatchHeaderValueRejects(String ifMatch, String expectedMessage) {
+        assertThatThrownBy(() -> BaseController.parseIfMatchHeaderValue(ifMatch))
+                .isInstanceOf(PreconditionFailedException.class)
+                .hasMessage(expectedMessage);
+    }
+}

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrCompositionControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrCompositionControllerTest.java
@@ -18,20 +18,26 @@
 package org.ehrbase.rest.openehr;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.nedap.archie.rm.composition.Composition;
 import com.nedap.archie.rm.support.identification.ObjectVersionId;
 import java.util.Optional;
 import java.util.UUID;
+import org.ehrbase.api.exception.PreconditionFailedException;
 import org.ehrbase.api.service.CompositionService;
 import org.ehrbase.api.service.SystemService;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.CompositionFormat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
@@ -102,5 +108,51 @@ class OpenehrCompositionControllerTest {
         assertThat(response.getHeaders().getETag()).isEqualTo("\"%s::%s::3\"".formatted(compositionId, SYSTEM_ID));
         assertThat(response.getHeaders().getLocation())
                 .hasToString(CONTEXT_PATH + "/ehr/" + ehrId + "/composition/" + compositionId);
+    }
+
+    /**
+     * An unusable <code>If-Match</code> must be rejected with 412 <em>before</em> the composition is written,
+     * so that the client never receives an error for an update that has already been committed.
+     */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(
+            strings = {
+                "*",
+                "\"*\"",
+                "W/\"305eb2fd-c228-445c-ada7-5429d852fbb2::test.composition.controller::2\"",
+                "\"305eb2fd-c228-445c-ada7-5429d852fbb2::test.composition.controller::2",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.composition.controller::2\"",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.composition.controller::",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.composition.controller::2::3"
+            })
+    void updateCompositionRejectsUnusableIfMatch(String ifMatch) {
+
+        UUID ehrId = UUID.fromString("d83a16ae-2644-4706-8911-282772c10137");
+        UUID compositionId = UUID.fromString("305eb2fd-c228-445c-ada7-5429d852fbb2");
+
+        String requestBody = "{}";
+
+        doReturn(new Composition())
+                .when(mockCompositionService)
+                .buildComposition(requestBody, CompositionFormat.JSON, null);
+
+        OpenehrCompositionController controller = controller();
+        assertThatThrownBy(() -> controller.updateComposition(
+                        null,
+                        null,
+                        MediaType.APPLICATION_JSON_VALUE,
+                        MediaType.APPLICATION_JSON_VALUE,
+                        null,
+                        ifMatch,
+                        ehrId.toString(),
+                        compositionId.toString(),
+                        null,
+                        null,
+                        requestBody))
+                .isInstanceOf(PreconditionFailedException.class);
+
+        verify(mockCompositionService, never()).update(any(), any(), any());
     }
 }

--- a/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrEhrStatusControllerTest.java
+++ b/rest-openehr/src/test/java/org/ehrbase/rest/openehr/OpenehrEhrStatusControllerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.nedap.archie.rm.changecontrol.OriginalVersion;
 import com.nedap.archie.rm.datavalues.DvText;
@@ -37,12 +38,14 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import org.ehrbase.api.exception.InvalidApiParameterException;
 import org.ehrbase.api.exception.ObjectNotFoundException;
+import org.ehrbase.api.exception.PreconditionFailedException;
 import org.ehrbase.api.service.EhrService;
 import org.ehrbase.rest.BaseController;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
@@ -233,6 +236,37 @@ class OpenehrEhrStatusControllerTest {
 
         assertResponse(HttpStatus.NO_CONTENT, response, ehrId, nextVersionId, "Tue, 16 Jul 2024 12:00:00 GMT");
         assertThat(response.getBody()).isNull();
+    }
+
+    /**
+     * An unusable <code>If-Match</code> must be rejected with 412 <em>before</em> the EHR_STATUS is written,
+     * so that the client never receives an error for an update that has already been committed.
+     */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(
+            strings = {
+                "*",
+                "\"*\"",
+                "W/\"305eb2fd-c228-445c-ada7-5429d852fbb2::test.ehr.controller::2\"",
+                "\"305eb2fd-c228-445c-ada7-5429d852fbb2::test.ehr.controller::2",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.ehr.controller::2\"",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.ehr.controller::",
+                "305eb2fd-c228-445c-ada7-5429d852fbb2::test.ehr.controller::2::3"
+            })
+    void updateEhrStatusRejectsUnusableIfMatch(String ifMatch) {
+
+        UUID ehrId = UUID.fromString("d83a16ae-2644-4706-8911-282772c10137");
+        UUID ehrStatusId = UUID.fromString("305eb2fd-c228-445c-ada7-5429d852fbb2");
+        EhrStatus ehrStatus =
+                ehrStatus(new ObjectVersionId(ehrStatusId.toString(), "test.ehr.controller", "3"), true, false);
+
+        OpenehrEhrStatusController controller = controller();
+        assertThatThrownBy(() -> controller.updateEhrStatus(ehrId, ifMatch, BaseController.RETURN_MINIMAL, ehrStatus))
+                .isInstanceOf(PreconditionFailedException.class);
+
+        verifyNoInteractions(mockEhrService);
     }
 
     private void runTestWithMockResult(BiFunction<UUID, EhrStatus, ResponseEntity<EhrStatus>> consumer) {


### PR DESCRIPTION
Validate the If-Match header for unbalanced quoting, weak indicator and respect the object version id